### PR TITLE
docs: финализировать ADR-012 и стандарт Mango Taxonomy

### DIFF
--- a/.github/workflows/kb.yml
+++ b/.github/workflows/kb.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Validate issue #152 Industry Taxonomy standard
         run: python3 scripts/validate_issue_152_industry_taxonomy_standard.py
 
+      - name: Validate issue #154 Mango Taxonomy standard
+        run: python3 scripts/validate_issue_154_mango_taxonomy_standard.py
+
   # Тяжёлый сквозной прогон извлечения.
   # На workflow_dispatch выполняет выбранный source. На push в main всегда
   # обрабатывает все kb/mango-product-docs/sources/*/meta.json и коммитит kb/mango-product-docs/processed.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-21T18:50:48.444Z for PR creation at branch issue-154-d77f0f3035e9 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/154

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-21T18:50:48.444Z for PR creation at branch issue-154-d77f0f3035e9 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/154

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ ai-generated: true
 
 ## Unreleased
 
+### Added — Issue #154 стандарт Mango Taxonomy
+
+- ADR-012 переведён в `status: canonical`, `version: 1.0` и связан с
+  [`standards/mango-taxonomy-standard.md`](standards/mango-taxonomy-standard.md),
+  ADR-011 canonical v1.0, Industry Taxonomy Standard и решением по
+  `voice-channel` / facet `channel`.
+- Добавлен machine-readable стандарт
+  [`standards/mango-taxonomy-standard.md`](standards/mango-taxonomy-standard.md):
+  двухслойная архитектура Official Layer + Internal Layer, иерархия
+  `Product -> Service -> Module -> Function`, 8 внутренних кластеров,
+  атрибуты по уровням, `function_type`, нормализация Component -> Module и
+  Operation -> Function, `maps_to.industry_alignment`, JSON Schema, YAML
+  contract, граничные кейсы, validator contract, AI-agent contract и процесс
+  эволюции.
+- Добавлена регрессионная проверка
+  [`scripts/validate_issue_154_mango_taxonomy_standard.py`](scripts/validate_issue_154_mango_taxonomy_standard.py),
+  подключённая к `make kb-validate` и KB workflow.
+
 ### Added — Issue #152 стандарт Industry Taxonomy
 
 - Добавлен формальный стандарт

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ kb-validate:
 	$(PYTHON) scripts/validate_issue_146_mango_taxonomy.py
 	$(PYTHON) scripts/validate_issue_148_taxonomy_extensions.py
 	$(PYTHON) scripts/validate_issue_152_industry_taxonomy_standard.py
+	$(PYTHON) scripts/validate_issue_154_mango_taxonomy_standard.py
 
 # Наглядно: токены индекса vs отдельных разделов (метод — см. token_method).
 kb-tokens:

