### PR TITLE
docs: доработать taxonomy ADR

### DIFF
--- a/.github/workflows/kb.yml
+++ b/.github/workflows/kb.yml
@@ -106,6 +106,9 @@ jobs:
       - name: Validate issue #146 Mango taxonomy validation
         run: python3 scripts/validate_issue_146_mango_taxonomy.py
 
+      - name: Validate issue #148 taxonomy extensions
+        run: python3 scripts/validate_issue_148_taxonomy_extensions.py
+
   # Тяжёлый сквозной прогон извлечения.
   # На workflow_dispatch выполняет выбранный source. На push в main всегда
   # обрабатывает все kb/mango-product-docs/sources/*/meta.json и коммитит kb/mango-product-docs/processed.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-20T21:11:29.133Z for PR creation at branch issue-148-be1ea7780a12 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/148

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-20T21:11:29.133Z for PR creation at branch issue-148-be1ea7780a12 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/148

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ ai-generated: true
 
 ## Unreleased
 
+### Changed — Issue #148 доработка taxonomy ADR
+
+- Обновлены ADR-011 и ADR-012: добавлены правила strict mapping на Industry
+  Taxonomy, `function_type` для Function (`business`, `configuration`,
+  `ui-action`), алиасы Component=Module и Operation=Function, а также YAML/JSON
+  формат `industry_ref` без свободных taxonomy tags.
+- Аудит
+  [`docs/audit/issue-146-mango-taxonomy-validation.md`](docs/audit/issue-146-mango-taxonomy-validation.md)
+  переведён в `canonical` и связан с issue #148.
+- Добавлена регрессионная проверка
+  [`scripts/validate_issue_148_taxonomy_extensions.py`](scripts/validate_issue_148_taxonomy_extensions.py),
+  подключённая к `make kb-validate` и KB workflow.
+
 ### Changed — Issue #146 validation Mango Taxonomy on real processed docs
 
 - Валидирована Mango Taxonomy на 12 processed guides из

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ kb-validate:
 	$(PYTHON) scripts/validate_issue_144_kb_structure_readmes.py
 	$(PYTHON) scripts/validate_issue_131_kb_processed_outputs.py
 	$(PYTHON) scripts/validate_issue_146_mango_taxonomy.py
+	$(PYTHON) scripts/validate_issue_148_taxonomy_extensions.py
 
 # Наглядно: токены индекса vs отдельных разделов (метод — см. token_method).
 kb-tokens:

--- a/docs/audit/issue-146-mango-taxonomy-validation.md
+++ b/docs/audit/issue-146-mango-taxonomy-validation.md
@@ -1,6 +1,6 @@
 ---
-status: draft
-version: 0.1
+status: canonical
+version: 1.0
 updated: 2026-06-20
 ai-generated: true
 type: audit
@@ -11,6 +11,8 @@ related_artifacts:
   - "standards/decisions/ADR-012-mango-taxonomy.md"
   - "standards/product-classification-contract.md"
   - "kb/mango-product-docs/processed/"
+canonicalized_by:
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/148"
 ---
 
 # Issue #146: Mango Taxonomy validation on processed product docs
@@ -30,6 +32,20 @@ Decision summary:
   documents.
 - Commercial packages, tariffs, procurement fields, industry segments and
   regional labels stay outside the hierarchy as facets.
+
+## Canonicalization note
+
+Issue #148 closes the three open questions from this audit and promotes the
+audit from draft to canonical:
+
+- `function_type` is fixed as the required Function attribute with the values
+  `business`, `configuration` and `ui-action`.
+- Term aliases are fixed as Component=Module and Operation=Function.
+- Mango-to-Industry mapping uses strict `industry_ref` links to ADR-011
+  Domain/Capability/Feature/Function nodes instead of free tags.
+
+Canonicalizing issue:
+<https://github.com/G-Ivan-A/mango_ba_prompts/issues/148>
 
 ## Sources
 

