### PR TITLE
refine: дополнить migration-strategy-rfc.md блоками 3-8 (зависимости, edge cases, workflow)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-03T11:03:12.768Z for PR creation at branch issue-12-58548950e08d for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/12

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-03T11:03:12.768Z for PR creation at branch issue-12-58548950e08d for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ ai-generated: true
   единый реестр research-зависимостей, корректное разделение
   `standards/GLOSSARY.md` и `standards/MANGO_CLASSIFICATION_CONTRACT.md`,
   а также правила переноса продуктовых экспериментов.
+- Завершена доработка RFC (`docs/analysis/migration-strategy-rfc.md`,
+  issue #12, v0.3, блоки 3–8): реестр зависимостей от исследований Хаба (§3.5),
+  переписка README.md как обязательная задача Фазы 1, согласованные формулировки
+  edge cases E5 (все эксперименты — часть продукта) и E6 (разделение
+  глоссария и контракта классификации, §4.1), временный workflow промптов P0
+  для `CONTRIBUTING.md` (§5.2) и шаблон Migration Manifest (§5.3).
 
 ### Removed
 

--- a/docs/analysis/migration-strategy-rfc.md
+++ b/docs/analysis/migration-strategy-rfc.md
@@ -1,7 +1,7 @@
 ---
 status: draft
-version: 0.2
-updated: 2026-06-02
+version: 0.3
+updated: 2026-06-03
 ai-generated: true
 type: rfc
 scope: mango_ba_prompts-migration-strategy
@@ -9,6 +9,7 @@ based_on: "docs/audit/initial-state-2026-06.md"
 hub_audit_ref: "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/tree/038868dd125b4e2d849ff73604890f1d2787ac0f/projects/mango"
 issue: "https://github.com/G-Ivan-A/mango_ba_prompts/issues/8"
 refinement_issue: "https://github.com/G-Ivan-A/mango_ba_prompts/issues/10"
+refinement_issue_part2: "https://github.com/G-Ivan-A/mango_ba_prompts/issues/12"
 ---
 
 # RFC: стратегия миграции проекта Mango из Хаба в спок `mango_ba_prompts`
@@ -110,11 +111,11 @@ RFC **закреплены за коммитом** `038868d` Хаба, чтоб�
 | [`prompts/usecase-stepwise-generator_simple-2026-05.md`](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868dd125b4e2d849ff73604890f1d2787ac0f/projects/mango/prompts/usecase-stepwise-generator_simple-2026-05.md) | 2.9 KB | 🟢 Промпт | **Переносим** + нормализация | Содержит явный раздел «ФОРМАТ ВЫВОДА» (эталон для выравнивания `_exp`). |
 | [`prompts/user-story-generator_exp-2026-05.md`](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868dd125b4e2d849ff73604890f1d2787ac0f/projects/mango/prompts/user-story-generator_exp-2026-05.md) | 1.5 KB | 🟢 Промпт | **Переносим** + нормализация | Ссылается на `research/mango/classification.md`, `standards/classification-glossary.md`, `kb/glossary.md`. |
 | [`prompts/user-story-generator_simple-2026-05.md`](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868dd125b4e2d849ff73604890f1d2787ac0f/projects/mango/prompts/user-story-generator_simple-2026-05.md) | 2.9 KB | 🟢 Промпт | **Переносим** + нормализация | Готовый asset (`_simple`), содержит «ФОРМАТ ВЫВОДА». |
-| [`experiments/tz-stats-prototype-2026-05.md`](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868dd125b4e2d849ff73604890f1d2787ac0f/projects/mango/experiments/tz-stats-prototype-2026-05.md) | 22.6 KB | ⚫ Эксперимент (`based_on`) | **Ссылка сейчас; перенос по необходимости** | Источник `based_on` для `tz-stats-generator_*`. Нужен для трассировки происхождения промпта, но не для исполнения. |
-| [`experiments/usecase_gen-stepwise-alignment_2026-05-26.md`](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868dd125b4e2d849ff73604890f1d2787ac0f/projects/mango/experiments/usecase_gen-stepwise-alignment_2026-05-26.md) | 28.3 KB | ⚫ Эксперимент (`based_on`) | **Ссылка; перенос по необходимости** | Источник `based_on` для `usecase-stepwise-generator_*`. |
-| [`experiments/user-story_gen-from-raw-request_2026-05-26.md`](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868dd125b4e2d849ff73604890f1d2787ac0f/projects/mango/experiments/user-story_gen-from-raw-request_2026-05-26.md) | 23.5 KB | ⚫ Эксперимент (`based_on`) | **Ссылка; перенос по необходимости** | Источник `based_on` для `user-story-generator_*`. |
-| [`experiments/prompts-audit-2026-05-26.md`](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868dd125b4e2d849ff73604890f1d2787ac0f/projects/mango/experiments/prompts-audit-2026-05-26.md) | 11.9 KB | ⚫ Эксперимент | **Ссылка; перенос, если нужен репро нормализации** | Аудит исходных промптов. Полезен как input для нормализации (Фаза 1). |
-| [`experiments/prompts-selftest-2026-05-26.md`](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868dd125b4e2d849ff73604890f1d2787ac0f/projects/mango/experiments/prompts-selftest-2026-05-26.md) | 8.7 KB | ⚫ Эксперимент | **Ссылка; перенос, если делаем self-test gate** | Сценарий self-test. Кандидат на перенос, если вводим self-test как acceptance-gate (улучшение C2). |
+| [`experiments/tz-stats-prototype-2026-05.md`](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868dd125b4e2d849ff73604890f1d2787ac0f/projects/mango/experiments/tz-stats-prototype-2026-05.md) | 22.6 KB | ⚫ Эксперимент (`based_on`) | **Переносим физически** в `prompts/experiments/` | Часть продукта (E5): источник `based_on` для `tz-stats-generator_*`; перенос сохраняет операционную историю. |
+| [`experiments/usecase_gen-stepwise-alignment_2026-05-26.md`](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868dd125b4e2d849ff73604890f1d2787ac0f/projects/mango/experiments/usecase_gen-stepwise-alignment_2026-05-26.md) | 28.3 KB | ⚫ Эксперимент (`based_on`) | **Переносим физически** в `prompts/experiments/` | Часть продукта (E5): источник `based_on` для `usecase-stepwise-generator_*`. |
+| [`experiments/user-story_gen-from-raw-request_2026-05-26.md`](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868dd125b4e2d849ff73604890f1d2787ac0f/projects/mango/experiments/user-story_gen-from-raw-request_2026-05-26.md) | 23.5 KB | ⚫ Эксперимент (`based_on`) | **Переносим физически** в `prompts/experiments/` | Часть продукта (E5): источник `based_on` для `user-story-generator_*`. |
+| [`experiments/prompts-audit-2026-05-26.md`](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868dd125b4e2d849ff73604890f1d2787ac0f/projects/mango/experiments/prompts-audit-2026-05-26.md) | 11.9 KB | ⚫ Эксперимент | **Переносим физически** в `prompts/experiments/` | Часть продукта (E5): аудит исходных промптов, input для нормализации (Фаза 1). |
+| [`experiments/prompts-selftest-2026-05-26.md`](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868dd125b4e2d849ff73604890f1d2787ac0f/projects/mango/experiments/prompts-selftest-2026-05-26.md) | 8.7 KB | ⚫ Эксперимент | **Переносим физически** в `prompts/experiments/` | Часть продукта (E5): сценарий self-test; используется для self-test gate (улучшение C2). |
 | `decisions/.gitkeep`, `docs/.gitkeep`, `kb/.gitkeep`, `experiments/.gitkeep` | 0 B | ⚫ Пустой плейсхолдер | **Не переносим** | Anti-Inflation (P5): пустые каталоги спок «с собой не носит». Создаются только под реальный артефакт. |
 
 ### 2.4. Внешние стандарты Хаба
@@ -155,9 +156,8 @@ URL**, а не копии. Инвентарь приведён для полно
   `standards/GLOSSARY.md` Хаба.
 - **Остаются в Хабе со ссылкой (🔵)**: 11 исследований.
 - **Индивидуально (⚫)**: монорепо-README (архив-ссылка) + 5 экспериментов
-  (продуктовые эксперименты переносим физически в `prompts/experiments/`,
-  provenance-only эксперименты оставляем ссылками) + 4 пустых плейсхолдера (не
-  переносим).
+  (все переносим физически в `prompts/experiments/` как часть продукта — E5) +
+  4 пустых плейсхолдера (не переносим).
 - **Главная зависимость**: `research/mango/classification.md` — её цитируют все
   `_exp`-промпты и контракт классификации; она **не переносится** (P1), а
   регистрируется в `docs/hub-research-dependencies.md` → отсюда edge case E1
@@ -210,8 +210,8 @@ Human Review и оставляет спок в работоспособном с
 | `https://.../projects/mango/prompts/tz-stats-generator_exp-2026-05.md` | `prompts/tz-stats-generator.md` | Перенести + нормализовать | Экспериментальный prompt asset; итоговое имя без даты/`_exp`, если вариант становится canonical. |
 | `https://.../projects/mango/prompts/*_simple-2026-05.md` | `prompts/<name>-simple.md` или `prompts/drafts/<name>.md` | Перенести + нормализовать | Simple-варианты сохраняются как отдельные assets, пока Human Review не решит объединить пары. |
 | `https://.../projects/mango/prompts/*_exp-2026-05.md` | `prompts/<name>.md` | Перенести + нормализовать | Остальные 🟢 артефакты; нормализованные имена фиксируются в manifest. |
-| `https://.../projects/mango/experiments/exp-2026-05-v2.md` | `prompts/experiments/exp-2026-05-v2.md` | **Перенести физически** | Часть продукта, не research Хаба; если фактическое имя в snapshot отличается, заменить на подтверждённый Hub-путь перед переносом. |
-| `https://.../projects/mango/experiments/prompts-selftest-2026-05-26.md` | `prompts/experiments/prompts-selftest-2026-05-26.md` | Перенести физически, если self-test gate обязателен | Acceptance-сценарий для нормализации промптов; не размещать в корневом `experiments/` спока. |
+| `https://.../projects/mango/experiments/*` (все 5 экспериментов) | `prompts/experiments/<file>.md` | **Перенести физически** | Все эксперименты — часть продукта (E5), не research Хаба; если фактическое имя в snapshot отличается, заменить на подтверждённый Hub-путь перед переносом. |
+| `https://.../projects/mango/experiments/prompts-selftest-2026-05-26.md` | `prompts/experiments/prompts-selftest-2026-05-26.md` | **Перенести физически** | Acceptance-сценарий для нормализации промптов (self-test gate, C2); не размещать в корневом `experiments/` спока. |
 | `https://.../projects/mango/standards/classification-glossary.md` | `standards/MANGO_CLASSIFICATION_CONTRACT.md` | **Переименовать + перенести в `standards/`** | Это контракт классификации, не глоссарий; путь = `standards/`. Если source в Хабе будет `projects/mango/kb/classification-glossary.md`, целевой путь не меняется. |
 | `https://.../standards/GLOSSARY.md` | `standards/GLOSSARY.md` | **Копировать из Хаба** | Стандарт Хаба, синхронизируется явно; используется в `glossary_ref`. |
 | `https://.../research/mango/*` | `docs/hub-research-dependencies.md#<anchor>` | Только зарегистрировать ссылку | Research не копируется; промпты ссылаются на якорь через `research_dep`. |
@@ -247,6 +247,17 @@ Human Review и оставляет спок в работоспособном с
 | `#classification` | `https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/<sha>/research/mango/classification.md` | `_exp`/canonical prompts, `standards/MANGO_CLASSIFICATION_CONTRACT.md` | Reference only; не копировать. |
 | `#classification-tz` | `https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/<sha>/research/mango/classification-tz.md` | `tz-stats-generator` | Reference only; не копировать. |
 | `#taxonomy-concept` | `https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/<sha>/research/mango/taxonomy-concept-2026-05.md` | `standards/MANGO_CLASSIFICATION_CONTRACT.md` | Reference only до canonical-статуса в Хабе. |
+
+##### Переписка README.md спока (обязательная задача Фазы 1)
+
+Текущий README скопирован из Хаба и содержит битые ссылки. В рамках Фазы 1 его
+необходимо переписать:
+
+- Назначение проекта Mango BA Prompts.
+- Структура `prompts/` и `standards/`.
+- Временный workflow (ссылка на `CONTRIBUTING.md`).
+- Контакты / ответственные.
+- Удалить все ссылки на Хаб, кроме `docs/hub-research-dependencies.md`.
 
 #### Фаза 2 — Фиксация ссылок на исследования (review-чекпоинт)
 - **Что делаем**: проверяем, что **все** ссылки на `research/mango/*` в споке
@@ -316,6 +327,24 @@ flowchart TD
 сравнению с v0.1, потому что продуктовые эксперименты и единый реестр
 зависимостей теперь входят в обязательную Фазу 1.
 
+### 3.5. Реестр зависимостей от исследований Хаба
+
+Единственный файл-носитель этого реестра — `docs/hub-research-dependencies.md`
+(⚠️ **не** создаём `hub-research-links.md` и не дублируем содержимое в других
+файлах). Ниже — целевая структура реестра, который заполняется при миграции на
+основе аудита §2.5. Заголовок файла-носителя — `# Реестр зависимостей от
+исследований Хаба`.
+
+| Название | Полный URL в Хабе | Тип зависимости | Версия/Дата | Статус синхронизации | Затронутые артефакты спока | Примечание |
+|----------|-------------------|-----------------|-------------|---------------------|---------------------------|------------|
+| Prompt Classification | https://... | Классификация промптов | 2026-05 | ✅ Актуально | `prompts/tz-stats-generator.md` | Базовая таксономия |
+
+**Правила:**
+
+- Заполняется при миграции на основе аудита.
+- В frontmatter промптов: `research_dep: docs/hub-research-dependencies.md#<anchor>`.
+- Если промпт не зависит от исследований: `research_dep: none` + комментарий о бизнес-задаче.
+
 ---
 
 ## 4. Обработка edge cases
@@ -326,10 +355,28 @@ flowchart TD
 | **E2** | `classification-glossary.md` выглядит как глоссарий, но фактически задаёт Mango-классификацию `Domain → Capability → Feature → Atomic Function`. | Переименовать в `standards/MANGO_CLASSIFICATION_CONTRACT.md`. Внутренние ссылки на research заменить на `research_dep`/якоря реестра. | Это контракт, не `kb`-глоссарий. Размещение в `standards/` совпадает с ролью файла и с принципом P4. |
 | **E3** | Артефакт **не попадает ни в одну категорию** (`projects/mango/README.md` — навигация монорепо). | **Не переносим.** Регистрируем в migration manifest как «архивная ссылка» (archived/reference) с пометкой «заменён spoke-README»; spoke-README обновляем только локальной навигацией Фазы 1. | Перенос дал бы битую навигацию (gap G6). Манифест сохраняет трассируемость: видно, что артефакт **рассмотрен**, а не потерян. |
 | **E4** | Как работать с промптами **пока нет ADR и матрицы**? | Временный workflow (улучшение C5): промпты в `prompts/`, черновики — в `prompts/drafts/` (разрешено без human review по capability boundaries `AI_GOVERNANCE.md`); изменение существующего промпта — через issue→PR→review; матрицу **не вводим**, навигацию держим в spoke-README и manifest. | «Практика первична» (P3). Capability boundaries уже описывают `prompts/drafts/` — используем готовое, не плодим процесс. |
-| **E5** | `based_on` промпта указывает на эксперимент в `projects/mango/experiments/...`. | Разделить по роли: продуктовый эксперимент переносится физически в `prompts/experiments/`; provenance-only эксперимент остаётся абсолютным Hub-URL в `based_on`. | Эксперимент может быть частью prompt package, а не research Хаба. Физический перенос нужен там, где без него промпт/self-test неполон. |
-| **E6** | **Коллизия глоссариев**: в споке уже есть тонкий `kb/glossary.md`, а Хаб даёт общий `standards/GLOSSARY.md`. | Не сливать. `kb/glossary.md` остаётся локальным словарём спока; `standards/GLOSSARY.md` копируется как стандарт Хаба; промпты используют `glossary_ref: standards/GLOSSARY.md` или `none`. | `kb` и `standards` решают разные задачи. Слияние скрывает source of truth и усложняет синхронизацию. |
+| **E5** | Эксперименты в `projects/mango/experiments/` — research Хаба или часть продукта? | **Эксперименты = часть продукта.** Все эксперименты переносятся физически в `prompts/experiments/` спока (согласованная формулировка — см. §4.1). | Они не являются исследованиями Хаба; перенос обязателен для сохранения операционной истории проекта. |
+| **E6** | **Глоссарий vs Контракт + путь**: `standards/GLOSSARY.md` (словарь терминов) и `classification-glossary.md` (спецификация классификации) смешиваются по роли и пути. | Разделить роли и пути: `standards/GLOSSARY.md` = словарь; `standards/MANGO_CLASSIFICATION_CONTRACT.md` = контракт классификации (переименование `classification-glossary.md`); взаимные ссылки; слияние запрещено (согласованная формулировка — см. §4.1). | `kb/` остаётся только для данных и практик, не являющихся стандартами; слияние скрывает source of truth. |
 | **E7** | Исследование или стандарт в Хабе **обновится** после того, как спок сослался на него. | Ссылки в реестре и provenance фиксируем **permalink-ом на SHA** (C3); синхронизация — осознанное действие спока, фиксируется записью в `CHANGELOG.md`/manifest. | P2: «спок решает, когда синхронизировать». Permalink даёт воспроизводимость; обновление становится видимым решением. |
 | **E8** | Несколько промптов зависят от одного research-файла. | Один anchor в `docs/hub-research-dependencies.md`; в каждом промпте только `research_dep` на этот anchor. | Убирает расхождение ссылок между промптами и делает Фазу 2 проверяемой grep/валидатором. |
+
+### 4.1. Согласованные формулировки E5 и E6 (issue #12)
+
+**E5 — Эксперименты:**
+
+> **Эксперименты = часть продукта.** Все эксперименты из
+> `projects/mango/experiments/` переносятся физически в `prompts/experiments/`
+> спока. Они не являются исследованиями Хаба. Перенос обязателен для сохранения
+> операционной истории проекта.
+
+**E6 — Глоссарий vs Контракт + Путь:**
+
+> **Разделение ролей и путей:**
+> - `standards/GLOSSARY.md` = словарь терминов (стандарт, копируется из Хаба).
+> - `standards/MANGO_CLASSIFICATION_CONTRACT.md` = спецификация классификации (переименовано из `classification-glossary.md`).
+> - Контракт ссылается на глоссарий: «Для значений терминов см. `standards/GLOSSARY.md`».
+> - Глоссарий может ссылаться на контракт: «Классификация продуктов: `standards/MANGO_CLASSIFICATION_CONTRACT.md`».
+> - Слияние запрещено. `kb/` остаётся только для данных и практик, не являющихся стандартами.
 
 ---
 
@@ -346,8 +393,8 @@ flowchart TD
 | **C2** | **Self-test как acceptance-gate** | Прогон промпта по сценарию из `prompts/experiments/prompts-selftest-2026-05-26.md` перед пометкой «migrated». | Превращает существующий артефакт Хаба в воспроизводимый критерий качества нормализации. Без него «нормализован» — субъективно. |
 | **C3** | **Permalink-pinning ссылок на Хаб** | Все ссылки на research/стандарт — на **commit SHA**, не на `main`. | Единственная защита от тихого дрейфа (E7). Стоимость нулевая (формат URL), выгода — воспроизводимость. Применено уже в этом RFC. |
 | **C4** | **Единый реестр research-зависимостей** | `docs/hub-research-dependencies.md` со списком `research/mango/*` → Hub-URL + consumers, создаётся в Фазе 1. | Спок ссылается на research **из одной точки**, а не врассыпную по промптам. Упрощает будущую синхронизацию и сверку (Фаза 2). |
-| **C5** | **Временный prompt-workflow без ADR** | `prompts/` для активных, `prompts/drafts/` для черновиков; изменения — через issue→PR→review; **без матрицы**. | Прямой ответ на «как работать, пока нет ADR» (E4). Опирается на уже описанные capability boundaries — не вводит новый процесс. |
-| **C6** | **Migration manifest как живой снимок** | Таблица «артефакт → действие → статус → ссылка», ведётся по ходу Фаз 0–3 и **закрывается** в Фазе 3. | Фиксирует «что перенесено / что осталось / что архивировано» (см. §7). Закрытый manifest = воспроизводимый снимок миграции для будущего аудита. |
+| **C5** | **Временный prompt-workflow без ADR** | `prompts/` для активных, `prompts/drafts/` для черновиков; изменения — через issue→PR→review; **без матрицы**. P0-содержание для `CONTRIBUTING.md` — §5.2. | Прямой ответ на «как работать, пока нет ADR» (E4). Опирается на уже описанные capability boundaries — не вводит новый процесс. |
+| **C6** | **Migration manifest как живой снимок** | Таблица «артефакт → действие → статус → ссылка» (§5.1) + чек-лист-трекер (§5.3), ведётся по ходу Фаз 0–3 и **закрывается** в Фазе 3. | Фиксирует «что перенесено / что осталось / что архивировано». Закрытый manifest = воспроизводимый снимок миграции для будущего аудита. |
 
 ### 5.1. Шаблон migration manifest (создаётся при миграции, не сейчас)
 
@@ -360,7 +407,33 @@ flowchart TD
 | research/mango/classification.md | 🔵 | register | referenced | docs/hub-research-dependencies.md#classification |
 | projects/mango/README.md | ⚫ | archive | archived | (заменён spoke-README) |
 | experiments/exp-2026-05-v2.md | ⚫ | migrate | migrated | prompts/experiments/exp-2026-05-v2.md |
-| experiments/...prototype... | ⚫ | reference | referenced | <Hub permalink> (based_on) |
+| experiments/...prototype... | ⚫ | migrate | migrated | prompts/experiments/...prototype... |
+```
+
+### 5.2. Временный workflow промптов P0 (содержание для `CONTRIBUTING.md`)
+
+Прямой ответ на «как работать с промптами, пока нет ADR и матрицы» (E4, C5).
+Это содержание добавляется в `CONTRIBUTING.md` при миграции (Фаза 1), не сейчас:
+
+1. Создать файл в `prompts/drafts/` с именем `[biz-process]-[purpose].md`.
+2. Frontmatter обязателен: `status: draft`, `version: 0.1`, `updated: {{date}}`, `temperature: 0.1`.
+3. Добавить комментарий: `<!-- Experimental: for [task/link], no formal research yet -->`.
+4. Создать issue `prompt:review` с описанием бизнес-контекста.
+5. После human review → переместить в `prompts/`, обновить `status: canonical`, `version: 1.0`.
+
+### 5.3. Шаблон Migration Manifest (минимальный локальный трекер)
+
+Локальный трекер состояния миграции; ведётся при переносе (Фазы 0–3),
+закрывается в Фазе 3. Дополняет таблицу §5.1 чек-лист-представлением:
+
+```markdown
+# Migration Manifest — mango_ba_prompts
+## Перенесено (Физически в спок)
+- [x] `prompts/tz-stats-generator.md` — 2026-06-03 — status: canonical
+## Осталось в Хабе (зависимости задекларированы)
+- [x] `Prompt Classification` → [полный URL]
+## Требует уточнения / В работе
+- [ ] `docs/unknown-file.md` — категория не определена, issue #XX создан
 ```
 
 ---
@@ -374,7 +447,6 @@ flowchart TD
 | **ADR-классификации** (как меняем `MANGO_CLASSIFICATION_CONTRACT.md`) | Целевой контракт уже задан, но правила его будущего изменения преждевременно усложнять. | Когда Unified Capability Taxonomy в Хабе перейдёт из `draft` в `canonical` **или** возникнет повторяющийся спор о классе при нормализации промптов. |
 | **Матрица промптов** | 6 промптов навигируются README/manifest без матрицы; матрица «на вырост» (P5). | Когда число промптов/вариантов превысит обозримое в README **или** появятся повторяющиеся ошибки выбора нужного варианта. |
 | **Расширение `MANGO_CLASSIFICATION_CONTRACT.md` до стандарта вне Mango** | Сейчас контракт Mango-only; расширение за границы проекта нарушило бы scope Фазы 1. | Когда классификация согласована в Хабе как общий стандарт **и** спок ощутит боль рассинхрона рабочей копии. |
-| **Перенос provenance-only экспериментов** (`projects/mango/experiments/*`) | Фаза 1 переносит только продуктовые эксперименты; остальное достаточно ссылать через manifest/`based_on`. | Когда потребуется **воспроизводимость** нормализации/self-test локально для конкретного эксперимента. |
 | **Валидатор frontmatter промптов** (вкл. `temperature`, `output_format`, `glossary_ref`, `research_dep`) | Tooling-улучшение, не блокирует миграцию. | Когда ручная сверка чек-листа Фазы 1 станет узким местом (≥ повторных промахов по обязательным полям/ссылкам). |
 
 **Общий принцип триггера**: следующая фаза эволюции запускается **фактом боли**


### PR DESCRIPTION
## 🎯 Задача

Fixes #12 — завершение доработки `docs/analysis/migration-strategy-rfc.md`: добавлены блоки 3–8 в режиме `Structured` (строгое следование тексту issue). Блоки 1–2 (Шаги 1–2) уже были внесены в issue #10; эта часть добавляет оставшиеся 6 блоков. **Физическая миграция не выполняется** — только обновление RFC-документа (стоп-фактор issue #8).

## 📝 Что сделано (блоки 3–8)

| Шаг | Блок | Где в RFC |
|-----|------|-----------|
| 3 | Реестр зависимостей от исследований Хаба (единый файл `docs/hub-research-dependencies.md`, без дублирования) | §3.5 |
| 4 | Edge Case **E5** заменён: эксперименты = часть продукта, все переносятся физически в `prompts/experiments/` | §4 (строка E5) + §4.1 |
| 5 | Edge Case **E6** заменён: разделение ролей/путей `GLOSSARY.md` vs `MANGO_CLASSIFICATION_CONTRACT.md`, слияние запрещено | §4 (строка E6) + §4.1 |
| 6 | Переписка `README.md` спока — обязательная задача Фазы 1 | §3.2 |
| 7 | Шаблон Migration Manifest (минимальный локальный трекер) | §5.3 |
| 8 | Временный workflow промптов P0 (содержание для `CONTRIBUTING.md`) | §5.2 |

### Anti-Inflation соблюдён
- ⚠️ **Не** создан `hub-research-links.md`; реестр живёт в единственном `docs/hub-research-dependencies.md`.
- Глоссарий **не** размещён в `kb/`; контракт классификации остаётся в `standards/`.

### Согласование внутренней консистентности
Новая формулировка E5 («все эксперименты — часть продукта») согласована с §2.3 (инвентарь), §2.6 (сводка), таблицей файлов Фазы 1 и §6 (триггеры эволюции), чтобы RFC не содержал противоречий.

### Прочее
- RFC `v0.2 → v0.3`, `updated: 2026-06-03`, добавлен `refinement_issue_part2`.
- `CHANGELOG.md` (`## Unreleased → Changed`) дополнен.
- Удалён технический bootstrap `.gitkeep`.

## ✅ Definition of Done

- [x] Блоки 3–8 внесены в `docs/analysis/migration-strategy-rfc.md`
- [x] Единый файл зависимостей добавлен (без дублирования)
- [x] Edge cases E5 и E6 заменены на согласованные формулировки
- [x] README.md включён в Фазу 1 как обязательная задача
- [x] Шаблон Migration Manifest и временный workflow добавлены
- [x] Коммит: `refine: complete migration-rfc with dependencies and workflow (part 2)`
- [ ] Human Review (запрошен)

## 👀 Запрос Human Review

Документ — RFC на ревью, а не реализация. Прошу проверить формулировки блоков 3–8 и согласованность с предыдущими частями (issue #8/#10).
