### PR TITLE
fix(kb): process all source manifests in KB pipeline

### DIFF
--- a/.github/workflows/kb.yml
+++ b/.github/workflows/kb.yml
@@ -4,7 +4,7 @@ name: KB pipeline
 # (stdlib-only, без pip, детерминированно). Полный конвейер извлечения PDF
 # (pdfplumber/PyMuPDF/tiktoken) запускается ВРУЧНУЮ через workflow_dispatch:
 # он тяжелее и зависит от сети для pip, поэтому не должен блокировать обычный CI.
-# По умолчанию ручной запуск обрабатывает source manifest mango-cc-manual.
+# По умолчанию ручной запуск обрабатывает все source manifest из kb/sources/.
 # Это GitHub-native извлечение, которого требует ФТ-2.
 
 on:
@@ -17,15 +17,15 @@ on:
   workflow_dispatch:
     inputs:
       source_dir:
-        description: "Source manifest directory under kb/sources/; leave empty to use raw source/out inputs"
+        description: "Source manifest directory under kb/sources/; use 'all' for every meta.json; leave empty to use raw source/out inputs"
         required: false
-        default: "kb/sources/mango-cc-manual"
+        default: "all"
       source:
         description: "PDF source path(s) under kb/sources/; use spaces for multi-part manuals"
         required: false
         default: "kb/sources/mango-cc-manual/CC_manual_1.26.23-part-1.pdf kb/sources/mango-cc-manual/CC_manual_1.26.23-part-2.pdf kb/sources/mango-cc-manual/CC_manual_1.26.23-part-3.pdf kb/sources/mango-cc-manual/CC_manual_1.26.23-part-4.pdf kb/sources/mango-cc-manual/CC_manual_1.26.23-part-5.pdf kb/sources/mango-cc-manual/CC_manual_1.26.23-part-6.pdf"
       out:
-        description: "Artifact/output directory under kb/processed/ (set to collection dir for source_dir runs)"
+        description: "Artifact/output directory under kb/processed/ (used for raw runs and artifact upload)"
         required: true
         default: "kb/processed/mango-cc-manual"
       doc_code:
@@ -81,6 +81,7 @@ jobs:
           python3 scripts/validate_issue_115_kb_mango_pipeline.py
           python3 scripts/validate_issue_117_kb_traceability.py
           python3 scripts/validate_issue_121_kb_multi_file.py
+          python3 scripts/validate_issue_129_kb_all_sources.py
 
   # Тяжёлый сквозной прогон извлечения — только по ручному запуску.
   # Доказывает воспроизводимость конвейера в GitHub-native среде (ФТ-2):
@@ -105,8 +106,11 @@ jobs:
 
       - name: Extract requested source
         run: |
-          if [ -n "${{ inputs.source_dir }}" ]; then
-            python3 scripts/kb/process_sources.py "${{ inputs.source_dir }}"
+          SOURCE_DIR="${{ inputs.source_dir }}"
+          if [ "$SOURCE_DIR" = "all" ]; then
+            python3 scripts/kb/process_sources.py --all
+          elif [ -n "$SOURCE_DIR" ]; then
+            python3 scripts/kb/process_sources.py "$SOURCE_DIR"
           else
             make kb-extract \
               SRCS="${{ inputs.source }}" \
@@ -132,7 +136,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: kb-processed
-          path: ${{ inputs.out }}/
+          path: kb/processed/
           if-no-files-found: error
 
       - name: Commit extracted KB

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-06-15T19:01:45.276Z for PR creation at branch issue-82-0e783db552e4 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/82
-# Updated: 2026-06-20T08:54:04.116Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-15T19:01:45.276Z for PR creation at branch issue-82-0e783db552e4 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/82
+# Updated: 2026-06-20T08:54:04.116Z

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ TITLE   ?= $(DOC_TITLE)
 VERSION ?= $(DOC_VERSION)
 SOURCE_DIR ?= kb/sources/mango-cc-manual
 
-.PHONY: help kb-all kb-sample kb-extract kb-source-plan kb-source-extract kb-mango kb-lk kb-mtalker kb-validate kb-tokens kb-clean
+.PHONY: help kb-all kb-sample kb-extract kb-source-plan kb-source-plan-all kb-source-extract kb-source-extract-all kb-mango kb-lk kb-mtalker kb-validate kb-tokens kb-clean
 
 help:
 	@echo "KB pipeline (issue #111):"
