### PR TITLE
fix: зафиксировать решения Q1-Q4 и устранить naming/path inconsistencies

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-03T18:54:28.144Z for PR creation at branch issue-21-9ea1abc30acd for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/21

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-03T18:54:28.144Z for PR creation at branch issue-21-9ea1abc30acd for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,13 @@ ai-generated: true
 - Уточнён RFC стратегии миграции (`docs/analysis/migration-strategy-rfc.md`,
   issue #10): добавлена таблица файлов Фазы 1, чек-лист нормализации промптов,
   единый реестр research-зависимостей, корректное разделение
-  `standards/GLOSSARY.md` и `standards/MANGO_CLASSIFICATION_CONTRACT.md`,
+  `standards/GLOSSARY.md` и `standards/product-classification-contract.md`,
   а также правила переноса продуктовых экспериментов.
+- Зафиксированы решения фаундера по Q1–Q4 в RFC миграции
+  (`docs/analysis/migration-strategy-rfc.md`, issue #21): таблица Фазы 1
+  утверждена, Hub-ссылки должны быть permalink на SHA, self-test стал
+  обязательным gate для статуса `migrated`, а стандарты, промпты, эксперименты и
+  `hub-research-dependencies.md` идут одним PR Фазы 1.
 - Завершена доработка RFC (`docs/analysis/migration-strategy-rfc.md`,
   issue #12, v0.3, блоки 3–8): реестр зависимостей от исследований Хаба (§3.5),
   переписка README.md как обязательная задача Фазы 1, согласованные формулировки

--- a/docs/analysis/migration-strategy-rfc.md
+++ b/docs/analysis/migration-strategy-rfc.md
@@ -84,9 +84,9 @@ RFC **закреплены за коммитом** `038868d` Хаба, чтоб�
 последующих изменениях монорепо (см. творческое улучшение C3, §5).
 
 - Корень аудита (tree):
-  <https://github.com/G-Ivan-A/hybrid-Intelligence-lab/tree/main/projects/mango>
+  <https://github.com/G-Ivan-A/hybrid-Intelligence-lab/tree/038868dd125b4e2d849ff73604890f1d2787ac0f/projects/mango>
 - Исследования (tree):
-  <https://github.com/G-Ivan-A/hybrid-Intelligence-lab/tree/main/research/mango>
+  <https://github.com/G-Ivan-A/hybrid-Intelligence-lab/tree/038868dd125b4e2d849ff73604890f1d2787ac0f/research/mango>
 - Permalink-база для blob-ссылок ниже:
   `https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868dd125b4e2d849ff73604890f1d2787ac0f/`
 
@@ -485,6 +485,35 @@ flowchart TD
 
 ---
 
+## §8. Решения фаундера по открытым вопросам (Human Review 2026-06)
+
+### Q1: Source paths Фазы 1
+
+**Решение:** Утверждаю таблицу файлов Фазы 1 из §3.2 как есть. Если имена в
+snapshot отличаются — заменить на подтверждённые Hub-пути перед переносом.
+
+### Q2: Стратегия ссылок на Хаб (C3, E7)
+
+**Решение:** Permalink на SHA (воспроизводимость). Ссылки на `main` запрещены.
+Обновление — через осознанное действие синхронизации.
+
+### Q3: Self-test gate (C2)
+
+**Решение:** Self-test — обязательный критерий пометки промпта «migrated». Без
+прохождения self-test промпт не считается нормализованным.
+
+### Q4: Фазирование
+
+**Решение:** Стандарты, промпты, эксперименты и
+`hub-research-dependencies.md` идут одним PR Фазы 1. Атомарная операция.
+
+---
+
+**Дата утверждения:** 2026-06-04
+**Утверждено:** Иван Гулиенко (фаундер)
+
+---
+
 ## Связанные артефакты
 
 - Issue: <https://github.com/G-Ivan-A/mango_ba_prompts/issues/8>
@@ -494,6 +523,6 @@ flowchart TD
 - Целевые стандарты Фазы 1: `standards/GLOSSARY.md`,
   `standards/product-classification-contract.md`
 - Контракт и правила: [`AI_GOVERNANCE.md`](../../AI_GOVERNANCE.md), [`AI_QUICK_RULES.md`](../../AI_QUICK_RULES.md)
-- Хаб, проект Mango (аудит): <https://github.com/G-Ivan-A/hybrid-Intelligence-lab/tree/main/projects/mango>
-- Хаб, исследования Mango: <https://github.com/G-Ivan-A/hybrid-Intelligence-lab/tree/main/research/mango>
-- Хаб, шаблон спока: <https://github.com/G-Ivan-A/hybrid-Intelligence-lab/tree/main/templates/spoke>
+- Хаб, проект Mango (аудит): <https://github.com/G-Ivan-A/hybrid-Intelligence-lab/tree/038868dd125b4e2d849ff73604890f1d2787ac0f/projects/mango>
+- Хаб, исследования Mango: <https://github.com/G-Ivan-A/hybrid-Intelligence-lab/tree/038868dd125b4e2d849ff73604890f1d2787ac0f/research/mango>
+- Хаб, шаблон спока: <https://github.com/G-Ivan-A/hybrid-Intelligence-lab/tree/038868dd125b4e2d849ff73604890f1d2787ac0f/templates/spoke>


### PR DESCRIPTION
## Summary

Fixes G-Ivan-A/mango_ba_prompts#21.

This PR records the founder decisions for Q1-Q4 in the migration RFC and tightens the remaining naming/link consistency around the Mango classification contract.

## Changes

- Added RFC §8 with founder decisions for Q1-Q4, including the approval date `2026-06-04` exactly as specified in the issue.
- Updated remaining RFC Hub tree links from `main` to the pinned SHA `038868dd125b4e2d849ff73604890f1d2787ac0f` to match the Q2 decision.
- Updated `CHANGELOG.md` so the repository no longer preserves the deprecated `standards/MANGO_CLASSIFICATION_CONTRACT.md` spelling.
- Removed the automatic root `.gitkeep` bootstrap artifact from the branch.

## Validation

- `git diff --check upstream/main...HEAD`
- `rg -n "MANGO_CLASSIFICATION_CONTRACT\.md" . || true`
- `rg -n "github\.com/G-Ivan-A/hybrid-Intelligence-lab/(tree|blob)/main" docs/analysis/migration-strategy-rfc.md || true`
- Verified `governance/BACKLOG.md` already contains the required M-002 `kb/glossary.md` handling and M-004 uses `standards/product-classification-contract.md`.

## Human Review Focus

Please confirm that RFC §8 captures the founder decisions correctly and that replacing RFC Hub `main` tree links with the pinned SHA is the intended interpretation of Q2.
