### PR TITLE
fix(kb): document post-migration structure

### DIFF
--- a/.github/workflows/kb.yml
+++ b/.github/workflows/kb.yml
@@ -14,7 +14,13 @@ on:
       - main
     paths:
       - ".github/workflows/kb.yml"
+      - "CHANGELOG.md"
       - "Makefile"
+      - "docs/audit/issue-144-kb-structure.md"
+      - "kb/README.md"
+      - "kb/fragments/README.md"
+      - "kb/practices/**"
+      - "kb/mango-product-docs/README.md"
       - "kb/mango-product-docs/UPLOAD-GUIDE.md"
       - "kb/mango-product-docs/sources/**"
       - "scripts/kb/**"
@@ -93,6 +99,9 @@ jobs:
           else
             echo "Issue #131 processed-output validation runs after extraction for ${{ github.event_name }}."
           fi
+
+      - name: Validate issue #144 KB structure README integrity
+        run: python3 scripts/validate_issue_144_kb_structure_readmes.py
 
   # Тяжёлый сквозной прогон извлечения.
   # На workflow_dispatch выполняет выбранный source. На push в main всегда

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-15T19:01:45.276Z for PR creation at branch issue-82-0e783db552e4 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/82
+# Updated: 2026-06-20T11:52:50.066Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-06-15T19:01:45.276Z for PR creation at branch issue-82-0e783db552e4 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/82
-# Updated: 2026-06-20T11:52:50.066Z

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ ai-generated: true
 
 ## Unreleased
 
+### Fixed — Issue #144 целостность структуры `kb/` после миграции product docs
+
+- Обновлён [`kb/README.md`](kb/README.md): описаны `kb/mango-product-docs/`,
+  `kb/fragments/`, `kb/practices/` и будущие namespaces `kb/industry/`,
+  `kb/mango/`.
+- Добавлены README для продуктовой БЗ и ручных практик:
+  [`kb/mango-product-docs/README.md`](kb/mango-product-docs/README.md) и
+  [`kb/practices/README.md`](kb/practices/README.md).
+- Зафиксирован аудит истории
+  [`docs/audit/issue-144-kb-structure.md`](docs/audit/issue-144-kb-structure.md):
+  `fragments/` и `practices/` оставлены в `kb/` как независимые материалы, без
+  переносов.
+- Добавлена регрессионная проверка
+  [`scripts/validate_issue_144_kb_structure_readmes.py`](scripts/validate_issue_144_kb_structure_readmes.py),
+  подключённая к `make kb-validate` и KB workflow.
+
 ### Added — Issue #139 ADR по Industry Taxonomy
 
 - Добавлен proposed ADR

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,7 @@ kb-validate:
 	$(PYTHON) scripts/validate_issue_121_kb_multi_file.py
 	$(PYTHON) scripts/validate_issue_129_kb_all_sources.py
 	$(PYTHON) scripts/validate_issue_137_kb_product_docs_migration.py
+	$(PYTHON) scripts/validate_issue_144_kb_structure_readmes.py
 	$(PYTHON) scripts/validate_issue_131_kb_processed_outputs.py
 
 # Наглядно: токены индекса vs отдельных разделов (метод — см. token_method).

