### PR TITLE
fix: добавить ID промпта в копируемый текст (#95)

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Validate Mango Office widget
         run: python3 scripts/validate_issue_86_mango_widget.py
 
+      - name: Validate prompt ID in copy
+        run: python3 scripts/validate_issue_95_prompt_id_in_copy.py
+
       - name: Prepare artifact
         run: |
           mkdir -p pages-dist

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-15T19:01:45.276Z for PR creation at branch issue-82-0e783db552e4 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/82
+# Updated: 2026-06-16T12:46:14.903Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-06-15T19:01:45.276Z for PR creation at branch issue-82-0e783db552e4 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/82
-# Updated: 2026-06-16T12:46:14.903Z

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ ai-generated: true
 
 ## Unreleased
 
+### Fixed — Issue #95 добавить ID промпта в копируемый текст
+
+- Кнопка «Копировать» в карточке промпта теперь добавляет HTML-комментарий с ID
+  в начало копируемого текста: формат `<!-- {prompt.id} -->\n\n{body}`.
+- HTML-комментарий добавляется **только при копировании** — в отображаемой карточке
+  он не появляется (изменения только в [`site/app.js`](site/app.js)).
+- LLM игнорирует HTML-комментарий, при этом ID виден в истории чата и позволяет
+  отследить, какой промпт был использован.
+- Добавлена локальная проверка
+  [`scripts/validate_issue_95_prompt_id_in_copy.py`](scripts/validate_issue_95_prompt_id_in_copy.py)
+  и шаг в workflow [`.github/workflows/github-pages.yml`](.github/workflows/github-pages.yml).
+
 ### Changed — Issue #92 метаданные промптов (`id` + `title`), удаление EXPERIMENTAL
 
 - В обязательный frontmatter всех 30 промптов (`prompts/` и `prompts/archive/`)

--- a/scripts/validate_issue_95_prompt_id_in_copy.py
+++ b/scripts/validate_issue_95_prompt_id_in_copy.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Local regression check for issue #95: prompt ID in copied text.
+
+Locks the requirements:
+- copyText call prepends <!-- {prompt.id} --> HTML comment (ФТ-1);
+- format matches <!-- {prompt.id} -->\n\n{body} (ФТ-1);
+- HTML comment is only added on copy, not in the rendered card (ФТ-1);
+- five target prompts have valid IDs in prompts.json (ФТ-3);
+- CHANGELOG.md mentions Issue #95 (ФТ-4).
+"""
+
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+TARGET_PROMPT_IDS = [
+    "mango-fr-documentation-stepwise",
+    "mango-asr-ingestion-oneshot",
+    "mango-uc-modeling-oneshot",
+    "mango-questions-customer-understanding-stepwise",
+    "mango-meeting-customer-documentation-stepwise",
+]
+
+
+def read_text(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def read_json(path: str) -> dict:
+    return json.loads(read_text(path))
+
+
+def require(text: str, path: str, *needles: str) -> list[str]:
+    return [f"{path}: missing {needle!r}" for needle in needles if needle not in text]
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    app_js = read_text("site/app.js")
+
+    # ФТ-1: copyText is called with <!-- {prompt.id} --> prefix.
+    errors += require(
+        app_js,
+        "site/app.js",
+        "<!-- ${prompt.id} -->",
+    )
+    # The format must be <!-- id -->\n\n{body}.
+    if "<!-- ${prompt.id} -->\\n\\n${body}" not in app_js and (
+        "<!-- ${prompt.id} -->\\n\\n" not in app_js
+        and "`<!-- ${prompt.id} -->\\n\\n${body}`" not in app_js
+    ):
+        # Check template literal form (backticks escape differently in source).
+        if not re.search(
+            r"copyText\(`<!-- \$\{prompt\.id\} -->\\n\\n\$\{body\}`\)",
+            app_js,
+        ):
+            errors.append(
+                "site/app.js: copyText must use format `<!-- ${prompt.id} -->\\n\\n${body}`"
+            )
+
+    # ФТ-1: HTML comment must NOT appear in the rendered card (promptCard function).
+    prompt_card_match = re.search(
+        r"function promptCard\(prompt\)\s*\{(.+?)^}", app_js, re.DOTALL | re.MULTILINE
+    )
+    if prompt_card_match:
+        card_body = prompt_card_match.group(1)
+        if "<!-- ${prompt.id} -->" in card_body:
+            errors.append(
+                "site/app.js: HTML comment must not appear in promptCard (display only)"
+            )
+
+    # ФТ-3: prompts.json exists and contains the 5 target prompts with valid IDs.
+    prompts_json_path = "site/data/prompts.json"
+    if not (ROOT / prompts_json_path).exists():
+        errors.append(f"{prompts_json_path}: file does not exist")
+    else:
+        prompts_data = read_json(prompts_json_path)
+        prompt_ids = {p["id"] for p in prompts_data.get("prompts", [])}
+        for target_id in TARGET_PROMPT_IDS:
+            if target_id not in prompt_ids:
+                errors.append(f"{prompts_json_path}: missing target prompt id {target_id!r}")
+
+        # Verify IDs follow mango-[operation]-[mode] pattern.
+        id_pattern = re.compile(r"^mango-[a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*$")
+        for prompt in prompts_data.get("prompts", []):
+            prompt_id = prompt.get("id", "")
+            if not id_pattern.match(prompt_id):
+                errors.append(
+                    f"{prompts_json_path}: prompt id {prompt_id!r} does not match mango-[operation]-[mode] format"
+                )
+
+    # ФТ-4: CHANGELOG.md documents the change.
+    changelog = read_text("CHANGELOG.md")
+    errors += require(changelog, "CHANGELOG.md", "Issue #95")
+
+    if errors:
+        print("issue-95 prompt-id-in-copy validation: FAIL")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("issue-95 prompt-id-in-copy validation: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/app.js
+++ b/site/app.js
@@ -523,7 +523,8 @@ nodes.promptGrid.addEventListener("click", async (event) => {
     return;
   }
   try {
-    await copyText(prompt.body || prompt.content);
+    const body = prompt.body || prompt.content;
+    await copyText(`<!-- ${prompt.id} -->\n\n${body}`);
     button.dataset.copied = "true";
     showToast(`${prompt.file} скопирован`);
     window.setTimeout(() => {

--- a/site/data/checks.json
+++ b/site/data/checks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T11:30:46.313Z",
+  "generatedAt": "2026-06-16T12:47:41.061Z",
   "sourceFiles": [
     {
       "path": "prompts/experiments/",
@@ -32,28 +32,28 @@
       "icon": "1",
       "prompts": [
         {
-          "id": "us-modeling-oneshot",
+          "id": "mango-us-modeling-oneshot",
           "file": "us-modeling-oneshot.md",
           "tests": 5,
           "feedback": 0,
           "usage": 5
         },
         {
-          "id": "us-modeling-stepwise",
+          "id": "mango-us-modeling-stepwise",
           "file": "us-modeling-stepwise.md",
           "tests": 5,
           "feedback": 0,
           "usage": 5
         },
         {
-          "id": "uc-modeling-oneshot",
+          "id": "mango-uc-modeling-oneshot",
           "file": "uc-modeling-oneshot.md",
           "tests": 3,
           "feedback": 0,
           "usage": 3
         },
         {
-          "id": "uc-modeling-stepwise",
+          "id": "mango-uc-modeling-stepwise",
           "file": "uc-modeling-stepwise.md",
           "tests": 3,
           "feedback": 0,
@@ -67,21 +67,21 @@
       "icon": "2",
       "prompts": [
         {
-          "id": "fr-validation-legacy",
+          "id": "mango-fr-validation-legacy",
           "file": "fr-validation-legacy.md",
           "tests": 1,
           "feedback": 0,
           "usage": 1
         },
         {
-          "id": "fr-validation-oneshot",
+          "id": "mango-fr-validation-oneshot",
           "file": "fr-validation-oneshot.md",
           "tests": 1,
           "feedback": 0,
           "usage": 1
         },
         {
-          "id": "fr-validation-stepwise",
+          "id": "mango-fr-validation-stepwise",
           "file": "fr-validation-stepwise.md",
           "tests": 1,
           "feedback": 0,
@@ -95,21 +95,21 @@
       "icon": "3",
       "prompts": [
         {
-          "id": "fr-validation-legacy",
+          "id": "mango-fr-validation-legacy",
           "file": "fr-validation-legacy.md",
           "tests": 1,
           "feedback": 0,
           "usage": 1
         },
         {
-          "id": "fr-validation-oneshot",
+          "id": "mango-fr-validation-oneshot",
           "file": "fr-validation-oneshot.md",
           "tests": 1,
           "feedback": 0,
           "usage": 1
         },
         {
-          "id": "fr-validation-stepwise",
+          "id": "mango-fr-validation-stepwise",
           "file": "fr-validation-stepwise.md",
           "tests": 1,
           "feedback": 0,
@@ -123,28 +123,28 @@
       "icon": "4",
       "prompts": [
         {
-          "id": "us-modeling-oneshot",
+          "id": "mango-us-modeling-oneshot",
           "file": "us-modeling-oneshot.md",
           "tests": 5,
           "feedback": 0,
           "usage": 5
         },
         {
-          "id": "us-modeling-stepwise",
+          "id": "mango-us-modeling-stepwise",
           "file": "us-modeling-stepwise.md",
           "tests": 5,
           "feedback": 0,
           "usage": 5
         },
         {
-          "id": "user-story-generator-legacy",
+          "id": "mango-user-story-generator-legacy",
           "file": "user-story-generator-legacy.md",
           "tests": 5,
           "feedback": 0,
           "usage": 5
         },
         {
-          "id": "user-story-generator-simple-legacy",
+          "id": "mango-user-story-generator-simple-legacy",
           "file": "user-story-generator-simple-legacy.md",
           "tests": 5,
           "feedback": 0,
@@ -158,7 +158,7 @@
       "icon": "6",
       "prompts": [
         {
-          "id": "session-debug-documentation-oneshot",
+          "id": "mango-session-debug-documentation-oneshot",
           "file": "session-debug-documentation-oneshot.md",
           "tests": 1,
           "feedback": 0,
@@ -172,14 +172,14 @@
       "icon": "7",
       "prompts": [
         {
-          "id": "tz-stats-generator-legacy",
+          "id": "mango-tz-stats-generator-legacy",
           "file": "tz-stats-generator-legacy.md",
           "tests": 3,
           "feedback": 0,
           "usage": 3
         },
         {
-          "id": "tz-stats-generator-simple-legacy",
+          "id": "mango-tz-stats-generator-simple-legacy",
           "file": "tz-stats-generator-simple-legacy.md",
           "tests": 3,
           "feedback": 0,
@@ -190,7 +190,7 @@
   ],
   "prompts": [
     {
-      "id": "us-modeling-oneshot",
+      "id": "mango-us-modeling-oneshot",
       "file": "us-modeling-oneshot.md",
       "status": "draft",
       "operation": "modeling",
@@ -211,7 +211,7 @@
       "usage": 5
     },
     {
-      "id": "us-modeling-stepwise",
+      "id": "mango-us-modeling-stepwise",
       "file": "us-modeling-stepwise.md",
       "status": "draft",
       "operation": "modeling",
@@ -232,7 +232,7 @@
       "usage": 5
     },
     {
-      "id": "user-story-generator-legacy",
+      "id": "mango-user-story-generator-legacy",
       "file": "user-story-generator-legacy.md",
       "status": "archived",
       "operation": "modeling",
@@ -252,7 +252,7 @@
       "usage": 5
     },
     {
-      "id": "user-story-generator-simple-legacy",
+      "id": "mango-user-story-generator-simple-legacy",
       "file": "user-story-generator-simple-legacy.md",
       "status": "archived",
       "operation": "modeling",
@@ -272,7 +272,7 @@
       "usage": 5
     },
     {
-      "id": "tz-stats-generator-legacy",
+      "id": "mango-tz-stats-generator-legacy",
       "file": "tz-stats-generator-legacy.md",
       "status": "archived",
       "operation": "quality",
@@ -290,7 +290,7 @@
       "usage": 3
     },
     {
-      "id": "tz-stats-generator-simple-legacy",
+      "id": "mango-tz-stats-generator-simple-legacy",
       "file": "tz-stats-generator-simple-legacy.md",
       "status": "archived",
       "operation": "quality",
@@ -308,7 +308,7 @@
       "usage": 3
     },
     {
-      "id": "uc-modeling-oneshot",
+      "id": "mango-uc-modeling-oneshot",
       "file": "uc-modeling-oneshot.md",
       "status": "draft",
       "operation": "modeling",
@@ -327,7 +327,7 @@
       "usage": 3
     },
     {
-      "id": "uc-modeling-stepwise",
+      "id": "mango-uc-modeling-stepwise",
       "file": "uc-modeling-stepwise.md",
       "status": "draft",
       "operation": "modeling",
@@ -346,7 +346,7 @@
       "usage": 3
     },
     {
-      "id": "usecase-stepwise-generator-legacy",
+      "id": "mango-usecase-stepwise-generator-legacy",
       "file": "usecase-stepwise-generator-legacy.md",
       "status": "archived",
       "operation": "modeling",
@@ -364,7 +364,7 @@
       "usage": 3
     },
     {
-      "id": "usecase-stepwise-generator-simple-legacy",
+      "id": "mango-usecase-stepwise-generator-simple-legacy",
       "file": "usecase-stepwise-generator-simple-legacy.md",
       "status": "archived",
       "operation": "modeling",
@@ -382,7 +382,7 @@
       "usage": 3
     },
     {
-      "id": "fr-documentation-oneshot",
+      "id": "mango-fr-documentation-oneshot",
       "file": "fr-documentation-oneshot.md",
       "status": "draft",
       "operation": "documentation",
@@ -398,7 +398,7 @@
       "usage": 1
     },
     {
-      "id": "fr-documentation-stepwise",
+      "id": "mango-fr-documentation-stepwise",
       "file": "fr-documentation-stepwise.md",
       "status": "draft",
       "operation": "documentation",
@@ -414,7 +414,7 @@
       "usage": 1
     },
     {
-      "id": "fr-validation-legacy",
+      "id": "mango-fr-validation-legacy",
       "file": "fr-validation-legacy.md",
       "status": "draft",
       "operation": "validation",
@@ -431,7 +431,7 @@
       "usage": 1
     },
     {
-      "id": "fr-validation-oneshot",
+      "id": "mango-fr-validation-oneshot",
       "file": "fr-validation-oneshot.md",
       "status": "draft",
       "operation": "validation",
@@ -448,7 +448,7 @@
       "usage": 1
     },
     {
-      "id": "fr-validation-stepwise",
+      "id": "mango-fr-validation-stepwise",
       "file": "fr-validation-stepwise.md",
       "status": "draft",
       "operation": "validation",
@@ -466,7 +466,7 @@
       "usage": 1
     },
     {
-      "id": "session-debug-documentation-oneshot",
+      "id": "mango-session-debug-documentation-oneshot",
       "file": "session-debug-documentation-oneshot.md",
       "status": "draft",
       "operation": "documentation",
@@ -482,7 +482,7 @@
       "usage": 1
     },
     {
-      "id": "asr-ingestion-legacy",
+      "id": "mango-asr-ingestion-legacy",
       "file": "asr-ingestion-legacy.md",
       "status": "draft",
       "operation": "ingestion",
@@ -497,7 +497,7 @@
       "usage": 0
     },
     {
-      "id": "asr-ingestion-oneshot",
+      "id": "mango-asr-ingestion-oneshot",
       "file": "asr-ingestion-oneshot.md",
       "status": "draft",
       "operation": "ingestion",
@@ -512,7 +512,7 @@
       "usage": 0
     },
     {
-      "id": "constraints-documentation-oneshot",
+      "id": "mango-constraints-documentation-oneshot",
       "file": "constraints-documentation-oneshot.md",
       "status": "draft",
       "operation": "documentation",
@@ -526,7 +526,7 @@
       "usage": 0
     },
     {
-      "id": "constraints-documentation-stepwise",
+      "id": "mango-constraints-documentation-stepwise",
       "file": "constraints-documentation-stepwise.md",
       "status": "draft",
       "operation": "documentation",
@@ -540,7 +540,7 @@
       "usage": 0
     },
     {
-      "id": "glossary-context-understanding-oneshot",
+      "id": "mango-glossary-context-understanding-oneshot",
       "file": "glossary-context-understanding-oneshot.md",
       "status": "draft",
       "operation": "understanding",
@@ -556,7 +556,7 @@
       "usage": 0
     },
     {
-      "id": "glossary-context-understanding-stepwise",
+      "id": "mango-glossary-context-understanding-stepwise",
       "file": "glossary-context-understanding-stepwise.md",
       "status": "draft",
       "operation": "understanding",
@@ -572,7 +572,7 @@
       "usage": 0
     },
     {
-      "id": "letter-customer-documentation-legacy",
+      "id": "mango-letter-customer-documentation-legacy",
       "file": "letter-customer-documentation-legacy.md",
       "status": "draft",
       "operation": "documentation",
@@ -586,7 +586,7 @@
       "usage": 0
     },
     {
-      "id": "meeting-customer-documentation-stepwise",
+      "id": "mango-meeting-customer-documentation-stepwise",
       "file": "meeting-customer-documentation-stepwise.md",
       "status": "draft",
       "operation": "documentation",
@@ -600,7 +600,7 @@
       "usage": 0
     },
     {
-      "id": "meeting-team-documentation-stepwise",
+      "id": "mango-meeting-team-documentation-stepwise",
       "file": "meeting-team-documentation-stepwise.md",
       "status": "draft",
       "operation": "documentation",
@@ -614,7 +614,7 @@
       "usage": 0
     },
     {
-      "id": "questions-customer-understanding-legacy",
+      "id": "mango-questions-customer-understanding-legacy",
       "file": "questions-customer-understanding-legacy.md",
       "status": "draft",
       "operation": "understanding",
@@ -630,7 +630,7 @@
       "usage": 0
     },
     {
-      "id": "questions-customer-understanding-stepwise",
+      "id": "mango-questions-customer-understanding-stepwise",
       "file": "questions-customer-understanding-stepwise.md",
       "status": "draft",
       "operation": "understanding",
@@ -646,7 +646,7 @@
       "usage": 0
     },
     {
-      "id": "technical-details-solution-design-legacy",
+      "id": "mango-technical-details-solution-design-legacy",
       "file": "technical-details-solution-design-legacy.md",
       "status": "draft",
       "operation": "solution_design",
@@ -660,7 +660,7 @@
       "usage": 0
     },
     {
-      "id": "technical-details-solution-design-oneshot",
+      "id": "mango-technical-details-solution-design-oneshot",
       "file": "technical-details-solution-design-oneshot.md",
       "status": "draft",
       "operation": "solution_design",
@@ -674,7 +674,7 @@
       "usage": 0
     },
     {
-      "id": "technical-details-solution-design-stepwise",
+      "id": "mango-technical-details-solution-design-stepwise",
       "file": "technical-details-solution-design-stepwise.md",
       "status": "draft",
       "operation": "solution_design",

--- a/site/data/prompts.json
+++ b/site/data/prompts.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T11:29:18.965Z",
+  "generatedAt": "2026-06-16T12:47:41.051Z",
   "sourceFiles": [
     {
       "path": "prompts/README.md",

--- a/site/data/roadmap.json
+++ b/site/data/roadmap.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T11:29:18.965Z",
+  "generatedAt": "2026-06-16T12:47:41.052Z",
   "sourceFiles": [
     {
       "path": "docs/ba-ecosystem.md",

--- a/site/data/stats.json
+++ b/site/data/stats.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T11:29:18.969Z",
+  "generatedAt": "2026-06-16T12:47:41.067Z",
   "sourceFiles": [
     {
       "path": "prompts/README.md",


### PR DESCRIPTION
## Summary

Fixes issue #95: prompt ID is now prepended as an HTML comment when the user clicks «Копировать».

- **`site/app.js`**: `copyText` now receives `` `<!-- ${prompt.id} -->\n\n${body}` `` instead of bare `body`. The HTML comment appears only in the clipboard — the rendered card is unchanged.
- **`scripts/validate_issue_95_prompt_id_in_copy.py`**: new validator that verifies the copy format in `app.js`, the 5 target prompt IDs in `prompts.json`, and the CHANGELOG entry.
- **`.github/workflows/github-pages.yml`**: added the new validator step.
- **`CHANGELOG.md`**: documented the fix under `## Unreleased`.

## Expected copy output

```
<!-- mango-questions-customer-understanding-stepwise -->

# РОЛЬ
Ты — команда экспертов в составе:
1. Ведущий бизнес-аналитик (CBAP)...
```

## Test plan

- [x] All 4 validators pass locally (`validate_issue_74`, `_86`, `_91`, `_95`)
- [ ] CI passes on fork: https://github.com/konard/G-Ivan-A-mango_ba_prompts/actions?query=branch%3Aissue-95-df2b28cb5eeb
- [x] 5 target prompts have correct IDs in `site/data/prompts.json`:
  - `mango-fr-documentation-stepwise`
  - `mango-asr-ingestion-oneshot`
  - `mango-uc-modeling-oneshot`
  - `mango-questions-customer-understanding-stepwise`
  - `mango-meeting-customer-documentation-stepwise`
- [x] HTML comment does NOT appear in the rendered card (only `prompt-id` span with the token)


Fixes G-Ivan-A/mango_ba_prompts#95