### PR TITLE
hotfix: correct prompt statuses and legacy placement

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-11T09:40:02.357Z for PR creation at branch issue-58-97bcf820d4ea for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/58

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-11T09:40:02.357Z for PR creation at branch issue-58-97bcf820d4ea for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/58

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,10 @@ ai-generated: true
 
 - Файл `prompts/drafts/Промпт+для+БА (1).md` (созданный в issue #54 как единый
   draft) разбит на **23 отдельных промпта** по схеме `[домен]-[операция]-[режим].md`
-  (kebab-case). **18 активных** промптов размещены в [`prompts/`](prompts/)
-  (`status: draft`, `version: 0.1`); **5 архивных** — в
+  (kebab-case). **18 новых** промптов размещены в [`prompts/`](prompts/)
+  (`status: draft`, `version: 0.1`); **5 legacy-промптов из PDF** также размещены
+  в [`prompts/`](prompts/) с суффиксом `-legacy` (`status: draft`, `version: 1.0`),
+  так как продолжают использоваться; **6 старых canonical-промптов** перенесены в
   [`prompts/archive/`](prompts/archive/) с суффиксом `-legacy` (`status: archived`,
   `version: 1.0`). Текст каждого промпта скопирован **дословно** (проверено
   побайтово против исходного среза); добавлены обязательный frontmatter (`status`,

--- a/prompts/archive/tz-stats-generator-legacy.md
+++ b/prompts/archive/tz-stats-generator-legacy.md
@@ -1,5 +1,5 @@
 ---
-status: canonical
+status: archived
 version: 1.0
 updated: 2026-06-04
 ai-generated: true

--- a/prompts/archive/tz-stats-generator-simple-legacy.md
+++ b/prompts/archive/tz-stats-generator-simple-legacy.md
@@ -1,5 +1,5 @@
 ---
-status: canonical
+status: archived
 version: 1.0
 updated: 2026-06-04
 ai-generated: true

--- a/prompts/archive/usecase-stepwise-generator-legacy.md
+++ b/prompts/archive/usecase-stepwise-generator-legacy.md
@@ -1,5 +1,5 @@
 ---
-status: canonical
+status: archived
 version: 1.0
 updated: 2026-06-04
 ai-generated: true

--- a/prompts/archive/usecase-stepwise-generator-simple-legacy.md
+++ b/prompts/archive/usecase-stepwise-generator-simple-legacy.md
@@ -1,5 +1,5 @@
 ---
-status: canonical
+status: archived
 version: 1.0
 updated: 2026-06-04
 ai-generated: true

--- a/prompts/archive/user-story-generator-legacy.md
+++ b/prompts/archive/user-story-generator-legacy.md
@@ -1,5 +1,5 @@
 ---
-status: canonical
+status: archived
 version: 1.0
 updated: 2026-06-04
 ai-generated: true

--- a/prompts/archive/user-story-generator-simple-legacy.md
+++ b/prompts/archive/user-story-generator-simple-legacy.md
@@ -1,5 +1,5 @@
 ---
-status: canonical
+status: archived
 version: 1.0
 updated: 2026-06-04
 ai-generated: true

--- a/prompts/asr-ingestion-legacy.md
+++ b/prompts/asr-ingestion-legacy.md
@@ -1,5 +1,5 @@
 ---
-status: archived
+status: draft
 version: 1.0
 updated: 2026-06-11
 temperature: 0.1

--- a/prompts/fr-validation-legacy.md
+++ b/prompts/fr-validation-legacy.md
@@ -1,5 +1,5 @@
 ---
-status: archived
+status: draft
 version: 1.0
 updated: 2026-06-11
 temperature: 0.1

--- a/prompts/letter-customer-documentation-legacy.md
+++ b/prompts/letter-customer-documentation-legacy.md
@@ -1,5 +1,5 @@
 ---
-status: archived
+status: draft
 version: 1.0
 updated: 2026-06-11
 temperature: 0.1

--- a/prompts/questions-customer-understanding-legacy.md
+++ b/prompts/questions-customer-understanding-legacy.md
@@ -1,5 +1,5 @@
 ---
-status: archived
+status: draft
 version: 1.0
 updated: 2026-06-11
 temperature: 0.1

--- a/prompts/technical-details-solution-design-legacy.md
+++ b/prompts/technical-details-solution-design-legacy.md
@@ -1,5 +1,5 @@
 ---
-status: archived
+status: draft
 version: 1.0
 updated: 2026-06-11
 temperature: 0.1


### PR DESCRIPTION
## Summary

Fixes G-Ivan-A/mango_ba_prompts#58.

This PR corrects the prompt placement regression from the previous migration:

- Moves the 5 PDF legacy prompts from `prompts/archive/` back to `prompts/`.
- Changes those 5 legacy prompts to `status: draft`, keeping `version: 1.0` and the `-legacy` suffix.
- Moves the 6 obsolete canonical prompts from `prompts/` into `prompts/archive/` with `-legacy` filenames.
- Changes those 6 archived prompts to `status: archived`, keeping `version: 1.0`.
- Updates the changelog wording so it documents the corrected 18 new + 5 active legacy + 6 archived canonical structure.
- Removes the auto-generated root `.gitkeep` scaffolding from the prepared PR branch.

## Reproduction

Before the fix, the repository had:

- `prompts/`: 24 markdown prompt files, including 6 old `status: canonical` prompts that should have been archived.
- `prompts/archive/`: 5 markdown prompt files, all PDF legacy prompts incorrectly marked `status: archived`.

## Validation

Local checks run:

```bash
python3 experiments/validate_issue_58_prompt_structure.py
find prompts -maxdepth 1 -type f -name '*.md' | wc -l
find prompts/archive -maxdepth 1 -type f -name '*.md' | wc -l
git diff --cached --check
```

Results:

- `prompts/`: 23 markdown prompt files.
- `prompts/archive/`: 6 markdown prompt files.
- All 5 active legacy prompts have `status: draft`, `version: 1.0`, `temperature: 0.1`.
- All 6 archived canonical prompts have `status: archived`, `version: 1.0`, `temperature: 0.1`.
- No prompt body text was intentionally changed; changes are path moves plus required frontmatter status updates.