@@ -53,7 +53,9 @@ help:
 	@echo "  make kb-sample    — собрать синтетическую фикстуру PDF (reportlab+Pillow)"
 	@echo "  make kb-extract   — извлечь SRC/SRCS в OUT (по умолчанию фикстура → $(SAMPLE_OUT))"
 	@echo "  make kb-source-plan SOURCE_DIR=kb/sources/<slug> — показать manifest-driven план"
+	@echo "  make kb-source-plan-all — показать manifest-driven план для всех kb/sources/*/meta.json"
 	@echo "  make kb-source-extract SOURCE_DIR=kb/sources/<slug> — извлечь по meta.json"
+	@echo "  make kb-source-extract-all — извлечь все kb/sources/*/meta.json"
 	@echo "  make kb-mango     — извлечь multi-part mango-cc-manual из issue #119"
 	@echo "  make kb-lk        — извлечь multi-part mango-lk-manual из issue #117"
 	@echo "  make kb-mtalker   — извлечь multi-document Mango Talker из issue #121"
@@ -86,9 +88,17 @@ kb-extract:
 kb-source-plan:
 	$(PYTHON) scripts/kb/process_sources.py "$(SOURCE_DIR)" --dry-run
 
+# Проверить планы для всех source manifest без чтения PDF.
+kb-source-plan-all:
+	$(PYTHON) scripts/kb/process_sources.py --all --dry-run
+
 # Извлечь один каталог kb/sources/<slug>/ по явному source manifest.
 kb-source-extract:
 	$(PYTHON) scripts/kb/process_sources.py "$(SOURCE_DIR)"
+
+# Извлечь все каталоги kb/sources/<slug>/ с meta.json.
+kb-source-extract-all:
+	$(PYTHON) scripts/kb/process_sources.py --all
 
 # Воспроизвести БЗ для split-руководства КЦ из issue #119.
 kb-mango:
@@ -120,6 +130,7 @@ kb-validate:
 	$(PYTHON) scripts/validate_issue_115_kb_mango_pipeline.py
 	$(PYTHON) scripts/validate_issue_117_kb_traceability.py
 	$(PYTHON) scripts/validate_issue_121_kb_multi_file.py
+	$(PYTHON) scripts/validate_issue_129_kb_all_sources.py
 
 # Наглядно: токены индекса vs отдельных разделов (метод — см. token_method).
 kb-tokens:

--- a/kb/sources/README.md
+++ b/kb/sources/README.md
@@ -145,10 +145,13 @@ kb/processed/mtalker/
 ## Как pipeline выбирает логику
 
 1. Если в `meta.json` задан `processing_mode`, используется он.
-2. Если режим не задан, но есть `documents`, режим считается `multi_document`.
-3. Если есть `parts > 1` или несколько `source_files`, режим считается
+2. Если режим не задан, но есть ровно один объект `documents`, режим считается
+   `single` и результат пишется в `kb/processed/<slug>/`.
+3. Если режим не задан, но есть несколько объектов `documents`, режим считается
+   `multi_document`.
+4. Если есть `parts > 1` или несколько `source_files`, режим считается
    `multi_part`.
-4. Иначе режим считается `single`.
+5. Иначе режим считается `single`.
 
 Для новых источников всегда задавайте `processing_mode` явно. Автоопределение
 оставлено только для обратной совместимости.
@@ -213,10 +216,22 @@ kb/processed/mtalker/
 make kb-source-plan SOURCE_DIR=kb/sources/mtalker
 ```
 
+Проверить план для всех `meta.json`:
+
+```bash
+make kb-source-plan-all
+```
+
 Запустить извлечение по `meta.json`:
 
 ```bash
 make kb-source-extract SOURCE_DIR=kb/sources/mtalker