--- a/scripts/validate_issue_154_mango_taxonomy_standard.py
+++ b/scripts/validate_issue_154_mango_taxonomy_standard.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Regression check for issue #154: canonical ADR-012 and Mango standard.
+
+Issue #154 finalizes ADR-012 and adds a machine-readable Mango Taxonomy
+standard aligned with ADR-011 canonical v1.0 and the Industry Taxonomy standard.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+ADR_012 = "standards/decisions/ADR-012-mango-taxonomy.md"
+STANDARD = "standards/mango-taxonomy-standard.md"
+INDUSTRY_STANDARD = "standards/industry-taxonomy-standard.md"
+VOICE_ANALYSIS = "docs/analysis/voice-digital-channels-comparison.md"
+CHANGELOG = "CHANGELOG.md"
+MAKEFILE = "Makefile"
+KB_WORKFLOW = ".github/workflows/kb.yml"
+VALIDATOR = "scripts/validate_issue_154_mango_taxonomy_standard.py"
+
+
+def read_text(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def require_path(path: str) -> list[str]:
+    return [] if (ROOT / path).exists() else [f"{path}: missing"]
+
+
+def require_text(path: str, *needles: str) -> list[str]:
+    errors = require_path(path)
+    if errors:
+        return errors
+    text = read_text(path)
+    return [f"{path}: missing {needle!r}" for needle in needles if needle not in text]
+
+
+def forbid_text(path: str, *needles: str) -> list[str]:
+    errors = require_path(path)
+    if errors:
+        return errors
+    text = read_text(path)
+    return [f"{path}: forbidden {needle!r}" for needle in needles if needle in text]
+
+
+def require_ordered_text(path: str, needles: tuple[str, ...]) -> list[str]:
+    errors = require_path(path)
+    if errors:
+        return errors
+    text = read_text(path)
+    last = -1
+    for needle in needles:
+        pos = text.find(needle)
+        if pos == -1:
+            errors.append(f"{path}: missing {needle!r}")
+        elif pos < last:
+            errors.append(f"{path}: {needle!r} is out of order")
+        last = max(last, pos)
+    return errors
+
+
+def check_adr_012() -> list[str]:
+    errors = require_text(
+        ADR_012,
+        "status: canonical",
+        "version: 1.0",
+        "https://github.com/G-Ivan-A/mango_ba_prompts/issues/154",
+        "## Canonicalization note",
+        "standards/mango-taxonomy-standard.md",
+        "Official Layer",
+        "Internal Layer",
+        "Product -> Service -> Module -> Function",
+        "`voice-channel`",
+        "`channel`",
+        "`function_type`",
+        "`business`",
+        "`configuration`",
+        "`ui-action`",
+        "primary",
+        "secondary",
+        "supporting",
+    )
+    errors += forbid_text(
+        ADR_012,
+        "Статус:** Proposed",
+        "status: proposed",
+        "оставить статус `Proposed`",
+        "`standards/mango-taxonomy-standard.md`: формальный стандарт Mango Taxonomy;",
+    )
+    return errors
+
+
+def check_standard() -> list[str]:
+    errors = require_text(
+        STANDARD,
+        "status: draft",
+        "type: standard",
+        "scope: mango-taxonomy",
+        "https://github.com/G-Ivan-A/mango_ba_prompts/issues/154",
+        "# Стандарт Mango Taxonomy",
+        "## 1. Область применения",
+        "## 2. Нормативные термины",
+        "## 3. Архитектура таксономии",
+        "Official Layer",
+        "Internal Layer",
+        "many-to-many",
+        "Product -> Service -> Module -> Function",
+        "## 4. Internal Layer",
+        "`vats-core`",
+        "`contact-center-core`",
+        "`digital-channels`",
+        "`mango-talker`",
+        "`ai-speech-quality`",
+        "`analytics-marketing`",
+        "`platform-integrations`",
+        "`security-access`",
+        "## 5. Атрибуты и типы",
+        "`function_type`",
+        "`business`",
+        "`configuration`",
+        "`ui-action`",
+        "`interaction_surface`",
+        "## 6. Нормализация терминов",
+        "Component -> Module",
+        "Operation -> Function",
+        "## 7. Mapping на Industry Taxonomy",
+        "`maps_to`",
+        "`industry_ref`",
+        "`alignment_type`",
+        "`primary`",
+        "`secondary`",
+        "`supporting`",
+        "## 8. Машиночитаемые схемы",
+        "MangoTaxonomyDocument",
+        "\"$schema\"",
+        "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$",
+        "## 9. YAML contract",
+        "taxonomy:",
+        "official_products:",
+        "internal_services:",
+        "modules:",
+        "functions:",
+        "## 10. Граничные кейсы и анти-паттерны",
+        "## 11. Контракт валидатора",
+        "## 12. Контракт AI-агента",
+        "## 13. Процесс эволюции",
+        "## 14. Самопроверка качества",
+        "## Источники",
+        INDUSTRY_STANDARD,
+        ADR_012,
+        "standards/decisions/ADR-011-industry-taxonomy.md",
+        VOICE_ANALYSIS,
+    )
+    if errors:
+        return errors
+
+    text = read_text(STANDARD)
+    minimum_examples = text.count("alignment_type:")
+    if minimum_examples < 10:
+        errors.append(f"{STANDARD}: expected at least 10 mapping examples, got {minimum_examples}")
+    for marker in ("channel_kind: voice", "channel_kind: text", "voice-channel"):
+        if marker not in text:
+            errors.append(f"{STANDARD}: missing inherited ADR-011 channel marker {marker!r}")
+    for forbidden in ("research/", "commercial_package as Product", "pricing as Product"):
+        if forbidden in text:
+            errors.append(f"{STANDARD}: forbidden or suspicious text {forbidden!r}")
+    return errors
+
+
+def check_changelog_and_ci() -> list[str]:
+    errors: list[str] = []
+    errors += require_text(
+        CHANGELOG,
+        "Issue #154",
+        STANDARD,
+        "ADR-012",
+        "canonical",
+        VALIDATOR,
+    )
+    errors += require_text(MAKEFILE, VALIDATOR)
+    errors += require_text(
+        KB_WORKFLOW,
+        "Validate issue #154 Mango Taxonomy standard",
+        f"python3 {VALIDATOR}",
+    )
+    return errors
+
+
+def main() -> int:
+    errors: list[str] = []
+    errors += check_adr_012()
+    errors += check_standard()
+    errors += require_ordered_text(
+        STANDARD,
+        (
+            "## 1. Область применения",
+            "## 2. Нормативные термины",
+            "## 3. Архитектура таксономии",
+            "## 4. Internal Layer",
+            "## 5. Атрибуты и типы",
+            "## 6. Нормализация терминов",
+            "## 7. Mapping на Industry Taxonomy",
+            "## 8. Машиночитаемые схемы",
+            "## 9. YAML contract",
+            "## 10. Граничные кейсы и анти-паттерны",
+            "## 11. Контракт валидатора",
+            "## 12. Контракт AI-агента",
+            "## 13. Процесс эволюции",
+            "## 14. Самопроверка качества",
+        ),
+    )
+    errors += check_changelog_and_ci()
+
+    if errors:
+        print("Issue #154 Mango Taxonomy standard validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("Issue #154 Mango Taxonomy standard validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/standards/decisions/ADR-012-mango-taxonomy.md
+++ b/standards/decisions/ADR-012-mango-taxonomy.md
@@ -1,7 +1,7 @@
 ---
-status: proposed
-version: 0.3
-updated: 2026-06-20
+status: canonical
+version: 1.0
+updated: 2026-06-21
 ai-generated: true
 type: adr
 scope: mango-taxonomy
@@ -9,8 +9,10 @@ issue: "https://github.com/G-Ivan-A/mango_ba_prompts/issues/142"
 validated_by:
   - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/146"
   - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/148"
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/154"
 depends_on:
   - "standards/decisions/ADR-011-industry-taxonomy.md"
+  - "standards/industry-taxonomy-standard.md"
 hub_research: "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/main/research/mango/classification.md"
 hub_research_sha: "3aa12727c9b87d5cf68301fa95d00a272408a97e"
 site_sources:
@@ -19,24 +21,43 @@ site_sources:
 related_prs:
   - "https://github.com/G-Ivan-A/mango_ba_prompts/pull/143"
   - "https://github.com/G-Ivan-A/mango_ba_prompts/pull/149"
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/pull/155"
 related_artifacts:
   - "standards/decisions/ADR-011-industry-taxonomy.md"
+  - "standards/industry-taxonomy-standard.md"
+  - "standards/mango-taxonomy-standard.md"
   - "standards/product-classification-contract.md"
   - "docs/audit/issue-146-mango-taxonomy-validation.md"
+  - "docs/analysis/voice-digital-channels-comparison.md"
   - "kb/mango-product-docs/processed/"
 ---
 
 # ADR-012: Mango Taxonomy для корпоративной таксономии продуктов Mango Office
 
-> **Статус:** Proposed · **Дата:** 2026-06-20 · **Issue:**
-> <https://github.com/G-Ivan-A/mango_ba_prompts/issues/142> · **Depends on:**
+> **Статус:** Canonical · **Дата:** 2026-06-21 · **Issue:**
+> <https://github.com/G-Ivan-A/mango_ba_prompts/issues/142> · **Canonicalized by:**
+> <https://github.com/G-Ivan-A/mango_ba_prompts/issues/154> · **Depends on:**
 > [`ADR-011`](ADR-011-industry-taxonomy.md)
 
 > **Numbering note.** ADR-012 продолжает дорожку `standards/decisions/`
 > вслед за ADR-011, потому что issue #142 явно требует путь
-> `standards/decisions/ADR-012-mango-taxonomy.md`. Этот ADR не создаёт
-> стандарт Mango Taxonomy, KB-данные, research-копию или дополнительные
-> артефакты.
+> `standards/decisions/ADR-012-mango-taxonomy.md`.
+
+## Canonicalization note
+
+Issue #154 завершает follow-up к issue #142: ADR-012 переведён в
+`status: canonical`, `version: 1.0`, а нормативные machine-readable правила
+вынесены в [`standards/mango-taxonomy-standard.md`](../mango-taxonomy-standard.md).
+Стандарт является обязательным operational companion к этому ADR для AI-агентов,
+валидаторов CI и будущих registry entries.
+
+Canonicalization наследует решения ADR-011 canonical v1.0 и Industry Taxonomy
+Standard: strict `industry_ref`, `alignment_type` (`primary`, `secondary`,
+`supporting`), cross-cutting facets, first-class `voice-channel` внутри
+`voice-ucaas` и facet `channel` (`channel_kind`, `synchronicity`, `direction`).
+Голосовая инфраструктура (`sip-connectivity`, numbering) остаётся supporting
+resource mapping, а голосовое interaction mapping ДОЛЖНО использовать
+`voice-channel` and/or `channel`.
 
 ## Контекст
 
@@ -56,15 +77,18 @@ Mango Taxonomy должна быть совместима с этой модел
 она нормализует продуктовый контур конкретного вендора Mango Office. Поэтому
 она не заменяет ADR-011, а добавляет вендорский слой поверх него.
 
-Жёсткие ограничения issue #142:
+Исходные ограничения issue #142 действовали только на первый proposed ADR:
 
 - создать только этот ADR;
 - обновить только `CHANGELOG.md`;
-- оставить статус `Proposed`;
-- не создавать стандарт, KB-реестр, research-файл или дополнительные
-  production-артефакты;
+- не создавать стандарт, KB-реестр или дополнительные production-артефакты;
 - использовать ADR-011, Hub classification, официальный сайт Mango Office и
   только обработанные markdown-документы в `kb/mango-product-docs/processed/`.
+
+Issue #154 явно снимает ограничение на стандарт и требует
+`standards/mango-taxonomy-standard.md`; это не меняет исходное решение ADR-012,
+а переводит его в canonical status и добавляет machine-readable операционный
+контракт.
 
 ## Research: источники
 
@@ -494,21 +518,27 @@ Commercial Layer, procurement-коды, тарифы, отраслевые ре�
 
 ## Follow-up work
 
-Этот ADR не создаёт follow-up артефакты, но задаёт направление для будущих
-issues:
+Issue #154 закрывает первый follow-up artifact: создан формальный стандарт
+[`standards/mango-taxonomy-standard.md`](../mango-taxonomy-standard.md). Открыты
+следующие future issues:
 
-- `standards/mango-taxonomy-standard.md`: формальный стандарт Mango Taxonomy;
 - `kb/mango/product-registry.md`: curated registry official products,
   services, modules and facets;
 - `kb/mango/product-mapping.md`: mapping Mango entities на ADR-011 и source
   evidence;
-- validators for required IDs, links, status values, function granularity and
-  alignment cardinality.
+- registry validators for required IDs, links, status values, function
+  granularity, `channel` facet and alignment cardinality;
+- migration checklist for concrete registry entries once processed KB evidence
+  is promoted from source material to curated registry.
 
 ## Связанные документы
 
 - ADR-011 Industry Taxonomy:
   [`standards/decisions/ADR-011-industry-taxonomy.md`](ADR-011-industry-taxonomy.md)
+- Mango Taxonomy Standard:
+  [`standards/mango-taxonomy-standard.md`](../mango-taxonomy-standard.md)
+- Industry Taxonomy Standard:
+  [`standards/industry-taxonomy-standard.md`](../industry-taxonomy-standard.md)
 - Hub Mango classification:
   <https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/main/research/mango/classification.md>
 - Официальный сайт Mango Office: <https://www.mango-office.ru/>

--- a/standards/mango-taxonomy-standard.md
+++ b/standards/mango-taxonomy-standard.md
@@ -1,0 +1,1628 @@
+---
+status: draft
+version: 0.1
+updated: 2026-06-21
+ai-generated: true
+type: standard
+scope: mango-taxonomy
+issue: "https://github.com/G-Ivan-A/mango_ba_prompts/issues/154"
+depends_on:
+  - "standards/decisions/ADR-012-mango-taxonomy.md"
+  - "standards/decisions/ADR-011-industry-taxonomy.md"
+  - "standards/industry-taxonomy-standard.md"
+related_artifacts:
+  - "docs/analysis/voice-digital-channels-comparison.md"
+  - "docs/audit/issue-146-mango-taxonomy-validation.md"
+validated_by:
+  - "scripts/validate_issue_154_mango_taxonomy_standard.py"
+---
+
+# Стандарт Mango Taxonomy
+
+> Носитель архитектурного решения:
+> [ADR-012 Mango Taxonomy](decisions/ADR-012-mango-taxonomy.md).
+> Внешний reference layer:
+> [ADR-011 Industry Taxonomy](decisions/ADR-011-industry-taxonomy.md) и
+> [Industry Taxonomy Standard](industry-taxonomy-standard.md).
+> Нормативный словарь: RFC 2119 / BCP 14
+> (**ДОЛЖЕН**, **НЕ ДОЛЖЕН**, **СЛЕДУЕТ**, **МОЖНО**).
+
+Этот стандарт задаёт строгий machine-readable контракт Mango Taxonomy для
+будущих реестров, валидаторов CI, AI-агентов и генерации требований. ADR-012
+объясняет принятое решение; этот стандарт определяет, как хранить, валидировать
+и использовать Mango-specific taxonomy entities без догадок.
+
+**Ограничение источников.** Issue #154 ссылается на прикреплённое резюме
+согласования ADR-012 как source of truth. В текущем checkout и через GitHub
+issue body/comments/timeline/code search отдельный attachment URL или файл не
+доступен. Нормативные решения ниже берутся из body issue #154, ADR-012,
+ADR-011 canonical v1.0, Industry Taxonomy Standard, issue #146 audit и
+аналитики voice/digital channels. Если attachment появится позже и будет
+противоречить этому стандарту, изменение ДОЛЖНО идти отдельным PR с явным
+diff of decisions.
+
+## 1. Область применения
+
+### 1.1 Что регулирует стандарт
+
+Стандарт ДОЛЖЕН применяться к любому артефакту, который:
+
+- описывает Mango Taxonomy entity;
+- создаёт или проверяет future registry для Mango products/services/modules/functions;
+- маппит Mango entity на Industry Taxonomy;
+- использует Mango taxonomy labels в requirements, KB, prompt, audit или CI;
+- генерирует machine-readable YAML/JSON для AI-агентов или валидаторов.
+
+Стандарт регулирует:
+
+- двухслойную архитектуру Official Layer + Internal Layer;
+- иерархию Internal Layer `Product -> Service -> Module -> Function`;
+- восемь внутренних кластеров и правила отнесения entities к ним;
+- обязательные и опциональные атрибуты для каждого уровня;
+- типы Function: `business`, `configuration`, `ui-action`;
+- нормализацию source terms: Component -> Module, Operation -> Function;
+- формат `maps_to` и `industry_alignment`;
+- JSON Schema/YAML contract для будущего реестра;
+- граничные кейсы, anti-patterns, validator contract, AI-agent contract и
+  процесс эволюции.
+
+### 1.2 Что стандарт НЕ регулирует
+
+Стандарт НЕ ДОЛЖЕН использоваться как:
+
+- реестр конкретных продуктов, сервисов, модулей и функций Mango;
+- коммерческий каталог, прайс-лист, тарифная матрица или procurement-реестр;
+- замена Industry Taxonomy Standard;
+- источник новых Industry Taxonomy slugs;
+- место для загрузки processed KB данных;
+- каталог исследований в споке.
+
+Конкретные entries future registry ДОЛЖНЫ жить в `kb/mango/` или другом
+утверждённом registry path отдельной задачей. В этом стандарте допускаются
+только illustrative examples, нужные для проверки структуры, mapping и boundary
+rules.
+
+### 1.3 Приоритет источников
+
+При конфликте применяется такой порядок:
+
+1. явное требование issue #154 или более поздний комментарий пользователя;
+2. этот стандарт;
+3. ADR-012 в статусе `canonical`;
+4. ADR-011 canonical v1.0;
+5. `standards/industry-taxonomy-standard.md`;
+6. `docs/analysis/voice-digital-channels-comparison.md`;
+7. `docs/audit/issue-146-mango-taxonomy-validation.md`;
+8. processed KB evidence.
+
+Если Mango-specific правило конфликтует с Industry Taxonomy Standard, PR ДОЛЖЕН
+явно указать один из вариантов: изменить Mango Taxonomy, предложить изменение
+Industry Taxonomy или зафиксировать vendor-specific extension outside
+`industry_ref`.
+
+## 2. Нормативные термины
+
+### 2.1 Mango Taxonomy
+
+**Mango Taxonomy** - vendor-specific taxonomy для продуктов Mango Office. Она
+связывает публичные product names и внутреннюю функциональную декомпозицию,
+сохраняя строгий mapping на Industry Taxonomy.
+
+Mango Taxonomy НЕ является Industry Taxonomy и НЕ создаёт отраслевые domains.
+
+### 2.2 Official Layer
+
+**Official Layer** фиксирует публичную витрину Mango Office: official product,
+product family, публичный URL, aliases, lifecycle/status и source evidence.
+
+Official Layer отвечает на вопрос: "Как Mango называет и показывает продукт
+наружу?"
+
+Official Layer ДОЛЖЕН:
+
+- хранить публичный product id;
+- иметь source refs на официальный сайт, каталог или иной approved public source;
+- поддерживать aliases without changing canonical id;
+- связываться с Internal Layer через many-to-many relations.
+
+Official Layer НЕ ДОЛЖЕН:
+
+- подменять внутренние service/module/function границы;
+- создавать отдельную branch для тарифа, сегмента, vertical, региона или SLA;
+- содержать leaf-level функции без Internal Layer entity.
+
+### 2.3 Internal Layer
+
+**Internal Layer** фиксирует функциональную и документационную структуру Mango:
+Product, Service, Module, Function, evidence refs и Industry mapping.
+
+Internal Layer отвечает на вопрос: "Какая функциональная единица реализует
+возможность и как её проверить?"
+
+Internal Layer ДОЛЖЕН использовать hierarchy:
+
+```text
+Product -> Service -> Module -> Function
+```
+
+### 2.4 Product
+
+**Product** - Mango-specific продукт или семейство, которое связывает Official
+Layer и Internal Layer. Product может быть видимым наружу или нормализованным
+internal product group, если public packaging объединяет несколько сервисов.
+
+Product ДОЛЖЕН:
+
+- иметь `id`;
+- ссылаться на one or more official products or explicit internal-only reason;
+- иметь `maps_to` на Industry Taxonomy минимум до Domain;
+- не содержать конкретные actions directly, если есть Service/Module/Function.
+
+### 2.5 Service
+
+**Service** - внутренняя capability-зона или функциональный сервис, который
+поддерживает один или несколько Products.
+
+Service ДОЛЖЕН:
+
+- принадлежать минимум одному Product;
+- иметь один primary internal cluster;
+- маппиться на Industry Capability, если evidence позволяет;
+- группировать Modules по устойчивой функциональной границе.
+
+Service НЕ ДОЛЖЕН быть экраном, endpoint, single setting, тарифом или
+marketing label.
+
+### 2.6 Module
+
+**Module** - конкретный модуль, экранная зона, API-группа, интеграционный блок,
+настройка или эксплуатационный блок внутри Service.
+
+Module ДОЛЖЕН:
+
+- иметь parent service(s);
+- маппиться на Industry Feature, если evidence позволяет;
+- содержать Functions или обоснование, почему Functions ещё не выделены;
+- хранить Component source terms as aliases/source_terms, not as a new level.
+
+### 2.7 Function
+
+**Function** - минимальная проверяемая единица поведения, настройки, API-команды,
+UI-действия, параметра или бизнес-правила внутри Module.
+
+Function ДОЛЖНА:
+
+- иметь parent module;
+- иметь ровно один `function_type`;
+- иметь observable result, state change, emitted event, data retrieval,
+  decision or UI interaction;
+- маппиться на Industry Function or nearest canonical parent with `mapping_gap`;
+- быть пригодной для acceptance criteria, test case, KB citation или requirement.
+
+### 2.8 Internal cluster
+
+**Internal cluster** - верхнеуровневая ось группировки Internal Layer. Cluster
+не заменяет Product/Service/Module/Function hierarchy и не является Industry
+Domain. Cluster нужен для ownership, navigation, validation и AI routing.
+
+### 2.9 `maps_to`
+
+`maps_to` - canonical relationship container для связей Mango entity с другими
+слоями. В этом стандарте обязательный target - Industry Taxonomy через
+`industry_alignment`. Допустимые future target types: `official_product`,
+`processed_kb`, `source_document`, `owner_registry`.
+
+`maps_to.industry_alignment[]` ДОЛЖЕН использовать typed objects, not free text.
+
+### 2.10 `industry_ref`
+
+`industry_ref` - строгая ссылка на Industry Taxonomy node. Она ДОЛЖНА
+соответствовать `standards/industry-taxonomy-standard.md`.
+
+Минимальная форма:
+
+```yaml
+maps_to:
+  industry_alignment:
+    - industry_ref:
+        domain: contact-center
+      alignment_type: primary
+```
+
+### 2.11 Evidence ref
+
+**Evidence ref** - repo path или URL, подтверждающий existence, boundary,
+status, mapping or naming decision. Free-text note НЕ заменяет evidence ref.
+
+## 3. Архитектура таксономии
+
+### 3.1 Двухслойная модель
+
+Mango Taxonomy ДОЛЖНА состоять из двух слоёв:
+
+```text
+Official Layer <-> Internal Layer <-> Industry Taxonomy
+```
+
+Official Layer и Internal Layer связываются many-to-many:
+
+- один official product может поддерживаться несколькими internal services;
+- один internal service может поддерживать несколько official products;
+- один module может быть reused across services;
+- одна function может иметь primary business mapping и supporting platform/security mapping.
+
+Industry Taxonomy остаётся external reference layer. Mango Taxonomy НЕ ДОЛЖНА
+копировать Industry Taxonomy rules полностью; она ДОЛЖНА ссылаться на
+`standards/industry-taxonomy-standard.md`.
+
+### 3.2 Обязательные relationship types
+
+| Relationship | Cardinality | Required on | Meaning |
+| --- | --- | --- | --- |
+| `official_product.supported_by_services[]` | many-to-many | Official Product | Internal services that realize public product promise. |
+| `product.official_refs[]` | one-to-many | Product | Public official products/families represented by Product. |
+| `product.services[]` | one-to-many | Product | Internal services inside Product. |
+| `service.parent_products[]` | many-to-many | Service | Products supported by Service. |
+| `service.modules[]` | one-to-many or many-to-many | Service | Modules implementing Service. |
+| `module.parent_services[]` | many-to-many | Module | Services that use Module. |
+| `module.functions[]` | one-to-many | Module | Leaf Functions. |
+| `entity.maps_to.industry_alignment[]` | one-to-many | Product/Service/Module/Function | Strict Industry Taxonomy mapping. |
+| `entity.evidence_refs[]` | one-to-many | All registry entities | Source-backed traceability. |
+
+### 3.3 Architectural invariants
+
+Mango Taxonomy artifacts ДОЛЖНЫ satisfy these invariants:
+
+1. Official Layer never contains leaf-level Function directly.
+2. Internal Layer uses canonical levels only: Product, Service, Module, Function.
+3. Component is not a level; Component -> Module.
+4. Operation is not a level; Operation -> Function.
+5. Every registry-grade entity has stable slug id.
+6. Every registry-grade entity has `lifecycle_status`.
+7. Every mapping uses `maps_to.industry_alignment[]`.
+8. Every `industry_ref` value is an Industry Taxonomy slug, not a Mango id.
+9. Commercial, procurement, segment, industry vertical and region stay facets or metadata.
+10. `channel` facet follows ADR-011 and Industry Taxonomy Standard.
+
+## 4. Internal Layer
+
+### 4.1 Canonical hierarchy
+
+Internal Layer hierarchy is:
+
+```text
+Product -> Service -> Module -> Function
+```
+
+Depth rules:
+
+| Mango level | Industry mapping depth | Example source signal |
+| --- | --- | --- |
+| Product | Domain or Domain/Capability | Public product or product family. |
+| Service | Capability | Stable internal capability-zone. |
+| Module | Feature | Screen, API group, configuration block, report, dashboard or integration block. |
+| Function | Function or nearest canonical parent | Action, setting, endpoint operation, event, rule or UI interaction. |
+
+### 4.2 Восемь внутренних кластеров
+
+Registry ДОЛЖЕН использовать один primary cluster для Service and Module.
+Secondary cluster references MAY be used only when a module is truly cross-product.
+
+| Cluster id | Label from issue #154 | Rule of assignment |
+| --- | --- | --- |
+| `vats-core` | VATS core | ВАТС, номера, сотрудники, группы, маршрутизация, IVR, SIP, запись, SMS, callback, автодозвон, базовая телефония. |
+| `contact-center-core` | Contact Center core | Очереди, статусы операторов, рабочее место, исходящие кампании, supervisors, WFM/WEM/QM orchestration. |
+| `digital-channels` | Digital channels | Сайт-чат, мессенджеры, email, SMS as interaction channel, обращения, Dialogi API, channel templates. |
+| `mango-talker` | Mango Talker | UC client: desktop/mobile client, calls, chats, channels, contacts, statuses, video, client administration. |
+| `ai-speech-quality` | AI/Speech/Quality | Speech analytics, AI summaries, quality management, scoring, checklists, categories, assistant and evaluation. |
+| `analytics-marketing` | Analytics/Marketing | Calltracking, сквозная аналитика, reports, dashboards, wallboard, attribution, marketing analytics, exports. |
+| `platform-integrations` | Platform integrations | Open API, webhooks, CPaaS-like surfaces, CRM/ERP integrations, API connector, SSO integration surfaces. |
+| `security-access` | Security and access | Role model, access rights, SSO, LDAP, audit/security settings, recording access, permission boundaries. |
+
+Assignment algorithm:
+
+1. Identify observable behavior and evidence.
+2. Exclude tariff, segment, region and commercial packaging.
+3. Pick the cluster that owns the primary user/customer outcome.
+4. If outcome is cross-cutting API/security, use `platform-integrations` or
+   `security-access` as primary only when the entity itself is an integration or
+   security/access function.
+5. If a business function is exposed via API, keep business cluster primary and
+   add platform mapping as supporting.
+6. If AI assists a CC/VATS/digital function without becoming a sold AI feature,
+   keep the business cluster primary and mark `facets.ai_assisted: true`.
+
+### 4.3 Product rules
+
+Product ДОЛЖЕН aggregate Services and map public packaging to internal
+capabilities. Product MUST NOT contain concrete module settings directly.
+
+Required Product fields:
+
+- `id`;
+- `level: product`;
+- `name_ru` or `name_en`;
+- `official_refs[]` or `internal_only_reason`;
+- `services[]`;
+- `maps_to.industry_alignment[]`;
+- `lifecycle_status`;
+- `evidence_refs[]`.
+
+### 4.4 Service rules
+
+Service ДОЛЖЕН group modules around a stable capability-zone. A Service SHOULD
+be reusable across products when evidence shows cross-product usage.
+
+Required Service fields:
+
+- `id`;
+- `level: service`;
+- `cluster`;
+- `parent_products[]`;
+- `modules[]`;
+- `maps_to.industry_alignment[]`;
+- `lifecycle_status`;
+- `evidence_refs[]`.
+
+### 4.5 Module rules
+
+Module ДОЛЖЕН represent a concrete feature surface or configuration/integration
+block. Component-like source terms normalize to Module.
+
+Required Module fields:
+
+- `id`;
+- `level: module`;
+- `cluster`;
+- `parent_services[]`;
+- `functions[]` or `function_extraction_status`;
+- `maps_to.industry_alignment[]`;
+- `lifecycle_status`;
+- `evidence_refs[]`.
+
+### 4.6 Function rules
+
+Function ДОЛЖНА be atomic enough for independent validation.
+
+A Function is atomic if:
+
+- it has one action/condition/effect;
+- it can become one acceptance criterion or test step;
+- its primary result can be classified as business, configuration or UI action;
+- it does not hide unrelated behavior.
+
+Required Function fields:
+
+- `id`;
+- `level: function`;
+- `function_type`;
+- `interaction_surface`;
+- `parent_module`;
+- `maps_to.industry_alignment[]`;
+- `lifecycle_status`;
+- `evidence_refs[]`.
+
+## 5. Атрибуты и типы
+
+### 5.1 Canonical slug
+
+Every canonical id ДОЛЖЕН match:
+
+```text
+^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$
+```
+
+Rules:
+
+- lowercase ASCII only;
+- hyphen as separator;
+- no spaces, underscores, slashes or uppercase;
+- stable after publication;
+- unique within level and parent scope.
+
+### 5.2 Lifecycle status
+
+Allowed `lifecycle_status` values:
+
+| Status | Meaning | Validator behavior |
+| --- | --- | --- |
+| `proposed` | Candidate entity; not production-grade. | Allowed in draft/proposed registry. |
+| `active` | Canonical entity allowed for production mapping. | Accepted. |
+| `deprecated` | Entity replaced or being phased out. | Warning with replacement required. |
+| `removed` | Entity no longer allowed. | Error unless legacy exemption is explicit. |
+
+### 5.3 Common attributes
+
+All entities SHOULD use this common structure:
+
+```yaml
+id: entity-slug
+level: product
+name_ru: Название
+name_en: Name
+description: Short source-backed definition.
+aliases: []
+source_terms: []
+lifecycle_status: proposed
+owner: unknown
+evidence_refs:
+  - standards/decisions/ADR-012-mango-taxonomy.md
+maps_to:
+  industry_alignment: []
+```
+
+### 5.4 Attribute matrix
+
+| Field | Official Product | Product | Service | Module | Function |
+| --- | --- | --- | --- | --- | --- |
+| `id` | required | required | required | required | required |
+| `level` | `official-product` | `product` | `service` | `module` | `function` |
+| `name_ru` or `name_en` | required | required | required | required | required |
+| `official_urls` | required | optional | forbidden | forbidden | forbidden |
+| `official_refs` | forbidden | required unless internal-only | optional | optional | optional |
+| `cluster` | forbidden | optional | required | required | inherited or optional |
+| `parent_products` | forbidden | forbidden | required | forbidden | forbidden |
+| `parent_services` | forbidden | forbidden | forbidden | required | forbidden |
+| `parent_module` | forbidden | forbidden | forbidden | forbidden | required |
+| `function_type` | forbidden | forbidden | forbidden | forbidden | required |
+| `interaction_surface` | optional | optional | optional | optional | required |
+| `maps_to.industry_alignment` | optional | required | required | required | required |
+| `evidence_refs` | required | required | required | required | required |
+
+### 5.5 `function_type`
+
+Every Function ДОЛЖНА have exactly one `function_type`.
+
+| `function_type` | When to use | Examples |
+| --- | --- | --- |
+| `business` | Function creates customer, operator or operational business outcome. | `transfer-call`, `send-dialog-message`, `create-outbound-campaign`, `generate-ai-summary`. |
+| `configuration` | Function changes setting, policy, route, access, integration, lifecycle or service behavior. | `configure-webhook-url`, `enable-call-recording`, `set-queue-schedule`, `assign-agent-role`. |
+| `ui-action` | Function describes a user interaction in UI that is required for scenario but is not standalone business/configuration capability. | `select-wallboard-widget`, `open-call-filter`, `switch-agent-tab`, `expand-report-section`. |
+
+Rules:
+
+- `function_type` classifies semantic result, not channel or surface.
+- API endpoint can be `business`, `configuration` or `ui-action` depending on effect.
+- UI action with configuration effect is `configuration`, not `ui-action`.
+- UI action without standalone effect is `ui-action`.
+- Channel marker belongs to `facets.channel`, not `function_type`.
+
+### 5.6 `interaction_surface`
+
+Allowed initial values:
+
+| Value | Meaning |
+| --- | --- |
+| `admin-ui` | Administrator UI or settings panel. |
+| `operator-ui` | Operator/agent/supervisor workspace. |
+| `end-user-ui` | End-user client or user-facing application. |
+| `api` | Public or integration API. |
+| `webhook` | Event callback or webhook surface. |
+| `background-job` | Scheduled or asynchronous internal process. |
+| `system-rule` | Rule applied by platform/runtime. |
+| `unknown` | Evidence is insufficient; requires review before active status. |
+
+## 6. Нормализация терминов
+
+### 6.1 Canonical levels
+
+Mango Taxonomy has only these canonical levels:
+
+```text
+Official Product
+Product
+Service
+Module
+Function
+```
+
+Source terms do not create levels.
+
+### 6.2 Component -> Module
+
+`Component -> Module` is mandatory.
+
+If processed KB, vendor docs or code comments use "Component", registry ДОЛЖЕН:
+
+- store canonical `level: module`;
+- preserve source term in `source_terms`;
+- optionally add alias in `aliases`;
+- avoid creating `component` in hierarchy, schema or mapping.
+
+Example:
+
+```yaml
+id: webhook-management
+level: module
+source_terms:
+  - Component
+aliases:
+  - webhook-component
+```
+
+### 6.3 Operation -> Function
+
+`Operation -> Function` is mandatory.
+
+API operation, user operation, operational step, action, command, endpoint,
+parameter change or rule ДОЛЖЕН become Function if it is leaf-level and
+verifiable.
+
+Example:
+
+```yaml
+id: configure-webhook-url
+level: function
+function_type: configuration
+source_terms:
+  - Operation
+  - endpoint
+```
+
+### 6.4 Aliases and ambiguity
+
+Alias rules:
+
+- one alias SHOULD resolve to one canonical entity;
+- ambiguous alias ДОЛЖЕН require explicit parent context;
+- aliases НЕ ДОЛЖНЫ appear inside `industry_ref`;
+- source terms MAY be multilingual;
+- canonical id remains ASCII slug.
+
+## 7. Mapping на Industry Taxonomy
+
+### 7.1 Required mapping container
+
+Every Product, Service, Module and Function ДОЛЖЕН use:
+
+```yaml
+maps_to:
+  industry_alignment:
+    - industry_ref:
+        domain: contact-center
+        capability: interaction-routing
+      alignment_type: primary
+      evidence_refs:
+        - standards/decisions/ADR-011-industry-taxonomy.md
+```
+
+`maps_to` MAY contain other relation families later, but
+`maps_to.industry_alignment[]` is the normative form for Industry mapping.
+
+### 7.2 `alignment_type`
+
+Allowed values:
+
+- `primary` - main industry meaning;
+- `secondary` - significant additional meaning;
+- `supporting` - platform, hardware, security, integration or operational support.
+
+Rules:
+
+- every mapped entity MUST have at least one `primary`, unless
+  `supporting_only_reason` is present;
+- `primary` is selected by customer/operational meaning, not technical surface;
+- `supporting` must not hide the primary business meaning;
+- many-to-many is expected and valid.
+
+### 7.3 Depth by Mango level
+
+| Mango level | Minimum industry_ref | Recommended industry_ref |
+| --- | --- | --- |
+| Product | `domain` | `domain` + `capability` |
+| Service | `domain` + `capability` | `domain` + `capability` |
+| Module | `domain` + `capability` | `domain` + `capability` + `feature` |
+| Function | nearest canonical parent | `domain` + `capability` + `feature` + `function` |
+
+If a deeper Industry node is not canonical, mapping ДОЛЖЕН stop at nearest
+canonical parent and add `mapping_gap`.
+
+### 7.4 Mapping examples
+
+Virtual PBX product:
+
+```yaml
+id: mango-virtual-pbx
+level: product
+maps_to:
+  industry_alignment:
+    - industry_ref:
+        domain: voice-ucaas
+        capability: cloud-pbx
+      alignment_type: primary
+      evidence_refs:
+        - standards/decisions/ADR-012-mango-taxonomy.md
+    - industry_ref:
+        domain: voice-ucaas
+        capability: sip-connectivity
+      alignment_type: secondary
+      evidence_refs:
+        - standards/decisions/ADR-011-industry-taxonomy.md
+```
+
+Inbound voice interaction:
+
+```yaml
+id: receive-inbound-call
+level: function
+function_type: business
+maps_to:
+  industry_alignment:
+    - industry_ref:
+        domain: voice-ucaas
+        capability: voice-channel
+        feature: inbound-voice-call
+        function: receive-inbound-call
+      alignment_type: primary
+      facets:
+        channel:
+          channel_kind: voice
+          synchronicity: sync
+          direction: inbound
+```
+
+SIP trunk as infrastructure:
+
+```yaml
+id: sip-trunk
+level: module
+maps_to:
+  industry_alignment:
+    - industry_ref:
+        domain: voice-ucaas
+        capability: sip-connectivity
+      alignment_type: supporting
+      supporting_only_reason: "Pure telecom infrastructure, not an interaction channel."
+```
+
+Contact center product:
+
+```yaml
+id: mango-contact-center
+level: product
+maps_to:
+  industry_alignment:
+    - industry_ref:
+        domain: contact-center
+        capability: omnichannel-contact-center
+      alignment_type: primary
+    - industry_ref:
+        domain: digital-channels
+        capability: omnichannel-messaging
+      alignment_type: secondary
+```
+
+Outbound campaign function:
+
+```yaml
+id: start-outbound-campaign
+level: function
+function_type: business
+maps_to:
+  industry_alignment:
+    - industry_ref:
+        domain: contact-center
+        capability: outbound-calling
+        feature: campaign-management
+        function: start-campaign
+      alignment_type: primary
+      facets:
+        channel:
+          channel_kind: voice
+          synchronicity: sync
+          direction: outbound
+```
+
+Text dialog channel:
+
+```yaml
+id: send-dialog-message
+level: function
+function_type: business
+maps_to:
+  industry_alignment:
+    - industry_ref:
+        domain: digital-channels
+        capability: omnichannel-messaging
+        feature: messenger-integration
+        function: send-message
+      alignment_type: primary
+      facets:
+        channel:
+          channel_kind: text
+          synchronicity: async
+          direction: outbound
+```
+
+Mango Talker mixed UC client:
+
+```yaml
+id: mango-talker
+level: product
+maps_to:
+  industry_alignment:
+    - industry_ref:
+        domain: voice-ucaas
+        capability: unified-communications
+      alignment_type: primary
+    - industry_ref:
+        domain: digital-channels
+        capability: team-messaging
+      alignment_type: secondary
+```
+
+Speech analytics:
+
+```yaml
+id: generate-ai-summary
+level: function
+function_type: business
+maps_to:
+  industry_alignment:
+    - industry_ref:
+        domain: ai-automation
+        capability: conversation-summaries
+        feature: ai-summary
+        function: generate-summary
+      alignment_type: primary
+    - industry_ref:
+        domain: analytics
+        capability: conversation-analytics
+      alignment_type: secondary
+```
+
+Wallboard:
+
+```yaml
+id: select-wallboard-widget
+level: function
+function_type: ui-action
+maps_to:
+  industry_alignment:
+    - industry_ref:
+        domain: analytics
+        capability: real-time-reporting
+        feature: dashboard-view
+        function: select-dashboard-widget
+      alignment_type: primary
+    - industry_ref:
+        domain: contact-center
+        capability: supervisor-workspace
+      alignment_type: supporting
+```
+
+Open API endpoint supporting business function:
+
+```yaml
+id: create-callback-request
+level: function
+function_type: business
+interaction_surface: api
+maps_to:
+  industry_alignment:
+    - industry_ref:
+        domain: voice-ucaas
+        capability: voice-channel
+        feature: callback
+        function: request-callback
+      alignment_type: primary
+    - industry_ref:
+        domain: platform
+        capability: open-api
+      alignment_type: supporting
+```
+
+Access control:
+
+```yaml
+id: assign-agent-role
+level: function
+function_type: configuration
+maps_to:
+  industry_alignment:
+    - industry_ref:
+        domain: security
+        capability: access-control
+        feature: role-management
+        function: assign-role
+      alignment_type: primary
+```
+
+### 7.5 Mapping gaps
+
+When Industry Function slug is absent:
+
+```yaml
+maps_to:
+  industry_alignment:
+    - industry_ref:
+        domain: contact-center
+        capability: interaction-routing
+        feature: routing-rules
+      alignment_type: primary
+      mapping_gap:
+        missing_level: function
+        proposed_id: configure-routing-condition
+        reason: "Mango Function exists; Industry Function is not canonical yet."
+```
+
+`mapping_gap.proposed_id` ДОЛЖЕН match slug pattern and MUST NOT silently become
+canonical.
+
+## 8. Машиночитаемые схемы
+
+This section defines the minimum JSON Schema contract. Future registry MAY split
+schemas into files, but MUST preserve these required fields and enum values.
+
+### 8.1 MangoTaxonomyDocument
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/G-Ivan-A/mango_ba_prompts/schemas/mango-taxonomy-document.schema.json",
+  "title": "MangoTaxonomyDocument",
+  "type": "object",
+  "required": ["taxonomy"],
+  "additionalProperties": false,
+  "properties": {
+    "taxonomy": { "$ref": "#/$defs/taxonomy" }
+  },
+  "$defs": {
+    "slug": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$"
+    },
+    "lifecycleStatus": {
+      "type": "string",
+      "enum": ["proposed", "active", "deprecated", "removed"]
+    },
+    "cluster": {
+      "type": "string",
+      "enum": [
+        "vats-core",
+        "contact-center-core",
+        "digital-channels",
+        "mango-talker",
+        "ai-speech-quality",
+        "analytics-marketing",
+        "platform-integrations",
+        "security-access"
+      ]
+    },
+    "functionType": {
+      "type": "string",
+      "enum": ["business", "configuration", "ui-action"]
+    },
+    "interactionSurface": {
+      "type": "string",
+      "enum": [
+        "admin-ui",
+        "operator-ui",
+        "end-user-ui",
+        "api",
+        "webhook",
+        "background-job",
+        "system-rule",
+        "unknown"
+      ]
+    },
+    "evidenceRef": {
+      "type": "string",
+      "minLength": 1
+    },
+    "industryRef": {
+      "type": "object",
+      "required": ["domain"],
+      "additionalProperties": false,
+      "properties": {
+        "domain": { "$ref": "#/$defs/slug" },
+        "capability": { "$ref": "#/$defs/slug" },
+        "feature": { "$ref": "#/$defs/slug" },
+        "function": { "$ref": "#/$defs/slug" }
+      }
+    },
+    "channelFacet": {
+      "type": "object",
+      "required": ["channel_kind", "synchronicity", "direction"],
+      "additionalProperties": false,
+      "properties": {
+        "channel_kind": { "type": "string", "enum": ["voice", "text", "video"] },
+        "synchronicity": { "type": "string", "enum": ["sync", "async"] },
+        "direction": { "type": "string", "enum": ["inbound", "outbound", "broadcast"] }
+      }
+    },
+    "facets": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "channel": { "$ref": "#/$defs/channelFacet" },
+        "ai_assisted": { "type": "boolean" },
+        "industry_vertical": { "type": "array", "items": { "$ref": "#/$defs/slug" } },
+        "segment": { "type": "array", "items": { "$ref": "#/$defs/slug" } },
+        "region": { "type": "array", "items": { "$ref": "#/$defs/slug" } }
+      }
+    },
+    "mappingGap": {
+      "type": "object",
+      "required": ["missing_level", "proposed_id", "reason"],
+      "additionalProperties": false,
+      "properties": {
+        "missing_level": {
+          "type": "string",
+          "enum": ["domain", "capability", "feature", "function"]
+        },
+        "proposed_id": { "$ref": "#/$defs/slug" },
+        "reason": { "type": "string", "minLength": 1 }
+      }
+    },
+    "industryAlignment": {
+      "type": "object",
+      "required": ["industry_ref", "alignment_type"],
+      "additionalProperties": false,
+      "properties": {
+        "industry_ref": { "$ref": "#/$defs/industryRef" },
+        "alignment_type": {
+          "type": "string",
+          "enum": ["primary", "secondary", "supporting"]
+        },
+        "evidence_refs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/evidenceRef" },
+          "minItems": 1
+        },
+        "facets": { "$ref": "#/$defs/facets" },
+        "mapping_gap": { "$ref": "#/$defs/mappingGap" },
+        "supporting_only_reason": { "type": "string" }
+      }
+    },
+    "mapsTo": {
+      "type": "object",
+      "required": ["industry_alignment"],
+      "additionalProperties": true,
+      "properties": {
+        "industry_alignment": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/industryAlignment" },
+          "minItems": 1
+        }
+      }
+    },
+    "commonEntity": {
+      "type": "object",
+      "required": ["id", "level", "lifecycle_status", "evidence_refs"],
+      "anyOf": [
+        { "required": ["name_ru"] },
+        { "required": ["name_en"] }
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/slug" },
+        "level": { "type": "string" },
+        "name_ru": { "type": "string", "minLength": 1 },
+        "name_en": { "type": "string" },
+        "description": { "type": "string" },
+        "aliases": { "type": "array", "items": { "type": "string" } },
+        "source_terms": { "type": "array", "items": { "type": "string" } },
+        "lifecycle_status": { "$ref": "#/$defs/lifecycleStatus" },
+        "owner": { "type": "string" },
+        "evidence_refs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/evidenceRef" },
+          "minItems": 1
+        },
+        "maps_to": { "$ref": "#/$defs/mapsTo" }
+      }
+    },
+    "officialProduct": {
+      "allOf": [
+        { "$ref": "#/$defs/commonEntity" },
+        {
+          "type": "object",
+          "required": ["official_urls"],
+          "properties": {
+            "level": { "const": "official-product" },
+            "official_urls": {
+              "type": "array",
+              "items": { "type": "string", "format": "uri" },
+              "minItems": 1
+            },
+            "supported_by_services": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/slug" }
+            }
+          }
+        }
+      ]
+    },
+    "product": {
+      "allOf": [
+        { "$ref": "#/$defs/commonEntity" },
+        {
+          "type": "object",
+          "required": ["services", "maps_to"],
+          "anyOf": [
+            { "required": ["official_refs"] },
+            { "required": ["internal_only_reason"] }
+          ],
+          "properties": {
+            "level": { "const": "product" },
+            "official_refs": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/slug" }
+            },
+            "internal_only_reason": { "type": "string", "minLength": 1 },
+            "services": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/slug" },
+              "minItems": 1
+            }
+          }
+        }
+      ]
+    },
+    "service": {
+      "allOf": [
+        { "$ref": "#/$defs/commonEntity" },
+        {
+          "type": "object",
+          "required": ["cluster", "parent_products", "modules", "maps_to"],
+          "properties": {
+            "level": { "const": "service" },
+            "cluster": { "$ref": "#/$defs/cluster" },
+            "parent_products": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/slug" },
+              "minItems": 1
+            },
+            "modules": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/slug" },
+              "minItems": 1
+            }
+          }
+        }
+      ]
+    },
+    "module": {
+      "allOf": [
+        { "$ref": "#/$defs/commonEntity" },
+        {
+          "type": "object",
+          "required": ["cluster", "parent_services", "maps_to"],
+          "properties": {
+            "level": { "const": "module" },
+            "cluster": { "$ref": "#/$defs/cluster" },
+            "parent_services": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/slug" },
+              "minItems": 1
+            },
+            "functions": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/slug" }
+            },
+            "function_extraction_status": {
+              "type": "string",
+              "enum": ["complete", "partial", "not-started"]
+            }
+          }
+        }
+      ]
+    },
+    "function": {
+      "allOf": [
+        { "$ref": "#/$defs/commonEntity" },
+        {
+          "type": "object",
+          "required": ["parent_module", "function_type", "interaction_surface", "maps_to"],
+          "properties": {
+            "level": { "const": "function" },
+            "parent_module": { "$ref": "#/$defs/slug" },
+            "function_type": { "$ref": "#/$defs/functionType" },
+            "interaction_surface": { "$ref": "#/$defs/interactionSurface" }
+          }
+        }
+      ]
+    },
+    "taxonomy": {
+      "type": "object",
+      "required": [
+        "version",
+        "official_products",
+        "products",
+        "internal_services",
+        "modules",
+        "functions"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "version": { "type": "integer", "minimum": 1 },
+        "official_products": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/officialProduct" }
+        },
+        "products": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/product" }
+        },
+        "internal_services": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/service" }
+        },
+        "modules": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/module" }
+        },
+        "functions": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/function" }
+        }
+      }
+    }
+  }
+}
+```
+
+### 8.2 Schema validation rules beyond JSON Schema
+
+Validator ДОЛЖЕН additionally check:
+
+- referenced ids exist in the same taxonomy document or approved registry;
+- no entity references itself as parent;
+- each Service has exactly one primary `cluster`;
+- every non-supporting-only entity has at least one `primary` alignment;
+- `industry_ref` parent chain resolves in Industry Taxonomy registry when such
+  registry exists;
+- `facets.channel` is absent for pure SIP/PSTN/numbering infrastructure mapping;
+- `function_type` exists on every Function and only on Function;
+- no source term creates extra level.
+
+## 9. YAML contract
+
+### 9.1 Minimal registry document
+
+```yaml
+taxonomy:
+  version: 1
+  official_products:
+    - id: mango-contact-center-official
+      level: official-product
+      name_ru: Омниканальный контакт-центр
+      official_urls:
+        - https://www.mango-office.ru/products/
+      lifecycle_status: proposed
+      evidence_refs:
+        - standards/decisions/ADR-012-mango-taxonomy.md
+      supported_by_services:
+        - outbound-campaigns
+  products:
+    - id: mango-contact-center
+      level: product
+      name_ru: Контакт-центр Mango
+      official_refs:
+        - mango-contact-center-official
+      services:
+        - outbound-campaigns
+      lifecycle_status: proposed
+      evidence_refs:
+        - standards/decisions/ADR-012-mango-taxonomy.md
+      maps_to:
+        industry_alignment:
+          - industry_ref:
+              domain: contact-center
+              capability: omnichannel-contact-center
+            alignment_type: primary
+  internal_services:
+    - id: outbound-campaigns
+      level: service
+      name_ru: Исходящие кампании
+      cluster: contact-center-core
+      parent_products:
+        - mango-contact-center
+      modules:
+        - campaign-management
+      lifecycle_status: proposed
+      evidence_refs:
+        - kb/mango-product-docs/processed/mango-cc-manual/index.md
+      maps_to:
+        industry_alignment:
+          - industry_ref:
+              domain: contact-center
+              capability: outbound-calling
+            alignment_type: primary
+  modules:
+    - id: campaign-management
+      level: module
+      name_ru: Управление кампаниями
+      cluster: contact-center-core
+      parent_services:
+        - outbound-campaigns
+      functions:
+        - start-outbound-campaign
+      lifecycle_status: proposed
+      evidence_refs:
+        - kb/mango-product-docs/processed/mango-cc-manual/index.md
+      maps_to:
+        industry_alignment:
+          - industry_ref:
+              domain: contact-center
+              capability: outbound-calling
+              feature: campaign-management
+            alignment_type: primary
+  functions:
+    - id: start-outbound-campaign
+      level: function
+      name_ru: Запустить исходящую кампанию
+      parent_module: campaign-management
+      function_type: business
+      interaction_surface: operator-ui
+      lifecycle_status: proposed
+      evidence_refs:
+        - kb/mango-product-docs/processed/mango-cc-manual/index.md
+      maps_to:
+        industry_alignment:
+          - industry_ref:
+              domain: contact-center
+              capability: outbound-calling
+              feature: campaign-management
+              function: start-campaign
+            alignment_type: primary
+            facets:
+              channel:
+                channel_kind: voice
+                synchronicity: sync
+                direction: outbound
+```
+
+### 9.2 Serialization rules
+
+YAML/JSON documents ДОЛЖНЫ:
+
+- preserve field names exactly as defined;
+- use arrays for all multi-value relationships;
+- use `null` only when schema explicitly allows it; otherwise omit unknown optional fields;
+- use `unknown` enum value only for `owner` or `interaction_surface`, not for taxonomy ids;
+- keep evidence refs close to the entity or mapping they justify;
+- be deterministic enough for diff review: stable ordering by level, then id.
+
+## 10. Граничные кейсы и анти-паттерны
+
+### 10.1 Public product vs internal service
+
+Incorrect:
+
+```yaml
+id: omnichannel-contact-center
+level: service
+official_urls:
+  - https://www.mango-office.ru/products/
+```
+
+Reason: official URL belongs to Official Layer or Product, not Service.
+
+Correct: create official product, Product and internal Service separately.
+
+### 10.2 API endpoint primary mapping
+
+Incorrect:
+
+```yaml
+id: start-campaign-endpoint
+level: function
+maps_to:
+  industry_alignment:
+    - industry_ref:
+        domain: platform
+        capability: open-api
+      alignment_type: primary
+```
+
+for an endpoint whose business effect is starting a contact-center campaign.
+
+Correct: business mapping primary, `platform/open-api` supporting.
+
+### 10.3 Pure infrastructure with channel facet
+
+Incorrect:
+
+```yaml
+industry_ref:
+  domain: voice-ucaas
+  capability: sip-connectivity
+alignment_type: primary
+facets:
+  channel:
+    channel_kind: voice
+    synchronicity: sync
+    direction: inbound
+```
+
+Correct:
+
+```yaml
+industry_ref:
+  domain: voice-ucaas
+  capability: sip-connectivity
+alignment_type: supporting
+```
+
+Use `voice-channel` only for interaction.
+
+### 10.4 AI feature in wrong domain
+
+Incorrect: move any AI-assisted routing into `ai-automation`.
+
+Correct: keep routing under contact-center primary and add `facets.ai_assisted:
+true`, unless the product is sold/described primarily as AI/bot/automation.
+
+### 10.5 Commercial and segment labels
+
+Tariff, package, SKU, "small business", region and vertical labels MUST NOT
+become Product/Service/Module/Function. Store them as facets/metadata when needed.
+
+### 10.6 Component/Operation as levels
+
+Incorrect levels:
+
+```yaml
+level: component
+level: operation
+```
+
+Correct:
+
+```yaml
+level: module
+source_terms: ["Component"]
+```
+
+```yaml
+level: function
+source_terms: ["Operation"]
+```
+
+### 10.7 Duplicate modules per product
+
+Do not copy a cross-product module into every product branch. Create one Module
+and connect it to multiple parent services/products through relationships.
+
+### 10.8 Unknown Industry slug
+
+Do not invent Industry slugs inside `industry_ref`. Use nearest canonical parent
+and `mapping_gap`.
+
+## 11. Контракт валидатора
+
+### 11.1 Document-level checks
+
+Validator ДОЛЖЕН verify:
+
+- `standards/mango-taxonomy-standard.md` exists;
+- ADR-012 is `status: canonical`, `version: 1.0`;
+- frontmatter fields exist: `status`, `version`, `updated`, `type`, `scope`,
+  `issue`, `depends_on`, `validated_by`;
+- sections 1-14 and `## Источники` exist in order;
+- all eight cluster ids are present;
+- hierarchy `Product -> Service -> Module -> Function` is present;
+- Official Layer and Internal Layer are both defined;
+- `function_type` enum has `business`, `configuration`, `ui-action`;
+- term normalization includes Component -> Module and Operation -> Function;
+- mapping section uses `maps_to`, `industry_ref`, `alignment_type`;
+- JSON Schema includes `$schema`, `MangoTaxonomyDocument`, slug pattern and enums;
+- YAML contract includes arrays for official_products, internal_services,
+  modules and functions;
+- no `research` directory is created in the spoke.
+
+### 11.2 Registry-level checks
+
+Future registry validator ДОЛЖЕН verify:
+
+1. YAML/JSON parses.
+2. Root object has `taxonomy.version`.
+3. Entity ids match slug pattern.
+4. Entity ids are unique inside level and parent scope.
+5. Required fields by level are present.
+6. Level values are allowed.
+7. Parent ids resolve.
+8. No cycles exist.
+9. Cluster values are one of eight canonical ids.
+10. `function_type` exists on Function only.
+11. `function_type` value is allowed.
+12. `interaction_surface` value is allowed.
+13. `maps_to.industry_alignment` is array.
+14. Each alignment has `industry_ref.domain`.
+15. No deeper `industry_ref` field appears without parent field.
+16. `alignment_type` is one of `primary`, `secondary`, `supporting`.
+17. Non-supporting-only entity has at least one `primary`.
+18. `evidence_refs` resolve to existing repo path or full URL.
+19. `facets.channel` uses allowed `channel_kind`, `synchronicity`, `direction`.
+20. Pure infrastructure mapping does not carry channel facet.
+21. Alias/source_terms do not create extra hierarchy levels.
+22. `Component` source term appears only with `level: module`.
+23. `Operation` source term appears only with `level: function`.
+24. Deprecated entity has replacement or deprecation reason.
+25. Removed entity fails unless explicit legacy exemption exists.
+
+### 11.3 Severity
+
+| Condition | Severity |
+| --- | --- |
+| Missing required field | error |
+| Invalid enum | error |
+| Invalid slug | error |
+| Unknown parent id | error |
+| Invalid `industry_ref` chain | error |
+| Missing primary alignment | error |
+| Missing evidence in active registry | error |
+| Missing evidence in draft registry | warning |
+| Ambiguous alias | error |
+| Deprecated reference | warning |
+| Removed reference | error |
+| Attachment source unavailable but documented | warning |
+
+## 12. Контракт AI-агента
+
+AI-агент, который создаёт или изменяет Mango Taxonomy, ДОЛЖЕН:
+
+1. Прочитать issue, latest comments, ADR-012, ADR-011, Industry Taxonomy
+   Standard, this standard and relevant audit/analysis docs.
+2. Treat Official Layer and Internal Layer separately.
+3. Find existing entity before proposing a new id.
+4. Use canonical levels only.
+5. Normalize Component -> Module and Operation -> Function.
+6. Select one primary internal cluster with evidence.
+7. Use `maps_to.industry_alignment[]`, not free tags.
+8. Add `alignment_type`, evidence refs and facets.
+9. Mark uncertainty with `mapping_gap`, `confidence` or open question.
+10. Avoid concrete registry data unless the task explicitly asks for registry.
+11. Avoid commercial/procurement/vertical labels as hierarchy nodes.
+12. Run available validators before finalizing PR.
+
+AI-агент НЕ ДОЛЖЕН:
+
+- invent Industry Taxonomy slugs;
+- turn public product names into internal services without evidence;
+- duplicate cross-product modules per product;
+- promote `active` status without reviewable evidence;
+- use UI label alone as proof of Product/Service boundary;
+- remove existing semantics without migration note.
+
+### 12.1 Decision checklist
+
+Before adding entity or mapping, answer:
+
+- What source entity is classified?
+- Is it Official Layer, Product, Service, Module or Function?
+- What evidence proves it?
+- Which internal cluster owns primary meaning?
+- What is the parent chain?
+- What is the nearest Industry Taxonomy node?
+- Why is `alignment_type` primary/secondary/supporting?
+- Does it need `channel` or `ai_assisted` facet?
+- If Function, what is `function_type` and `interaction_surface`?
+- Are there aliases/source terms that must be normalized?
+- Is uncertainty represented as `mapping_gap` or review question?
+
+## 13. Процесс эволюции
+
+### 13.1 Adding entity
+
+New entity MAY be proposed when:
+
+- source evidence exists;
+- existing entity does not cover semantic meaning;
+- parent chain is clear;
+- id matches slug pattern;
+- cluster assignment is justified;
+- Industry mapping or mapping gap exists.
+
+### 13.2 Rejecting entity
+
+New entity MUST NOT be added when it is only:
+
+- tariff, package, SKU or contract condition;
+- customer segment, vertical or region;
+- alias of existing entity;
+- implementation detail without taxonomy semantics;
+- one-off UI label without stable behavior;
+- source term that normalizes to existing level.
+
+### 13.3 Change request contract
+
+PR changing Mango Taxonomy standard or future registry ДОЛЖЕН include:
+
+- problem statement;
+- affected entities and mappings;
+- evidence refs;
+- before/after YAML snippets;
+- validator impact;
+- migration/deprecation note if ids change;
+- self-check against sections 1-14;
+- risks and human-review focus.
+
+### 13.4 Versioning
+
+Version meaning:
+
+- patch: editorial clarification, no schema or validator change;
+- minor: additive field, enum value, cluster clarification or compatible rule;
+- major: breaking hierarchy, required field, id or enum change.
+
+Canonical ids MUST NOT be renamed without deprecation period and replacement.
+
+## 14. Самопроверка качества
+
+### 14.1 Полнота
+
+Стандарт covers all issue #154 mandatory elements:
+
+- two-layer architecture Official Layer + Internal Layer;
+- Internal Layer hierarchy Product, Service, Module, Function;
+- eight internal clusters;
+- attributes for each level;
+- Function types business/configuration/ui-action;
+- normalization Component -> Module and Operation -> Function;
+- mapping to Industry Taxonomy with primary/secondary/supporting;
+- inherited ADR-011 `voice-channel` and `channel` facet;
+- machine-readable JSON Schema and YAML contract;
+- validator and AI-agent contracts;
+- evolution process.
+
+### 14.2 Однозначность
+
+Closed enums are defined for:
+
+- cluster;
+- lifecycle_status;
+- function_type;
+- interaction_surface;
+- alignment_type;
+- channel_kind, synchronicity, direction.
+
+Each level has definition, positive rules, negative rules and required fields.
+
+### 14.3 Отсутствие дублирования
+
+The standard references Industry Taxonomy Standard for Industry rules and does
+not restate all Industry node semantics. Mango-specific content is limited to
+layers, internal hierarchy, clusters, source-term normalization and registry
+contract.
+
+### 14.4 Отсутствие противоречий
+
+The standard aligns with:
+
+- ADR-012 canonical: two-layer Mango Taxonomy and
+  `Product -> Service -> Module -> Function`;
+- ADR-011 canonical v1.0: Industry Taxonomy, `voice-channel`, `channel` facet;
+- Industry Taxonomy Standard: strict `industry_ref`, `alignment_type`, facets;
+- issue #146 audit: processed KB evidence for Function and terminology;
+- issue #154 body: mandatory clusters, function types, mapping and
+  machine-readable contracts.
+
+### 14.5 Машиночитаемость
+
+Validator-ready elements are explicit:
+
+- schema title `MangoTaxonomyDocument`;
+- `$schema` and `$defs`;
+- regex for slugs;
+- required fields;
+- enum values;
+- mapping object shape;
+- YAML examples;
+- validation severity matrix.
+
+## Источники
+
+- ADR-012 Mango Taxonomy:
+  [`standards/decisions/ADR-012-mango-taxonomy.md`](decisions/ADR-012-mango-taxonomy.md)
+- ADR-011 Industry Taxonomy:
+  [`standards/decisions/ADR-011-industry-taxonomy.md`](decisions/ADR-011-industry-taxonomy.md)
+- Industry Taxonomy Standard:
+  [`standards/industry-taxonomy-standard.md`](industry-taxonomy-standard.md)
+- Voice/digital channels analysis:
+  [`docs/analysis/voice-digital-channels-comparison.md`](../docs/analysis/voice-digital-channels-comparison.md)
+- Issue #146 Mango Taxonomy audit:
+  [`docs/audit/issue-146-mango-taxonomy-validation.md`](../docs/audit/issue-146-mango-taxonomy-validation.md)
+- Issue #154:
+  <https://github.com/G-Ivan-A/mango_ba_prompts/issues/154>