--- a/docs/audit/issue-144-kb-structure.md
+++ b/docs/audit/issue-144-kb-structure.md
@@ -1,0 +1,64 @@
+---
+status: draft
+version: 0.1
+updated: 2026-06-20
+ai-generated: true
+type: audit
+scope: kb
+related_issues:
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/144"
+related_artifacts:
+  - "kb/README.md"
+  - "kb/mango-product-docs/README.md"
+  - "kb/fragments/README.md"
+  - "kb/practices/README.md"
+---
+
+# Аудит структуры `kb/` после миграции product docs
+
+Проверка фиксирует решение по `kb/fragments/` и `kb/practices/` после переноса
+продуктовой документации в `kb/mango-product-docs/`.
+
+## Что проверено?
+
+Команды истории:
+
+```bash
+git log --follow -- kb/fragments/
+git log --follow -- kb/practices/
+```
+
+Дополнительно проверены `git log --all --name-status -- kb/fragments/` и
+`git log --all --name-status -- kb/practices/`, чтобы увидеть изменения после
+миграции issue #137.
+
+## Находки
+
+| Каталог | История | Вывод |
+| --- | --- | --- |
+| `kb/fragments/` | `2c766812695a1163b2e7f9cf4c4878dce9a75a1f` создал `kb/fragments/README.md` в issue #111 как будущий слой атомарных фрагментов/vector RAG. `f361fd5b91cec0493b39a3ed73f3322bb3d7d165` только обновил ссылку README при миграции product docs в issue #137. | Оставить в `kb/`: каталог не хранит product-docs источники или generated output, а описывает будущий RAG-слой поверх KB. |
+| `kb/practices/` | `37dc51c0c2bb1e89642e841e4962407be02e445b` добавил `source-backed-analysis.md` в рамках ADR-007 / KB standard до миграции product docs. | Оставить в `kb/`: это ручная практика анализа, независимая от документации продуктов Mango Office. |
+
+## Решение
+
+Оставить в kb/ оба каталога:
+
+- `kb/fragments/` — задел под будущие атомарные RAG-фрагменты;
+- `kb/practices/` — ручные практики и методики, цитируемые по `kb-standard`.
+
+Переносить их в `kb/mango-product-docs/` не нужно: product-docs namespace
+отвечает за документацию Mango Office, `sources/`, `processed/`, `USAGE.md` и
+`UPLOAD-GUIDE.md`.
+
+История Git сохранена: в рамках issue #144 файлы не перемещались, поэтому
+`git mv` не требовался.
+
+## Чек-лист целостности
+
+- [x] `kb/README.md` описывает `mango-product-docs/`, `fragments/`, `practices/`
+      и будущие namespaces `industry/`, `mango/`.
+- [x] `kb/mango-product-docs/README.md` создан и описывает product-docs
+      структуру.
+- [x] `kb/practices/README.md` создан для независимых ручных практик.
+- [x] `kb/fragments/README.md` явно отделён от продуктовой документации.
+- [x] История Git сохранена без перемещений.

--- a/kb/README.md
+++ b/kb/README.md
@@ -1,68 +1,119 @@
 ---
 status: draft
-version: 0.1
-updated: 2026-06-16
+version: 0.2
+updated: 2026-06-20
 ai-generated: true
 type: kb-index
 scope: kb
 related_artifacts:
   - "standards/kb-standard.md"
   - "docs/adr/007-kb-standard.md"
+  - "kb/mango-product-docs/README.md"
+  - "docs/audit/issue-144-kb-structure.md"
 related_issues:
   - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/97"
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/111"
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/144"
 ---
 
-# База знаний (KB) — индекс-карта
+# База знаний (KB)
 
-> Регулируется [kb-standard.md](../standards/kb-standard.md) /
-> [ADR-007](../docs/adr/007-kb-standard.md). KB хранит **практики, примеры и
-> справочники, не являющиеся стандартами** (см. границы в ADR-007 §4). Термины —
-> в [глоссарии](../standards/GLOSSARY.md), не здесь.
+`kb/` — централизованное хранилище знаний проекта: ручные практики, фрагменты
+для будущего RAG и извлечённая документация Mango Office. Каталог отделяет
+знания от стандартов, ADR, run records и продуктового кода.
 
-## Два слоя БЗ
+## Что это?
 
-| Слой | Что это | Где |
+KB регулируется [kb-standard.md](../standards/kb-standard.md) и
+[ADR-007](../docs/adr/007-kb-standard.md). Термины хранятся в
+[глоссарии](../standards/GLOSSARY.md), стандарты — в `standards/`, а этот
+каталог отвечает за применимые знания, примеры и источники для ответов агентов.
+
+## Структура
+
+| Каталог | Назначение | Статус |
 | --- | --- | --- |
