### PR TITLE
project: создать live Issues M-001–M-009 для Фазы 1 миграции

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-04T19:58:32.226Z for PR creation at branch issue-25-5ff249e9d413 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/25

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-04T19:58:32.226Z for PR creation at branch issue-25-5ff249e9d413 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/25

--- a/governance/migration-issues-registry.md
+++ b/governance/migration-issues-registry.md
@@ -1,0 +1,13 @@
+# Реестр созданных issues для Фазы 1 миграции
+
+| ID | Название | URL Issue | Статус |
+|----|----------|-----------|--------|
+| M-001 | Переписать README.md спока | https://github.com/G-Ivan-A/mango_ba_prompts/issues/28 | Open |
+| M-002 | Создать базовую структуру папок проекта | https://github.com/G-Ivan-A/mango_ba_prompts/issues/29 | Open |
+| M-003 | Скопировать standards/GLOSSARY.md из Хаба | https://github.com/G-Ivan-A/mango_ba_prompts/issues/30 | Open |
+| M-004 | Перенести и переименовать classification-glossary → standards/product-classification-contract.md | https://github.com/G-Ivan-A/mango_ba_prompts/issues/31 | Open |
+| M-005 | Перенести эксперименты в prompts/experiments/ | https://github.com/G-Ivan-A/mango_ba_prompts/issues/32 | Open |
+| M-006 | Нормализовать frontmatter у всех старых промптов | https://github.com/G-Ivan-A/mango_ba_prompts/issues/33 | Open |
+| M-007 | Создать docs/hub-research-dependencies.md | https://github.com/G-Ivan-A/mango_ba_prompts/issues/34 | Open |
+| M-008 | Добавить временный workflow в CONTRIBUTING.md | https://github.com/G-Ivan-A/mango_ba_prompts/issues/35 | Open |
+| M-009 | Создать Migration Manifest | https://github.com/G-Ivan-A/mango_ba_prompts/issues/36 | Open |


### PR DESCRIPTION
## Что сделано

Refs #25.

Созданы 9 live GitHub Issues для Фазы 1 миграции в upstream-репозитории `G-Ivan-A/mango_ba_prompts`:

| ID | Issue |
|----|-------|
| M-001 | https://github.com/G-Ivan-A/mango_ba_prompts/issues/28 |
| M-002 | https://github.com/G-Ivan-A/mango_ba_prompts/issues/29 |
| M-003 | https://github.com/G-Ivan-A/mango_ba_prompts/issues/30 |
| M-004 | https://github.com/G-Ivan-A/mango_ba_prompts/issues/31 |
| M-005 | https://github.com/G-Ivan-A/mango_ba_prompts/issues/32 |
| M-006 | https://github.com/G-Ivan-A/mango_ba_prompts/issues/33 |
| M-007 | https://github.com/G-Ivan-A/mango_ba_prompts/issues/34 |
| M-008 | https://github.com/G-Ivan-A/mango_ba_prompts/issues/35 |
| M-009 | https://github.com/G-Ivan-A/mango_ba_prompts/issues/36 |

Также добавлен реестр: `governance/migration-issues-registry.md`.
Технический bootstrap `.gitkeep` удалён.

## Проверка

- `git diff --check`
- `gh issue list --repo G-Ivan-A/mango_ba_prompts --state all --limit 50 --json number,title,state,labels,milestone,url`
- Spot-check тел issues #28 и #36: структура `Title`, `Мета`, `Контекст`, `Артефакты`, `Готово, когда` присутствует; Hub-ссылки используют SHA `038868dd125b4e2d849ff73604890f1d2787ac0f`.

## Требуется maintainer action

Создание самих issues доступно и выполнено. Но у текущего token в upstream нет прав на repository labels/milestones (`permissions.push=false`, `triage=false`, `maintain=false`, `admin=false`), поэтому API-запрос на создание labels/milestone возвращает HTTP 404.

Нужно создать и применить GitHub metadata из полей `## 🔗 Мета` каждого issue:

- labels: `migration`, `creative`, `structured`, `priority:P0`, `priority:P1`, `priority:P2`
- milestone: `Sprint 3 — Hybrid Minimum Bootstrap`

Все эти значения уже указаны в body каждого созданного issue.