### PR DESCRIPTION
## Summary

Fixes #154.

- Переводит ADR-012 в `status: canonical`, `version: 1.0` и связывает его с issue #154, ADR-011 canonical v1.0 и Industry Taxonomy Standard.
- Добавляет `standards/mango-taxonomy-standard.md`: двухслойная Official/Internal архитектура, Internal hierarchy `Product -> Service -> Module -> Function`, 8 кластеров, атрибуты уровней, `function_type`, Component -> Module, Operation -> Function, `maps_to.industry_alignment`, JSON Schema/YAML contract, validator contract, AI-agent contract и evolution process.
- Добавляет regression validator `scripts/validate_issue_154_mango_taxonomy_standard.py` и подключает его к `make kb-validate` и KB workflow.
- Обновляет `CHANGELOG.md` для Unreleased.

## Verification

Passed locally:

- `python3 scripts/validate_issue_154_mango_taxonomy_standard.py`
- `python3 -m py_compile scripts/validate_issue_154_mango_taxonomy_standard.py`
- `python3 scripts/validate_issue_146_mango_taxonomy.py`
- `python3 scripts/validate_issue_148_taxonomy_extensions.py`
- `python3 scripts/validate_issue_152_industry_taxonomy_standard.py`
- embedded `MangoTaxonomyDocument` JSON Schema parse check
- `git diff --check`
- `node scripts/generate-pages-data.mjs`

Full local `make kb-validate` was attempted and saved to `/tmp/issue154-kb-validate.log`; it stops at existing issue #131 validation because this local checkout has Git LFS pointer files instead of PDF bytes. The KB workflow uses `actions/checkout` with `lfs: true`, so CI should exercise the full validator set with real PDF contents.

## Notes

Issue #154 references an attached ADR-012 agreement summary, but no attachment URL/file was available through the issue body, issue comments, timeline, checkout, or repository code search. The source limitation is documented in the new standard so a future attachment can be reconciled with an explicit decision diff.
