### PR TITLE
[M-008] docs: добавить временный prompt-workflow в CONTRIBUTING.md

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-04T21:13:03.258Z for PR creation at branch issue-35-93276d378b3b for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/35

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-04T21:13:03.258Z for PR creation at branch issue-35-93276d378b3b for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/35

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ ai-generated: true
 
 ### Changed
 
+- Добавлен временный workflow создания промптов в `CONTRIBUTING.md` (issue #35,
+  M-008): ровно 5 шагов `draft → frontmatter → marker → prompt:review →
+  canonical`, capability boundary `prompts/drafts/` и минимальный пример
+  frontmatter для черновика без введения матрицы или ADR-процесса.
 - Переписан корневой `README.md` под standalone-спок (issue #28, M-001, v2.0):
   README теперь описывает `mango_ba_prompts` как **библиотеку промптов для
   бизнес-аналитиков** (ТЗ-статистика, use-case, user story), а не как базу

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 ---
 status: draft
 version: 0.1
-updated: 2026-06-02
+updated: 2026-06-04
 ai-generated: true
 ---
 
@@ -19,6 +19,35 @@ traceability и практическую полезность для hybrid huma
    unrelated restructuring. Связывайте PR с issue.
 3. **Review.** Финальные решения по vision, publication и merge остаются за
    человеком согласно [AI_GOVERNANCE.md](AI_GOVERNANCE.md).
+
+## Временный workflow промптов
+
+До появления ADR это единственный разрешённый способ создания новых промптов в
+споке. Workflow опирается на capability boundary `prompts/drafts/` и не вводит
+матрицу решений или дополнительный ADR-процесс.
+
+1. **Draft.** Создать файл в `prompts/drafts/` с именем
+   `[biz-process]-[purpose].md`.
+2. **Frontmatter.** Добавить обязательный frontmatter: `status: draft`,
+   `version: 0.1`, `updated: {{date}}`, `temperature: 0.1`.
+3. **Experimental marker.** Добавить комментарий
+   `<!-- Experimental: for [task/link], no formal research yet -->`.
+4. **Review issue.** Создать issue `prompt:review` с бизнес-контекстом.
+5. **Canonical promotion.** После human review переместить файл в `prompts/`,
+   обновить `status: canonical`, `version: 1.0`.
+
+Минимальный черновик:
+
+```markdown
+---
+status: draft
+version: 0.1
+updated: {{date}}
+temperature: 0.1
+---
+
+<!-- Experimental: for [task/link], no formal research yet -->
+```
 
 ## AI-Assisted Work
 


### PR DESCRIPTION
## Summary

- Adds the temporary prompt workflow section to `CONTRIBUTING.md` with exactly five RFC §5.2 steps.
- States that this is the only allowed prompt-creation path before ADR, using `prompts/drafts/` as the capability boundary and avoiding a matrix/ADR process.
- Adds a minimal draft frontmatter example and records the change in `CHANGELOG.md`.

## Reproduction

Before the change, `CONTRIBUTING.md` did not contain the required `prompt:review`, `Experimental: for [task/link]`, or `prompts/drafts/` workflow markers from issue #35.

## Validation

- `awk '/^## Временный workflow промптов/{flag=1; next} /^## /{flag=0} flag && /^[0-9]+\\. /{count++} END{print count; exit count==5 ? 0 : 1}' CONTRIBUTING.md` → `5`\n- Required-token check for `prompts/drafts/`, `[biz-process]-[purpose].md`, draft frontmatter fields, experimental marker, `prompt:review`, `status: canonical`, and `version: 1.0` passed.\n- `git diff --check` passed.\n\nFixes G-Ivan-A/mango_ba_prompts#35


Fixes G-Ivan-A/mango_ba_prompts#35