-| **Ручные записи** (этот файл) | Практики/примеры/справочники, написанные руками (правило R1) | таблица ниже, `practices/` · `examples/` · `references/` |
-| **Извлечённые документы** (issue #111) | Машиночитаемые чанки из PDF/веб-источников: индекс → раздел → цитата | [`mango-product-docs/sources/`](mango-product-docs/sources/README.md) (ручной ввод) → [`mango-product-docs/processed/`](mango-product-docs/processed/README.md) → [`fragments/`](fragments/README.md) |
+| [`kb/mango-product-docs/`](mango-product-docs/README.md) | База знаний продуктов Mango Office: PDF/веб-источники, обработанные Markdown-чанки и инструкции использования. | Рабочий product-docs namespace |
+| [`kb/fragments/`](fragments/README.md) | Задел под атомарные фрагменты будущего векторного RAG; сейчас product-docs чанки живут в `kb/mango-product-docs/processed/`. | Оставить в `kb/`, не переносить в product-docs |
+| [`kb/practices/`](practices/README.md) | Ручные практики и методики анализа, не привязанные к конкретному продукту Mango Office. | Оставить в `kb/`, не переносить в product-docs |
+| `kb/industry/ (будущий)` | Industry Taxonomy: отраслевая классификация и справочники после утверждения стандарта. | Планируемый namespace |
+| `kb/mango/ (будущий)` | Mango Taxonomy: корпоративная классификация продуктов и mapping к taxonomy. | Планируемый namespace |
 
-Слой извлечения документов: как пополнять — [`mango-product-docs/sources/README.md`](mango-product-docs/sources/README.md)
-(**ФТ-7**); как промпт обращается к нему — [`mango-product-docs/USAGE.md`](mango-product-docs/USAGE.md) (**ФТ-6**);
-методология и оценка качества — [`docs/kb-experiment-report.md`](../docs/kb-experiment-report.md).
-Оба слоя используют один формат цитат/адресации и готовятся к одному будущему RAG
-(правила R1–R4 [kb-standard](../standards/kb-standard.md)).
+## Как использовать?
 
-## Зачем этот файл (pre-RAG)
+Для фактов о продуктах Mango Office идите в
+[`kb/mango-product-docs/README.md`](mango-product-docs/README.md): там описаны
+`sources/`, `processed/`, [`USAGE.md`](mango-product-docs/USAGE.md) и
+[`UPLOAD-GUIDE.md`](mango-product-docs/UPLOAD-GUIDE.md).
 
-До внедрения настоящего RAG этот индекс заменяет retrieval-шаг (правило R2
-[kb-standard](../standards/kb-standard.md)): агент или человек находит нужную
-запись по таблице ниже и цитирует её стабильным адресом
-`kb/<path>#<anchor>`. Когда появится векторный RAG, те же адреса станут chunk-id
-без переписывания артефактов (R4).
-
-## Как цитировать запись KB
+Для ручных практик используйте `kb/practices/` и цитируйте запись стабильным
+адресом вида:
 
 ```markdown
 [KB: <slug>](kb/<path>#<anchor>)
 ```
 
-и продублировать в разделе `## Источники` артефакта (правило C3).
+Для будущих атомарных чанков используйте `kb/fragments/`; пока этот слой пуст,
+потому что разделы в `kb/mango-product-docs/processed/` уже являются
+достаточными pre-RAG чанками.
+
+## Быстрый старт
+
+Проверить структуру KB README после миграции product docs:
+
+```bash
+python3 scripts/validate_issue_144_kb_structure_readmes.py
+```
+
+Проверить весь лёгкий KB-контур:
+
+```bash
+make kb-validate
+```
+
+Проверить планы обработки всех product-docs источников без чтения PDF:
+
+```bash
+make kb-source-plan-all
+```
 
 ## Индекс записей
 
 | Тема | Файл | Когда применять |
 | --- | --- | --- |
-| Анализ с опорой на источники (source-backed analysis) | [practices/source-backed-analysis.md](practices/source-backed-analysis.md) | Любой нормативный вывод; проверка существования цитируемого стандарта. |
+| Анализ с опорой на источники | [practices/source-backed-analysis.md](practices/source-backed-analysis.md) | Любой нормативный вывод; проверка существования цитируемого стандарта. |
 
 ## Добавление записи
 
-1. Создать файл в `practices/`, `examples/` или `references/` с frontmatter
-   (`id`, `status`, `sources`) — правило R1.
-2. Добавить строку в индекс выше — правило R2.
-3. Если вводится новый термин — предложить его в глоссарий через issue (K2),
-   а не определять в KB (K1).
+Для ручной практики создайте файл в `kb/practices/` с frontmatter (`id`,
+`status`, `sources`) и добавьте строку в индекс выше. Если запись вводит новый
+термин, предложите его в глоссарий через issue, а не определяйте локально в KB.
 
-## Источники
+Для продуктовой документации используйте
+[`kb/mango-product-docs/UPLOAD-GUIDE.md`](mango-product-docs/UPLOAD-GUIDE.md):
+новые источники добавляются в `kb/mango-product-docs/sources/`, а результат
+генерируется в `kb/mango-product-docs/processed/`.
 
-- [kb-standard.md](../standards/kb-standard.md)
-- [ADR-007](../docs/adr/007-kb-standard.md)
+## Решение по границам
+
+История Git для `kb/fragments/` и `kb/practices/` проверена в
+[`docs/audit/issue-144-kb-structure.md`](../docs/audit/issue-144-kb-structure.md).
+Оба каталога остаются независимыми материалами KB: `fragments/` — будущий слой
+RAG, `practices/` — ручные практики. Их не нужно переносить в
+`kb/mango-product-docs/`, потому что product-docs namespace отвечает только за
+документацию продуктов Mango Office и её pipeline.
+
+## Связанные документы
+
+- [`kb/mango-product-docs/README.md`](mango-product-docs/README.md) — структура
+  продуктовой БЗ.
+- [`kb/mango-product-docs/USAGE.md`](mango-product-docs/USAGE.md) — как агент
+  читает извлечённую БЗ.
+- [`kb/mango-product-docs/UPLOAD-GUIDE.md`](mango-product-docs/UPLOAD-GUIDE.md) —
+  как добавлять и обновлять документы.
+- [`docs/audit/issue-144-kb-structure.md`](../docs/audit/issue-144-kb-structure.md) —
+  проверка истории `fragments/` и `practices/`.
+- [`docs/kb-experiment-report.md`](../docs/kb-experiment-report.md) —
+  методология и оценка качества извлечения PDF в БЗ.
+- [`standards/kb-standard.md`](../standards/kb-standard.md) — правила цитат,
+  границы KB и pre-RAG retrieval.

--- a/kb/fragments/README.md
+++ b/kb/fragments/README.md
@@ -1,12 +1,13 @@
 ---
 status: draft
-version: 0.1
-updated: 2026-06-18
+version: 0.2
+updated: 2026-06-20
 ai-generated: true
 type: kb-fragments-guide
 scope: kb/fragments
 related_issues:
   - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/111"
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/144"
 ---
 
 # `kb/fragments/` — атомарные фрагменты (задел под RAG)
@@ -15,6 +16,10 @@ related_issues:
 пуст намеренно: разделы из [`kb/mango-product-docs/processed/`](../mango-product-docs/processed/README.md) уже работают
 как чанки (раздел = файл = адрес), и дробить их мельче без реального RAG —
 преждевременная оптимизация (приоритет issue: **качество > экономия токенов**).
+
+Каталог создан в issue #111 как будущий слой атомарных фрагментов. Он не хранит продуктовую документацию,
+исходные PDF или generated output pipeline; это
+остаётся зоной ответственности `kb/mango-product-docs/`.
 
 ## Когда он понадобится
 

--- a/kb/mango-product-docs/README.md
+++ b/kb/mango-product-docs/README.md
@@ -1,0 +1,99 @@
+---
+status: draft
+version: 0.1
+updated: 2026-06-20
+ai-generated: true
+type: kb-product-docs-readme
+scope: kb/mango-product-docs
+related_artifacts:
+  - "kb/mango-product-docs/sources/README.md"
+  - "kb/mango-product-docs/processed/README.md"
+  - "kb/mango-product-docs/USAGE.md"
+  - "kb/mango-product-docs/UPLOAD-GUIDE.md"
+related_issues:
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/137"
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/144"
+---
+
+# База знаний продуктов Mango Office
+
+`kb/mango-product-docs/` хранит продуктовую документацию Mango Office: исходные
+PDF/веб-источники, обработанные Markdown-чанки и инструкции для агентов и людей.
+Каталог отделён от общих практик KB и будущих taxonomy namespaces.
+
+## Что это?
+
+Это product-docs namespace после миграции issue #137. Здесь живёт только
+документация продуктов и сервисов Mango Office вместе с pipeline-артефактами:
+исходники, обработанные разделы, usage examples и upload guide.
+
+## Структура
+
+```
+kb/mango-product-docs/
+├── README.md
+├── USAGE.md
+├── UPLOAD-GUIDE.md
+├── sources/
+└── processed/
+```
+
+### `sources/`
+
+Исходные PDF и source manifests. Каждый подкаталог описывает один управляемый
+набор источников: `single`, `multi_part` или `multi_document`. PDF-файлы
+хранятся через Git LFS, а правила пополнения описаны в
+[`sources/README.md`](sources/README.md).
+
+### `processed/`
+
+Сгенерированные Markdown-артефакты для агентов: `index.md`, `meta.json`,
+`sections/` и `images/`. Эти файлы не редактируются вручную; обновляйте
+`sources/` и перезапускайте pipeline. Контракт результата описан в
+[`processed/README.md`](processed/README.md).
+
+### Инструкции
+
+- [`USAGE.md`](USAGE.md) — как промпт или агент читает БЗ: индекс, выбор
+  раздела, загрузка чанка, цитата.
+- [`UPLOAD-GUIDE.md`](UPLOAD-GUIDE.md) — короткая инструкция загрузки и
+  обновления документов.
+
+## Как использовать?
+
+Для ответа на вопрос о продукте агент сначала читает `processed/<doc>/index.md`,
+выбирает релевантный раздел и загружает только нужный файл из `sections/`.
+Факты цитируются по frontmatter и `meta.json`; полный пример есть в
+[`USAGE.md`](USAGE.md).
+
+Для добавления или обновления документа человек меняет `sources/<slug>/`,
+проверяет план обработки и коммитит вместе source changes и generated
+`processed/<slug>/`.
+
+## Быстрый старт
+
+Проверить планы всех source manifests без чтения PDF:
+
+```bash
+make kb-source-plan-all
+```
+
+Проверить лёгкий KB-контур:
+
+```bash
+make kb-validate
+```
+
+## Связанные каталоги
+
+- [`kb/fragments/`](../fragments/README.md) — будущие атомарные фрагменты RAG; не
+  является хранилищем product-docs источников.
+- [`kb/practices/`](../practices/README.md) — ручные практики и методики; это не
+  продуктовая документация.
+- `kb/industry/` — будущая Industry Taxonomy.
+- `kb/mango/` — будущая Mango Taxonomy.
+
+## Как помочь?
+
+Создайте GitHub Issue с контекстом, ожидаемым результатом и ссылкой на источник
+или Pull Request по правилам [`CONTRIBUTING.md`](../../CONTRIBUTING.md).

--- a/kb/practices/README.md
+++ b/kb/practices/README.md
@@ -1,0 +1,55 @@
+---
+status: draft
+version: 0.1
+updated: 2026-06-20
+ai-generated: true
+type: kb-practices-readme
+scope: kb/practices
+related_artifacts:
+  - "kb/practices/source-backed-analysis.md"
+  - "standards/kb-standard.md"
+related_issues:
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/97"
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/144"
+---
+
+# KB Practices
+
+`kb/practices/` хранит ручные практики и методики анализа, которые можно
+применять в разных задачах проекта. Это не продуктовая документация Mango Office
+и не generated output pipeline из `kb/mango-product-docs/`.
+
+## Что это?
+
+Практика KB — это компактная, цитируемая запись с правилом, чек-листом или
+методикой. Она отличается от стандарта тем, что описывает рабочий приём, а не
+обязательный контракт; точные правила цитирования остаются в
+[`standards/kb-standard.md`](../../standards/kb-standard.md).
+
+## Как использовать?
+
+1. Найдите подходящую практику в этом каталоге или в индексе
+   [`kb/README.md`](../README.md).
+2. Примените правило к задаче.
+3. Сошлитесь на запись стабильным адресом `kb/practices/<file>.md#<anchor>`.
+
+Текущая запись:
+
+- [`source-backed-analysis.md`](source-backed-analysis.md) — проверка
+  существования источника перед нормативным выводом.
+
+## Быстрый старт
+
+Проверить, что каталог описан в общей структуре KB:
+
+```bash
+python3 scripts/validate_issue_144_kb_structure_readmes.py
+```
+
+## Связанные документы
+
+- [`kb/README.md`](../README.md) — общий индекс и границы KB.
+- [`kb/mango-product-docs/README.md`](../mango-product-docs/README.md) —
+  отдельный namespace продуктовой документации.
+- [`standards/kb-standard.md`](../../standards/kb-standard.md) — контракт
+  цитирования и pre-RAG retrieval.

--- a/scripts/validate_issue_144_kb_structure_readmes.py
+++ b/scripts/validate_issue_144_kb_structure_readmes.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Regression check for issue #144: KB structure README integrity.
+
+Issue #144 follows the product-docs migration from issue #137 and locks the
+documentation boundary for the generic ``kb/`` namespace:
+
+- the root KB README describes ``mango-product-docs/``, ``fragments/``,
+  ``practices/`` and planned taxonomy namespaces;
+- ``kb/mango-product-docs/README.md`` exists and owns product-documentation
+  sources, generated outputs, and human usage guides;
+- ``kb/fragments/`` and ``kb/practices/`` stay as independent KB material, not
+  as product-doc source or processed-output directories;
+- the git-history audit and changelog record the decision;
+- Makefile and the KB workflow run this validator.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+VALIDATOR = "scripts/validate_issue_144_kb_structure_readmes.py"
+MAKEFILE = "Makefile"
+KB_WORKFLOW = ".github/workflows/kb.yml"
+CHANGELOG = "CHANGELOG.md"
+AUDIT = "docs/audit/issue-144-kb-structure.md"
+
+
+def read_text(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def require_path(path: str) -> list[str]:
+    return [] if (ROOT / path).exists() else [f"{path}: missing"]
+
+
+def require_absent(path: str) -> list[str]:
+    return [f"{path}: must not exist for issue #144"] if (ROOT / path).exists() else []
+
+
+def require_text(path: str, *needles: str) -> list[str]:
+    text = read_text(path)
+    return [f"{path}: missing {needle!r}" for needle in needles if needle not in text]
+
+
+def check_readmes() -> list[str]:
+    errors: list[str] = []
+    required = (
+        "kb/README.md",
+        "kb/mango-product-docs/README.md",
+        "kb/mango-product-docs/sources/README.md",
+        "kb/mango-product-docs/processed/README.md",
+        "kb/fragments/README.md",
+        "kb/practices/README.md",
+    )
+    for path in required:
+        errors += require_path(path)
+    if errors:
+        return errors
+
+    errors += require_text(
+        "kb/README.md",
+        "kb/mango-product-docs/",
+        "kb/fragments/",
+        "kb/practices/",
+        "kb/industry/ (будущий)",
+        "kb/mango/ (будущий)",
+        "kb/mango-product-docs/README.md",
+        "USAGE.md",
+        "UPLOAD-GUIDE.md",
+        "docs/audit/issue-144-kb-structure.md",
+        "не переносить в product-docs",
+    )
+    errors += require_text(
+        "kb/mango-product-docs/README.md",
+        "База знаний продуктов Mango Office",
+        "sources/",
+        "processed/",
+        "USAGE.md",
+        "UPLOAD-GUIDE.md",
+        "Git LFS",
+        "make kb-source-plan-all",
+        "kb/fragments/",
+        "kb/practices/",
+    )
+    errors += require_text(
+        "kb/fragments/README.md",
+        "не хранит продуктовую документацию",
+        "kb/mango-product-docs/processed/",
+        "issue #111",
+    )
+    errors += require_text(
+        "kb/practices/README.md",
+        "source-backed-analysis.md",
+        "не продуктовая документация",
+        "kb/mango-product-docs/",
+    )
+    return errors
+
+
+def check_audit() -> list[str]:
+    errors = require_path(AUDIT)
+    if errors:
+        return errors
+    errors += require_text(
+        AUDIT,
+        "git log --follow -- kb/fragments/",
+        "git log --follow -- kb/practices/",
+        "2c766812695a1163b2e7f9cf4c4878dce9a75a1f",
+        "37dc51c0c2bb1e89642e841e4962407be02e445b",
+        "f361fd5b91cec0493b39a3ed73f3322bb3d7d165",
+        "Оставить в kb/",
+        "История Git сохранена",
+    )
+    return errors
+
+
+def check_changelog_and_ci() -> list[str]:
+    errors: list[str] = []
+    for path in (CHANGELOG, MAKEFILE, KB_WORKFLOW):
+        errors += require_path(path)
+    if errors:
+        return errors
+
+    errors += require_text(
+        CHANGELOG,
+        "Issue #144",
+        "kb/mango-product-docs/README.md",
+        "kb/practices/README.md",
+        AUDIT,
+        VALIDATOR,
+    )
+    errors += require_text(
+        MAKEFILE,
+        VALIDATOR,
+    )
+    errors += require_text(
+        KB_WORKFLOW,
+        "Validate issue #144 KB structure README integrity",
+        f"python3 {VALIDATOR}",
+    )
+    return errors
+
+
+def check_layout_boundaries() -> list[str]:
+    errors: list[str] = []
+    old_root_paths = (
+        "/".join(("kb", "sources")),
+        "/".join(("kb", "processed")),
+        "/".join(("kb", "USAGE.md")),
+        "/".join(("kb", "UPLOAD-GUIDE.md")),
+    )
+    for path in old_root_paths:
+        errors += require_absent(path)
+    return errors
+
+
+def main() -> int:
+    errors: list[str] = []
+    errors += check_readmes()
+    errors += check_audit()
+    errors += check_changelog_and_ci()
+    errors += check_layout_boundaries()
+
+    if errors:
+        print("Issue #144 KB structure README validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("Issue #144 KB structure README validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes G-Ivan-A/mango_ba_prompts#144

## Summary
- Updated `kb/README.md` so the root KB README describes `kb/mango-product-docs/`, `kb/fragments/`, `kb/practices/`, and the future `kb/industry/` / `kb/mango/` namespaces.
- Added `kb/mango-product-docs/README.md` and `kb/practices/README.md`, and clarified `kb/fragments/README.md` as a future RAG fragment layer rather than product documentation storage.
- Added `docs/audit/issue-144-kb-structure.md` with the git-history findings for `fragments/` and `practices/`; both remain in `kb/` and no file moves were needed.
- Added `scripts/validate_issue_144_kb_structure_readmes.py` and wired it into `make kb-validate` plus the KB workflow.

## Reproduction and Verification
- Before the docs update, `python3 scripts/validate_issue_144_kb_structure_readmes.py` failed on the missing product-docs README, practices README, audit, changelog entry, and CI wiring.
- After the fix:
  - `python3 scripts/validate_issue_144_kb_structure_readmes.py`
  - `python3 scripts/validate_issue_137_kb_product_docs_migration.py`
  - `python3 scripts/validate_issue_111_kb_pipeline.py`
  - `python3 scripts/validate_issue_134_readme_standard.py`
  - `git diff --check`

## Local Limitation
- `make kb-validate` passes through issue #144 and then fails in `scripts/validate_issue_131_kb_processed_outputs.py` because this checkout has Git LFS pointer files instead of PDF payloads. The failure is the existing local LFS limitation from the product-docs migration context, not a new issue #144 failure.