--- a/scripts/validate_issue_148_taxonomy_extensions.py
+++ b/scripts/validate_issue_148_taxonomy_extensions.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Regression check for issue #148: taxonomy extensions in ADR-011/ADR-012.
+
+Issue #148 closes the open questions from the issue #146 audit:
+
+- ADR-011 documents strict Industry Taxonomy references for mapping.
+- ADR-012 documents Function attributes, term aliases, and mapping format.
+- ``function_type`` is justified by external standards.
+- The issue #146 audit is promoted to canonical.
+- Changelog, Makefile and CI run this validator.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+ADR_011 = "standards/decisions/ADR-011-industry-taxonomy.md"
+ADR_012 = "standards/decisions/ADR-012-mango-taxonomy.md"
+AUDIT = "docs/audit/issue-146-mango-taxonomy-validation.md"
+CHANGELOG = "CHANGELOG.md"
+MAKEFILE = "Makefile"
+KB_WORKFLOW = ".github/workflows/kb.yml"
+VALIDATOR = "scripts/validate_issue_148_taxonomy_extensions.py"
+
+
+def read_text(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def require_path(path: str) -> list[str]:
+    return [] if (ROOT / path).exists() else [f"{path}: missing"]
+
+
+def require_text(path: str, *needles: str) -> list[str]:
+    errors = require_path(path)
+    if errors:
+        return errors
+    text = read_text(path)
+    return [f"{path}: missing {needle!r}" for needle in needles if needle not in text]
+
+
+def require_ordered_text(path: str, needles: tuple[str, ...]) -> list[str]:
+    text = read_text(path)
+    errors: list[str] = []
+    last = -1
+    for needle in needles:
+        pos = text.find(needle)
+        if pos == -1:
+            errors.append(f"{path}: missing {needle!r}")
+        elif pos < last:
+            errors.append(f"{path}: {needle!r} is out of order")
+        last = max(last, pos)
+    return errors
+
+
+def check_adr_011() -> list[str]:
+    errors = require_text(
+        ADR_011,
+        "https://github.com/G-Ivan-A/mango_ba_prompts/issues/148",
+        "## Использование в маппинге",
+        "industry_ref",
+        "`alignment_type`",
+        "`primary`",
+        "`secondary`",
+        "`supporting`",
+        "строгими ссылками",
+        "не свободными тегами",
+        "Product может ссылаться на несколько Domain/Capability",
+        "Mango `Function`",
+    )
+    errors += require_ordered_text(
+        ADR_011,
+        (
+            "## Решение",
+            "## Использование в маппинге",
+            "## Rationale",
+        ),
+    )
+    return errors
+
+
+def check_adr_012() -> list[str]:
+    errors = require_text(
+        ADR_012,
+        "https://github.com/G-Ivan-A/mango_ba_prompts/issues/148",
+        "### Атрибуты Function",
+        "`function_type`",
+        "`business`",
+        "`configuration`",
+        "`ui-action`",
+        "TM Forum SID",
+        "TM Forum ODA Functional Framework",
+        "ITIL 4",
+        "ISO/IEC 25010:2023",
+        "https://www.tmforum.org/open-digital-architecture/information-framework-sid/",
+        "https://www.tmforum.org/open-digital-architecture/functional-framework/",
+        "https://www.axelos.com/certifications/itil-service-management/itil-practices-manager/itil-4-specialist-plan-implement-and-control/itil-4-practitioner-service-configuration-management",
+        "https://www.iso.org/standard/78176.html",
+        "### Алиасы терминов",
+        "Component",
+        "Module",
+        "Operation",
+        "Function",
+        "### Формат маппинга",
+        "taxonomy_mapping:",
+        "industry_alignment:",
+        "industry_ref:",
+        "alignment_type: primary",
+        "domain: contact-center",
+        "capability: omnichannel-contact-center",
+        "не свободные теги",
+    )
+    errors += require_ordered_text(
+        ADR_012,
+        (
+            "### Атрибуты",
+            "### Атрибуты Function",
+            "### Алиасы терминов",
+            "### Формат маппинга",
+            "## Taxonomy Alignment с ADR-011",
+        ),
+    )
+    return errors
+
+
+def check_audit() -> list[str]:
+    text = read_text(AUDIT)
+    errors: list[str] = []
+    for needle in (
+        "status: canonical",
+        "version: 1.0",
+        "Canonicalization note",
+        "https://github.com/G-Ivan-A/mango_ba_prompts/issues/148",
+        "function_type",
+        "Component=Module",
+        "Operation=Function",
+    ):
+        if needle not in text:
+            errors.append(f"{AUDIT}: missing {needle!r}")
+    if "status: draft" in text:
+        errors.append(f"{AUDIT}: must not remain draft")
+    return errors
+
+
+def check_changelog_and_ci() -> list[str]:
+    errors: list[str] = []
+    errors += require_text(
+        CHANGELOG,
+        "Issue #148",
+        "function_type",
+        "Component=Module",
+        "Operation=Function",
+        "ADR-011",
+        "ADR-012",
+        AUDIT,
+        VALIDATOR,
+    )
+    errors += require_text(MAKEFILE, VALIDATOR)
+    errors += require_text(
+        KB_WORKFLOW,
+        "Validate issue #148 taxonomy extensions",
+        f"python3 {VALIDATOR}",
+    )
+    return errors
+
+
+def main() -> int:
+    errors: list[str] = []
+    errors += check_adr_011()
+    errors += check_adr_012()
+    errors += check_audit()
+    errors += check_changelog_and_ci()
+
+    if errors:
+        print("Issue #148 taxonomy extension validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("Issue #148 taxonomy extension validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/standards/decisions/ADR-011-industry-taxonomy.md
+++ b/standards/decisions/ADR-011-industry-taxonomy.md
@@ -1,6 +1,6 @@
 ---
 status: proposed
-version: 0.2
+version: 0.3
 updated: 2026-06-20
 ai-generated: true
 type: adr
@@ -8,10 +8,12 @@ scope: industry-taxonomy
 issue: "https://github.com/G-Ivan-A/mango_ba_prompts/issues/139"
 validated_by:
   - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/146"
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/148"
 hub_research: "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/main/research/mango/classification.md"
 hub_research_sha: "73e94c6e69995ccf9e746c19d9c18359971285f2"
 related_prs:
   - "https://github.com/G-Ivan-A/mango_ba_prompts/pull/140"
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/pull/149"
 related_artifacts:
   - "https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/standards/product-classification-contract.md"
   - "https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/docs/hub-research-dependencies.md"
@@ -258,6 +260,47 @@ processed KB в issue #146.
 Этот ADR не утверждает финальный стандарт и не создаёт KB. Он фиксирует решение,
 которое должна проверить команда перед отдельными PR на стандарт, Mango Taxonomy
 и KB reference data.
+
+## Использование в маппинге
+
+Industry Taxonomy используется как reference layer для Mango Taxonomy и будущих
+KB-реестров. Связи с ним должны быть строгими ссылками на taxonomy nodes, а
+не свободными тегами. Свободные labels допустимы только в фасетах вроде
+`industry`, `segment`, `use_case` или `region`; они не заменяют
+`industry_ref`.
+
+Минимальная структура ссылки:
+
+```yaml
+industry_ref:
+  domain: contact-center
+  capability: omnichannel-contact-center
+  feature: agent-workspace
+  function: set-agent-status
+alignment_type: primary
+```
+
+Правила применения:
+
+- `industry_ref.domain` обязателен для любой связи и должен ссылаться на
+  canonical Domain из ADR-011 или будущего Industry Taxonomy registry.
+- `industry_ref.capability`, `industry_ref.feature` и `industry_ref.function`
+  добавляются по мере глубины Mango entity: Product может ссылаться на несколько Domain/Capability,
+  Service — на Capability, Module — на Feature, Mango `Function` — на Function.
+- `alignment_type` принимает только `primary`, `secondary` или `supporting`.
+  `primary` фиксирует главный отраслевой смысл; `secondary` — важную
+  дополнительную связь; `supporting` — platform, hardware, security или
+  operational support связь.
+- Каждая связь должна иметь evidence в ADR, processed KB или future registry.
+  Если canonical slug отсутствует, связь остаётся открытым вопросом, а не
+  добавляется как произвольный tag.
+- Many-to-many является нормой: один Mango Product может покрывать несколько
+  Domain/Capability, а один Industry Capability может поддерживаться несколькими
+  Mango Products, Services или Modules.
+
+Эти правила нужны, чтобы Product-to-Industry mapping был проверяемым,
+диффируемым и пригодным для генерации требований, а не зависел от локальных
+синонимов в документации.
 
 ## Rationale
 

--- a/standards/decisions/ADR-012-mango-taxonomy.md
+++ b/standards/decisions/ADR-012-mango-taxonomy.md
@@ -1,6 +1,6 @@
 ---
 status: proposed
-version: 0.2
+version: 0.3
 updated: 2026-06-20
 ai-generated: true
 type: adr
@@ -8,6 +8,7 @@ scope: mango-taxonomy
 issue: "https://github.com/G-Ivan-A/mango_ba_prompts/issues/142"
 validated_by:
   - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/146"
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/148"
 depends_on:
   - "standards/decisions/ADR-011-industry-taxonomy.md"
 hub_research: "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/main/research/mango/classification.md"
@@ -17,6 +18,7 @@ site_sources:
   - "https://www.mango-office.ru/products/"
 related_prs:
   - "https://github.com/G-Ivan-A/mango_ba_prompts/pull/143"
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/pull/149"
 related_artifacts:
   - "standards/decisions/ADR-011-industry-taxonomy.md"
   - "standards/product-classification-contract.md"
@@ -281,7 +283,7 @@ function:
   id: select-wallboard-widget
   layer: internal
   parent_module: wallboard
-  function_type: setting
+  function_type: ui-action
   industry_alignment:
     - domain: analytics
       capability: product-analytics
@@ -291,6 +293,142 @@ function:
   kb_refs:
     - kb/mango-product-docs/processed/wallboard/sections/04-nastroyka-wallboard.md
 ```
+
+### Атрибуты Function
+
+`Function` остаётся leaf-level единицей Mango Taxonomy: минимальным
+проверяемым поведением, настройкой, API-командой, UI-действием, параметром или
+правилом внутри Module. Для будущего стандарта каждая Function должна иметь
+следующий минимум:
+
+```yaml
+function:
+  id: configure-webhook-url
+  layer: internal
+  parent_module: webhooks
+  name_ru: Настроить URL webhook
+  function_type: configuration
+  interaction_surface: admin-ui
+  source_terms:
+    - operation
+    - setting
+  aliases:
+    - configure-callback-url
+  industry_alignment:
+    - industry_ref:
+        domain: platform
+        capability: open-api
+        feature: webhook-management
+        function: configure-webhook-endpoint
+      alignment_type: supporting
+  kb_refs:
+    - kb/mango-product-docs/processed/vpbx-api/index.md
+```
+
+`function_type` классифицирует смысл функции, а не канал реализации. API,
+экран или background job фиксируются отдельно в `interaction_surface`.
+
+| `function_type` | Когда использовать | Примеры | Использование в требованиях |
+| --- | --- | --- | --- |
+| `business` | Функция создаёт клиентский или операционный бизнес-результат. | `transfer-call`, `send-dialog-message`, `create-outbound-campaign`, `generate-ai-summary`. | Генерировать ФТ, acceptance criteria, бизнес-правила и gap analysis. |
+| `configuration` | Функция меняет настройку, политику, маршрутизацию, доступ или lifecycle параметр сервиса. | `configure-webhook-url`, `enable-call-recording`, `set-queue-schedule`, `assign-agent-role`. | Генерировать admin requirements, migration checklist, controls and rollback steps. |
+| `ui-action` | Функция описывает пользовательское действие в интерфейсе, нужное для сценария, но не является самостоятельной бизнес-возможностью. | `select-wallboard-widget`, `open-call-filter`, `switch-agent-tab`, `expand-report-section`. | Генерировать UX/UI acceptance criteria, сценарии обучения и e2e шаги, не раздувая product capability list. |
+
+Внешнее обоснование:
+
+| Источник | Сигнал | Решение для Mango Taxonomy |
+| --- | --- | --- |
+| TM Forum SID: <https://www.tmforum.org/open-digital-architecture/information-framework-sid/> | SID даёт общий словарь и data reference model для business entities, function, application, component и API development. | `Function` остаётся leaf-level, а Component не становится отдельным уровнем: source-specific Component нормализуется в Mango `Module`. |
+| TM Forum ODA Functional Framework: <https://www.tmforum.org/open-digital-architecture/functional-framework/> | Functional Framework описывает granular functions как базовые единицы, которые выполняют service and produce a complete result. | `business` фиксирует функции, которые дают завершённый результат, независимо от того, вызваны они UI или API. |
+| ITIL 4 Service Configuration Management: <https://www.axelos.com/certifications/itil-service-management/itil-practices-manager/itil-4-specialist-plan-implement-and-control/itil-4-practitioner-service-configuration-management> | ITIL 4 отделяет configuration information/support items от остального service management. | `configuration` отделяет настройки и управление конфигурацией от бизнес-функций и UI-шагов. |
+| ISO/IEC 25010:2023: <https://www.iso.org/standard/78176.html> | ISO/IEC 25010:2023 используется для requirements specification, evaluation, testing objectives and acceptance criteria of ICT products. | `business` и `ui-action` разделяют функциональный результат и interaction-oriented проверку, чтобы требования и acceptance criteria не смешивали capability с экранным шагом. |
+
+### Алиасы терминов
+
+Canonical taxonomy terms должны использоваться в ADR, standards, validators and
+future registry. Source terms из Mango docs сохраняются как aliases/source_terms,
+но не создают новые уровни.
+
+| Source term | Canonical term | Правило использования |
+| --- | --- | --- |
+| Component | Module | Component=Module. Если processed KB или внешний источник говорит Component, в registry пишем `module`, а исходный термин сохраняем в `aliases` или `source_terms`. |
+| Operation | Function | Operation=Function. API operation, user operation или operational step нормализуется в `Function`, если это проверяемое leaf-level действие, команда, настройка или правило. |
+
+Дополнительные слова вроде action, setting, endpoint, command и parameter
+являются evidence terms. Они помогают выбрать `function_type`, но не заменяют
+canonical уровни `Product -> Service -> Module -> Function`.
+
+### Формат маппинга
+
+Product-to-Industry mapping хранится как typed YAML/JSON object с массивом
+`industry_alignment`. Значения внутри `industry_ref` являются строгими ссылками
+на Industry Taxonomy, не свободные теги.
+
+```yaml
+taxonomy_mapping:
+  version: 1
+  mapping_scope: mango-to-industry
+  source_taxonomy: mango-taxonomy
+  target_taxonomy: industry-taxonomy
+  products:
+    - product_id: mango-contact-center
+      industry_alignment:
+        - industry_ref:
+            domain: contact-center
+            capability: omnichannel-contact-center
+          alignment_type: primary
+          evidence_refs:
+            - standards/decisions/ADR-012-mango-taxonomy.md
+            - kb/mango-product-docs/processed/mango-cc-manual/index.md
+        - industry_ref:
+            domain: digital-channels
+            capability: omnichannel-messaging
+          alignment_type: secondary
+          evidence_refs:
+            - kb/mango-product-docs/processed/mdialogi-api/index.md
+  services:
+    - service_id: open-api
+      supports_official_products:
+        - mango-virtual-pbx
+        - mango-contact-center
+      industry_alignment:
+        - industry_ref:
+            domain: platform
+            capability: open-api
+          alignment_type: supporting
+          evidence_refs:
+            - kb/mango-product-docs/processed/vpbx-api/index.md
+  functions:
+    - function_id: configure-webhook-url
+      function_type: configuration
+      industry_alignment:
+        - industry_ref:
+            domain: platform
+            capability: open-api
+            feature: webhook-management
+            function: configure-webhook-endpoint
+          alignment_type: supporting
+          evidence_refs:
+            - kb/mango-product-docs/processed/vpbx-api/index.md
+```
+
+Validation rules for future registry:
+
+- `taxonomy_mapping.version`, `source_taxonomy`, `target_taxonomy` and
+  `industry_alignment[]` are required.
+- `industry_ref.domain` is required for every alignment; deeper fields are
+  required by Mango level: Product may stop at Domain/Capability, Service at
+  Capability, Module at Feature, Function at Function.
+- `domain`, `capability`, `feature` and `function` values must resolve to
+  canonical Industry Taxonomy slugs from ADR-011 or the future registry.
+- `alignment_type` must be one of `primary`, `secondary`, `supporting`; every
+  mapped entity must have at least one `primary` or an explicit reason why it is
+  only `supporting`.
+- `evidence_refs[]` must point to ADR, official site, processed KB or future
+  registry evidence; free-text notes do not replace evidence refs.
+- Facets such as `industry`, `segment`, `region`, `commercial_package` and
+  `compliance` stay outside `industry_ref` so they cannot masquerade as
+  taxonomy nodes.
 
 ## Taxonomy Alignment с ADR-011
 


### PR DESCRIPTION
## Summary

- Updated ADR-011 with strict Industry Taxonomy mapping rules: `industry_ref`, `alignment_type`, evidence refs, and many-to-many Product -> Domain/Capability alignment.
- Updated ADR-012 with `function_type` values (`business`, `configuration`, `ui-action`), external standards rationale, Component=Module and Operation=Function aliases, and a typed YAML/JSON mapping format.
- Promoted the issue #146 audit to `canonical`, updated `CHANGELOG.md`, and added `scripts/validate_issue_148_taxonomy_extensions.py` to `make kb-validate` and the KB workflow.

## Reproduction and Verification

- Reproduced the missing deliverables by adding and running `python3 scripts/validate_issue_148_taxonomy_extensions.py`; it failed before the ADR/audit/changelog/workflow updates.
- Passed locally: `python3 scripts/validate_issue_148_taxonomy_extensions.py`.
- Passed locally: `python3 scripts/validate_issue_146_mango_taxonomy.py`.
- Passed locally: `python3 -m py_compile scripts/validate_issue_148_taxonomy_extensions.py`.
- Passed locally: `git diff --check`.
- `make kb-validate` cannot complete in this local checkout because `git-lfs` is not installed and source PDFs are checked out as LFS pointer text files; the PR KB pipeline uses `actions/checkout` with `lfs: true` and its `validate` job is passing.

Fixes G-Ivan-A/mango_ba_prompts#148