+```
+
+Запустить извлечение всех источников:
+
+```bash
+make kb-source-extract-all
 ```
 
 Готовый target для текущего комплекта Mango Talker:

--- a/scripts/kb/process_sources.py
+++ b/scripts/kb/process_sources.py
@@ -117,7 +117,10 @@ def infer_mode(source_dir: Path, manifest: dict) -> str:
                 f"{', '.join(sorted(VALID_MODES))}"
             )
         return explicit
-    if manifest.get("documents"):
+    documents = manifest.get("documents")
+    if isinstance(documents, list) and len(documents) == 1:
+        return "single"
+    if documents:
         return "multi_document"
     if int(manifest.get("parts") or 0) > 1:
         return "multi_part"
@@ -212,7 +215,20 @@ def build_plan(
     collection_dir = (processed_root / collection_slug).resolve()
 
     if mode in {"single", "multi_part"}:
-        files = resolve_files(source_dir, manifest.get("source_files"), rel_to_root(source_dir / "meta.json"))
+        files_value = manifest.get("source_files")
+        doc_meta = None
+        documents = manifest.get("documents")
+        if files_value is None and isinstance(documents, list) and len(documents) == 1:
+            only_doc = documents[0]
+            if not isinstance(only_doc, dict):
+                raise ManifestError(f"{rel_to_root(source_dir / 'meta.json')}: documents[1] must be an object")
+            files_value = only_doc.get("source_files")
+            if files_value is None and only_doc.get("file_name"):
+                files_value = [only_doc["file_name"]]
+            doc_meta = only_doc
+        elif files_value is None and manifest.get("file_name"):
+            files_value = [manifest["file_name"]]
+        files = resolve_files(source_dir, files_value, rel_to_root(source_dir / "meta.json"))
         if mode == "single" and len(files) != 1:
             raise ManifestError(f"{rel_to_root(source_dir / 'meta.json')}: single mode requires exactly one PDF")
         if mode == "multi_part" and len(files) < 2:
@@ -225,6 +241,7 @@ def build_plan(
             mode=mode,
             source_set=collection_slug,
             source_document=collection_slug,
+            doc_meta=doc_meta,
         )
         return SourcePlan(source_dir, mode, name, version, collection_dir, (job,), manifest)
 

--- a/scripts/validate_issue_121_kb_multi_file.py
+++ b/scripts/validate_issue_121_kb_multi_file.py
@@ -244,9 +244,12 @@ def check_synthetic_update_scenarios() -> list[str]:
         if not keep.exists():
             errors.append("synthetic multi_document add/delete: expected child was removed")
 
-        # Inference remains backward-compatible for old manifests.
-        if infer_mode(multi_dir, {"documents": [{"file_name": "a.pdf"}]}) != "multi_document":
-            errors.append("mode inference: documents should imply multi_document")
+        # Inference remains backward-compatible for real product collections,
+        # while one-document manifests stay a single top-level KB.
+        if infer_mode(multi_dir, {"documents": [{"file_name": "a.pdf"}]}) != "single":
+            errors.append("mode inference: one document should imply single")
+        if infer_mode(multi_dir, {"documents": [{"file_name": "a.pdf"}, {"file_name": "b.pdf"}]}) != "multi_document":
+            errors.append("mode inference: multiple documents should imply multi_document")
         if infer_mode(single_dir, {"parts": 2}) != "multi_part":
             errors.append("mode inference: parts > 1 should imply multi_part")
 

--- a/scripts/validate_issue_129_kb_all_sources.py
+++ b/scripts/validate_issue_129_kb_all_sources.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Regression check for issue #129 — KB pipeline processes every source.
+
+Issue #129 reported a successful KB workflow that still left 12 newly uploaded
+source folders absent from ``kb/processed``. The failure mode was orchestration:
+manual dispatch defaulted to one hardcoded source, while the repository already
+had enough manifest data to plan every ``kb/sources/*/meta.json``.
+
+This check stays stdlib-only for CI and verifies:
+
+- the issue's processable ``meta.json`` sources exist with PDF payloads;
+- every issue source expands to a top-level processed output directory;
+- workflow_dispatch defaults to all manifests and invokes ``process_sources.py --all``;
+- Makefile validation includes this regression.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts" / "kb"))
+
+from process_sources import ManifestError, build_plan, iter_source_dirs  # noqa: E402
+
+WORKFLOW = ".github/workflows/kb.yml"
+MAKEFILE = "Makefile"
+
+ISSUE_129_SOURCES = {
+    "Rolevaya-model-vats": {"mode": "single", "jobs": 1},
+    "integration-bitrix24": {"mode": "single", "jobs": 1},
+    "integration_1c": {"mode": "single", "jobs": 1},
+    "integration_amocrm": {"mode": "single", "jobs": 1},
+    "lk-vats-sso": {"mode": "single", "jobs": 1},
+    "mdialogi-api": {"mode": "single", "jobs": 1},
+    "quality-managment": {"mode": "single", "jobs": 1},
+    "sip-trunk": {"mode": "single", "jobs": 1},
+    "speech-analytics": {"mode": "multi_document", "jobs": 4},
+    "vpbx-api": {"mode": "single", "jobs": 1},
+    "wallboard": {"mode": "single", "jobs": 1},
+}
+
+
+def read_text(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def require_text(text: str, path: str, *needles: str) -> list[str]:
+    return [f"{path}: missing {needle!r}" for needle in needles if needle not in text]
+
+
+def check_source_plans() -> list[str]:
+    errors: list[str] = []
+    planned = {path.name: path for path in iter_source_dirs()}
+    missing = sorted(set(ISSUE_129_SOURCES) - set(planned))
+    for slug in missing:
+        errors.append(f"kb/sources/{slug}/meta.json: missing")
+
+    for slug, expected in sorted(ISSUE_129_SOURCES.items()):
+        source_dir = planned.get(slug)
+        if source_dir is None:
+            continue
+        try:
+            plan = build_plan(source_dir)
+        except ManifestError as exc:
+            errors.append(str(exc))
+            continue
+        if plan.mode != expected["mode"]:
+            errors.append(f"kb/sources/{slug}/meta.json: mode {plan.mode!r}, expected {expected['mode']!r}")
+        if len(plan.jobs) != expected["jobs"]:
+            errors.append(f"kb/sources/{slug}/meta.json: {len(plan.jobs)} jobs, expected {expected['jobs']}")
+        if plan.output_dir != ROOT / "kb" / "processed" / slug:
+            errors.append(f"kb/sources/{slug}/meta.json: output must be kb/processed/{slug}")
+        for job in plan.jobs:
+            if not job.pdf_paths:
+                errors.append(f"kb/sources/{slug}/meta.json: job {job.source_document} has no PDFs")
+            for pdf_path in job.pdf_paths:
+                if pdf_path.suffix.lower() != ".pdf":
+                    errors.append(f"{pdf_path.relative_to(ROOT)}: expected PDF source")
+                if not pdf_path.exists():
+                    errors.append(f"{pdf_path.relative_to(ROOT)}: missing")
+    return errors
+
+
+def check_workflow_all_dispatch() -> list[str]:
+    text = read_text(WORKFLOW)
+    errors = require_text(
+        text,
+        WORKFLOW,
+        'default: "all"',
+        'if [ "$SOURCE_DIR" = "all" ]; then',
+        "python3 scripts/kb/process_sources.py --all",
+        "path: kb/processed/",
+        "scripts/validate_issue_129_kb_all_sources.py",
+    )
+    if 'default: "kb/sources/mango-cc-manual"' in text:
+        errors.append(f"{WORKFLOW}: workflow_dispatch must not default to one hardcoded source")
+    return errors
+
+
+def check_makefile_targets() -> list[str]:
+    text = read_text(MAKEFILE)
+    return require_text(
+        text,
+        MAKEFILE,
+        "kb-source-plan-all",
+        "kb-source-extract-all",
+        "$(PYTHON) scripts/kb/process_sources.py --all --dry-run",
+        "$(PYTHON) scripts/kb/process_sources.py --all",
+        "scripts/validate_issue_129_kb_all_sources.py",
+    )
+
+
+def main() -> int:
+    errors: list[str] = []
+    errors += check_source_plans()
+    errors += check_workflow_all_dispatch()
+    errors += check_makefile_targets()
+    if errors:
+        print("Issue #129 validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("Issue #129 validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Change KB workflow dispatch default from one hardcoded source to all `kb/sources/*/meta.json` manifests via `process_sources.py --all`.
- Add all-source Makefile targets and documentation for planning/extracting every source manifest.
- Treat one-document legacy `documents` manifests as a single top-level KB output, while preserving true multi-document collections.
- Add issue #129 regression validation so CI fails if the workflow stops processing all processable source manifests.

## Reproduction / Root Cause
Before this change, manual KB workflow dispatch defaulted to `kb/sources/mango-cc-manual`, so a successful run could leave newly uploaded source manifests unprocessed. Some one-document manifests also planned nested collection paths instead of `kb/processed/<slug>`.

## Verification
- `make kb-validate`
- `python3 scripts/kb/process_sources.py --all --dry-run`

Note: this checkout has 11 new processable `meta.json` source folders from issue #129. `kb/sources/contact-center-manual/` still contains only the older `source.md` placeholder and no `meta.json`, so it is not included in the manifest-driven all-source run.

Fixes G-Ivan-A/mango_ba_prompts#129
