### PR TITLE
data: создать реестр Industry Taxonomy

### DIFF
--- a/.github/workflows/kb.yml
+++ b/.github/workflows/kb.yml
@@ -18,6 +18,7 @@ on:
       - "Makefile"
       - "docs/audit/issue-144-kb-structure.md"
       - "kb/README.md"
+      - "kb/industry/**"
       - "kb/fragments/README.md"
       - "kb/practices/**"
       - "kb/mango-product-docs/README.md"
@@ -25,6 +26,7 @@ on:
       - "kb/mango-product-docs/sources/**"
       - "scripts/kb/**"
       - "scripts/validate_issue_*_kb*.py"
+      - "scripts/validate_issue_156_industry_taxonomy_registry.py"
   workflow_dispatch:
     inputs:
       source_dir:
@@ -114,6 +116,9 @@ jobs:
 
       - name: Validate issue #154 Mango Taxonomy standard
         run: python3 scripts/validate_issue_154_mango_taxonomy_standard.py
+
+      - name: Validate issue #156 Industry Taxonomy registry
+        run: python3 scripts/validate_issue_156_industry_taxonomy_registry.py
 
   # Тяжёлый сквозной прогон извлечения.
   # На workflow_dispatch выполняет выбранный source. На push в main всегда

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-21T19:04:57.732Z for PR creation at branch issue-156-62fe689b92d5 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/156

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-21T19:04:57.732Z for PR creation at branch issue-156-62fe689b92d5 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/156

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,25 @@ ai-generated: true
   [`scripts/validate_issue_154_mango_taxonomy_standard.py`](scripts/validate_issue_154_mango_taxonomy_standard.py),
   подключённая к `make kb-validate` и KB workflow.
 
+### Added — Issue #156 реестр Industry Taxonomy
+
+- Добавлен machine-readable реестр
+  [`kb/industry/reference-taxonomy.json`](kb/industry/reference-taxonomy.json):
+  зафиксированы семь canonical domains ADR-011, cross-domain layer `platform`,
+  capabilities/features/functions, lifecycle статусы, `function_type`,
+  `evidence_refs` и cross-cutting facets включая `channel`.
+- Добавлены локальная schema
+  [`kb/industry/reference-taxonomy.schema.json`](kb/industry/reference-taxonomy.schema.json)
+  и README
+  [`kb/industry/README.md`](kb/industry/README.md) для namespace `kb/industry/`;
+  продуктовые Mango mappings в реестр не включались.
+- Добавлена регрессионная проверка
+  [`scripts/validate_issue_156_industry_taxonomy_registry.py`](scripts/validate_issue_156_industry_taxonomy_registry.py),
+  подключённая к `make kb-validate` и KB workflow.
+- Обновлена проверка Issue #144, чтобы root KB README больше не требовал
+  помечать `kb/industry/` как будущий namespace после добавления рабочего
+  Industry Taxonomy registry.
+
 ### Added — Issue #152 стандарт Industry Taxonomy
 
 - Добавлен формальный стандарт

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ kb-validate:
 	$(PYTHON) scripts/validate_issue_148_taxonomy_extensions.py
 	$(PYTHON) scripts/validate_issue_152_industry_taxonomy_standard.py
 	$(PYTHON) scripts/validate_issue_154_mango_taxonomy_standard.py
+	$(PYTHON) scripts/validate_issue_156_industry_taxonomy_registry.py
 
 # Наглядно: токены индекса vs отдельных разделов (метод — см. token_method).
 kb-tokens:

--- a/kb/README.md
+++ b/kb/README.md
@@ -1,7 +1,7 @@
 ---
 status: draft
 version: 0.2
-updated: 2026-06-20
+updated: 2026-06-21
 ai-generated: true
 type: kb-index
 scope: kb
@@ -9,11 +9,13 @@ related_artifacts:
   - "standards/kb-standard.md"
   - "docs/adr/007-kb-standard.md"
   - "kb/mango-product-docs/README.md"
+  - "kb/industry/README.md"
   - "docs/audit/issue-144-kb-structure.md"
 related_issues:
   - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/97"
   - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/111"
   - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/144"
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/156"
 ---
 
 # База знаний (KB)
@@ -36,7 +38,7 @@ KB регулируется [kb-standard.md](../standards/kb-standard.md) и
 | [`kb/mango-product-docs/`](mango-product-docs/README.md) | База знаний продуктов Mango Office: PDF/веб-источники, обработанные Markdown-чанки и инструкции использования. | Рабочий product-docs namespace |
 | [`kb/fragments/`](fragments/README.md) | Задел под атомарные фрагменты будущего векторного RAG; сейчас product-docs чанки живут в `kb/mango-product-docs/processed/`. | Оставить в `kb/`, не переносить в product-docs |
 | [`kb/practices/`](practices/README.md) | Ручные практики и методики анализа, не привязанные к конкретному продукту Mango Office. | Оставить в `kb/`, не переносить в product-docs |
-| `kb/industry/ (будущий)` | Industry Taxonomy: отраслевая классификация и справочники после утверждения стандарта. | Планируемый namespace |
+| [`kb/industry/`](industry/README.md) | Industry Taxonomy: machine-readable реестр отраслевой классификации `Domain -> Capability -> Feature -> Function`. | Рабочий industry namespace |
 | `kb/mango/ (будущий)` | Mango Taxonomy: корпоративная классификация продуктов и mapping к taxonomy. | Планируемый namespace |
 
 ## Как использовать?
@@ -111,6 +113,8 @@ RAG, `practices/` — ручные практики. Их не нужно пер
   читает извлечённую БЗ.
 - [`kb/mango-product-docs/UPLOAD-GUIDE.md`](mango-product-docs/UPLOAD-GUIDE.md) —
   как добавлять и обновлять документы.
+- [`kb/industry/README.md`](industry/README.md) — machine-readable Industry
+  Taxonomy registry.
 - [`docs/audit/issue-144-kb-structure.md`](../docs/audit/issue-144-kb-structure.md) —
   проверка истории `fragments/` и `practices/`.
 - [`docs/kb-experiment-report.md`](../docs/kb-experiment-report.md) —

--- a/kb/industry/README.md
+++ b/kb/industry/README.md
@@ -1,0 +1,110 @@
+---
+status: active
+version: 1.0.0
+updated: 2026-06-21
+ai-generated: true
+type: kb-industry-taxonomy
+scope: kb/industry
+related_artifacts:
+  - "kb/industry/reference-taxonomy.json"
+  - "kb/industry/reference-taxonomy.schema.json"
+  - "standards/decisions/ADR-011-industry-taxonomy.md"
+  - "standards/industry-taxonomy-standard.md"
+related_issues:
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/156"
+---
+
+# Industry Taxonomy
+
+`kb/industry/` хранит machine-readable Industry Taxonomy для отраслевой
+классификации коммуникационных, контакт-центровых и смежных capabilities.
+Реестр следует модели `Domain -> Capability -> Feature -> Function` из
+ADR-011 и стандарта Industry Taxonomy.
+
+## Артефакты
+
+| Файл | Назначение |
+| --- | --- |
+| [`kb/industry/reference-taxonomy.json`](reference-taxonomy.json) | Канонический JSON-реестр Industry Taxonomy v1.0.0. |
+| [`kb/industry/reference-taxonomy.schema.json`](reference-taxonomy.schema.json) | Локальная JSON Schema для структуры реестра и базовых enum-контрактов. |
+
+## Покрытие
+
+Реестр фиксирует семь canonical domains из ADR-011 v1.0:
+
+- `voice-ucaas`
+- `contact-center`
+- `digital-channels`
+- `ai-automation`
+- `analytics`
+- `hardware`
+- `security`
+
+`platform` вынесен отдельно как cross-domain layer, а не как восьмой domain.
+Он содержит общие capabilities: `platform-integration`, `open-api`, `cpaas`,
+`service-desk` и `vendor-support-services`.
+
+## Контракт данных
+
+Каждый taxonomy node содержит:
+
+- `id` — canonical slug;
+- `level` — один из `domain`, `capability`, `feature`, `function`;
+- `name_en` и `name_ru` — человекочитаемые названия;
+- `definition` — краткое определение;
+- `lifecycle_status` — `proposed`, `active`, `deprecated` или `removed`;
+- `evidence_refs` — ссылки на ADR, стандарт или источник decomposition;
+- `parent` — путь к родительским уровням для non-domain nodes.
+
+Каждый `function` дополнительно содержит `function_type`
+(`business`, `configuration`, `ui-action`) и список `parameters`.
+
+## Facets
+
+Cross-cutting facets хранятся отдельно от иерархии, чтобы не создавать
+дублирующие domain-ветки:
+
+- `channel` с полями `channel_kind`, `synchronicity`, `direction`;
+- `ai_assisted`;
+- `security_compliance`;
+- `commercial`;
+- `procurement`;
+- `industry_vertical`;
+- `geography_region`.
+
+`voice-channel` находится внутри `voice-ucaas` как first-class capability.
+`sip-connectivity` остаётся инфраструктурной capability и не получает channel
+facet, потому что SIP trunking не является пользовательским каналом.
+
+## Источники и границы
+
+Приоритет источников:
+
+1. [`standards/decisions/ADR-011-industry-taxonomy.md`](../../standards/decisions/ADR-011-industry-taxonomy.md)
+2. [`standards/industry-taxonomy-standard.md`](../../standards/industry-taxonomy-standard.md)
+3. [`docs/analysis/voice-digital-channels-comparison.md`](../../docs/analysis/voice-digital-channels-comparison.md)
+4. Reviewed Hub classification v3.0 и draft capability decomposition, указанные
+   в `sources` внутри JSON-реестра.
+
+Реестр не содержит Mango product mappings и не добавляет `industry_ref` для
+продуктовых документов. Такие связи должны появляться отдельно в Mango
+Taxonomy или mapping-артефактах.
+
+Некоторые functions помечены `source_status=derived-completion`: это leaf-level
+functions, добавленные для machine-readable полноты там, где источник называл
+feature, но не выделял отдельную function. Их lifecycle наследуется от
+родительской capability.
+
+## Проверка
+
+Лёгкая проверка Issue #156:
+
+```bash
+python3 scripts/validate_issue_156_industry_taxonomy_registry.py
+```
+
+Полный лёгкий KB-контур:
+
+```bash
+make kb-validate
+```

--- a/kb/industry/reference-taxonomy.json
+++ b/kb/industry/reference-taxonomy.json
@@ -1,0 +1,8263 @@
+{
+  "$schema": "reference-taxonomy.schema.json",
+  "taxonomy_id": "industry-taxonomy",
+  "schema_version": 1,
+  "version": "1.0.0",
+  "last_updated": "2026-06-21",
+  "status": "active",
+  "description": "Canonical machine-readable Industry Taxonomy registry for communications and contact-center analysis.",
+  "levels": [
+    "domain",
+    "capability",
+    "feature",
+    "function"
+  ],
+  "lifecycle_statuses": [
+    "proposed",
+    "active",
+    "deprecated",
+    "removed"
+  ],
+  "function_types": [
+    "business",
+    "configuration",
+    "ui-action"
+  ],
+  "sources": [
+    {
+      "id": "adr-011",
+      "path": "standards/decisions/ADR-011-industry-taxonomy.md",
+      "role": "canonical taxonomy decision"
+    },
+    {
+      "id": "industry-taxonomy-standard",
+      "path": "standards/industry-taxonomy-standard.md",
+      "role": "schema and governance contract"
+    },
+    {
+      "id": "voice-channel-analysis",
+      "path": "docs/analysis/voice-digital-channels-comparison.md",
+      "role": "channel asymmetry evidence"
+    },
+    {
+      "id": "hub-classification-v3",
+      "url": "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+      "role": "reviewed reference hierarchy baseline"
+    },
+    {
+      "id": "hub-capability-decomposition-2026-05",
+      "url": "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md",
+      "role": "draft decomposition evidence for proposed nodes"
+    }
+  ],
+  "registry_notes": [
+    "The seven canonical domains are exactly the ADR-011 v1.0 domains.",
+    "The platform node is modeled as a cross-domain layer, not as an eighth domain.",
+    "Functions marked source_status=derived-completion complete the machine-readable leaf layer when the reviewed source named a feature but not a separate function.",
+    "No Mango product mappings or product-specific industry_ref links are included in this registry."
+  ],
+  "facets": {
+    "channel": {
+      "description": "Cross-cutting channel characterization for features and functions.",
+      "allowed_values": {
+        "channel_kind": [
+          "voice",
+          "text",
+          "video"
+        ],
+        "synchronicity": [
+          "sync",
+          "async"
+        ],
+        "direction": [
+          "inbound",
+          "outbound",
+          "broadcast"
+        ]
+      }
+    },
+    "ai_assisted": {
+      "description": "Marks capabilities, features, or functions materially assisted by AI."
+    },
+    "security_compliance": {
+      "description": "Marks security, compliance, privacy, audit, or access-control relevance."
+    },
+    "commercial": {
+      "description": "Marks monetization, revenue, sales, pipeline, or campaign relevance."
+    },
+    "procurement": {
+      "description": "Marks buying, sourcing, vendor, or equipment-procurement relevance."
+    },
+    "industry_vertical": {
+      "description": "Optional vertical specialization without creating domain-specific forks."
+    },
+    "geography_region": {
+      "description": "Optional regional or regulatory specialization without changing canonical IDs."
+    }
+  },
+  "domains": [
+    {
+      "id": "voice-ucaas",
+      "level": "domain",
+      "name_en": "Voice UCaaS",
+      "name_ru": "Голосовая UCaaS",
+      "definition": "Cloud voice communications, virtual PBX, SIP connectivity, numbers, and unified voice collaboration services.",
+      "lifecycle_status": "active",
+      "evidence_refs": [
+        "standards/decisions/ADR-011-industry-taxonomy.md",
+        "standards/industry-taxonomy-standard.md",
+        "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+        "docs/analysis/voice-digital-channels-comparison.md"
+      ],
+      "capabilities": [
+        {
+          "id": "voice-channel",
+          "level": "capability",
+          "name_en": "Voice Channel",
+          "name_ru": "Голосовой канал",
+          "definition": "First-class voice channel capability for inbound, outbound, and broadcast voice interactions.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "docs/analysis/voice-digital-channels-comparison.md"
+          ],
+          "parent": {
+            "domain": "voice-ucaas"
+          },
+          "features": [
+            {
+              "id": "inbound-voice-call",
+              "level": "feature",
+              "name_en": "Inbound Voice Call",
+              "name_ru": "Входящий голосовой вызов",
+              "definition": "Feature of the Voice Channel capability covering inbound voice call.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "docs/analysis/voice-digital-channels-comparison.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "voice-channel"
+              },
+              "functions": [
+                {
+                  "id": "accept-inbound-voice-call",
+                  "level": "function",
+                  "name_en": "Accept Inbound Voice Call",
+                  "name_ru": "Accept Inbound Voice Call",
+                  "definition": "Executes the Inbound Voice Call feature within the Voice Channel capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "docs/analysis/voice-digital-channels-comparison.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "voice-channel",
+                    "feature": "inbound-voice-call"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "call_id",
+                      "description": "Canonical parameter `call_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "caller_number",
+                      "description": "Canonical parameter `caller_number` for configuring or executing this function."
+                    },
+                    {
+                      "name": "destination_number",
+                      "description": "Canonical parameter `destination_number` for configuring or executing this function."
+                    }
+                  ],
+                  "facets": {
+                    "channel": {
+                      "channel_kind": "voice",
+                      "synchronicity": "sync",
+                      "direction": "inbound"
+                    }
+                  }
+                }
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "inbound"
+                }
+              }
+            },
+            {
+              "id": "outbound-voice-call",
+              "level": "feature",
+              "name_en": "Outbound Voice Call",
+              "name_ru": "Исходящий голосовой вызов",
+              "definition": "Feature of the Voice Channel capability covering outbound voice call.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "docs/analysis/voice-digital-channels-comparison.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "voice-channel"
+              },
+              "functions": [
+                {
+                  "id": "initiate-outbound-voice-call",
+                  "level": "function",
+                  "name_en": "Initiate Outbound Voice Call",
+                  "name_ru": "Initiate Outbound Voice Call",
+                  "definition": "Executes the Outbound Voice Call feature within the Voice Channel capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "docs/analysis/voice-digital-channels-comparison.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "voice-channel",
+                    "feature": "outbound-voice-call"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "call_id",
+                      "description": "Canonical parameter `call_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "callee_number",
+                      "description": "Canonical parameter `callee_number` for configuring or executing this function."
+                    },
+                    {
+                      "name": "caller_id",
+                      "description": "Canonical parameter `caller_id` for configuring or executing this function."
+                    }
+                  ],
+                  "facets": {
+                    "channel": {
+                      "channel_kind": "voice",
+                      "synchronicity": "sync",
+                      "direction": "outbound"
+                    }
+                  }
+                }
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "outbound"
+                }
+              }
+            },
+            {
+              "id": "voice-broadcast",
+              "level": "feature",
+              "name_en": "Voice Broadcast",
+              "name_ru": "Голосовая рассылка",
+              "definition": "Feature of the Voice Channel capability covering voice broadcast.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "docs/analysis/voice-digital-channels-comparison.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "voice-channel"
+              },
+              "functions": [
+                {
+                  "id": "broadcast-voice-message",
+                  "level": "function",
+                  "name_en": "Broadcast Voice Message",
+                  "name_ru": "Broadcast Voice Message",
+                  "definition": "Executes the Voice Broadcast feature within the Voice Channel capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "docs/analysis/voice-digital-channels-comparison.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "voice-channel",
+                    "feature": "voice-broadcast"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "contact_list",
+                      "description": "Canonical parameter `contact_list` for configuring or executing this function."
+                    },
+                    {
+                      "name": "voice_template",
+                      "description": "Canonical parameter `voice_template` for configuring or executing this function."
+                    },
+                    {
+                      "name": "retry_policy",
+                      "description": "Canonical parameter `retry_policy` for configuring or executing this function."
+                    }
+                  ],
+                  "facets": {
+                    "channel": {
+                      "channel_kind": "voice",
+                      "synchronicity": "async",
+                      "direction": "broadcast"
+                    }
+                  }
+                }
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "async",
+                  "direction": "broadcast"
+                }
+              }
+            }
+          ],
+          "facets": {
+            "channel": {
+              "channel_kind": "voice",
+              "synchronicity": "sync",
+              "direction": "inbound"
+            }
+          }
+        },
+        {
+          "id": "cloud-pbx",
+          "level": "capability",
+          "name_en": "Cloud PBX",
+          "name_ru": "Облачная АТС",
+          "definition": "Virtual PBX configuration and call-control capabilities for business telephony.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "voice-ucaas"
+          },
+          "features": [
+            {
+              "id": "extension-management",
+              "level": "feature",
+              "name_en": "Extension Management",
+              "name_ru": "Extension Management",
+              "definition": "Feature of the Cloud PBX capability covering extension management.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "cloud-pbx"
+              },
+              "functions": [
+                {
+                  "id": "extension-provisioning",
+                  "level": "function",
+                  "name_en": "Extension Provisioning",
+                  "name_ru": "Extension Provisioning",
+                  "definition": "Executes the Extension Management feature within the Cloud PBX capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "cloud-pbx",
+                    "feature": "extension-management"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "extension_range",
+                      "description": "Canonical parameter `extension_range` for configuring or executing this function."
+                    },
+                    {
+                      "name": "sip_profile",
+                      "description": "Canonical parameter `sip_profile` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "call-routing-rules",
+              "level": "feature",
+              "name_en": "Call Routing Rules",
+              "name_ru": "Правила маршрутизации звонков",
+              "definition": "Feature of the Cloud PBX capability covering call routing rules.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "cloud-pbx"
+              },
+              "functions": [
+                {
+                  "id": "auto-attendant",
+                  "level": "function",
+                  "name_en": "Auto Attendant",
+                  "name_ru": "Auto Attendant",
+                  "definition": "Executes the Call Routing Rules feature within the Cloud PBX capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "cloud-pbx",
+                    "feature": "call-routing-rules"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "greeting_set",
+                      "description": "Canonical parameter `greeting_set` for configuring or executing this function."
+                    },
+                    {
+                      "name": "routing_tree",
+                      "description": "Canonical parameter `routing_tree` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "working-hours-schedule",
+              "level": "feature",
+              "name_en": "Working Hours Schedule",
+              "name_ru": "Working Hours Schedule",
+              "definition": "Feature of the Cloud PBX capability covering working hours schedule.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "cloud-pbx"
+              },
+              "functions": [
+                {
+                  "id": "working-hours-routing",
+                  "level": "function",
+                  "name_en": "Working Hours Routing",
+                  "name_ru": "Working Hours Routing",
+                  "definition": "Executes the Working Hours Schedule feature within the Cloud PBX capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "cloud-pbx",
+                    "feature": "working-hours-schedule"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "schedule_id",
+                      "description": "Canonical parameter `schedule_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "holiday_calendar",
+                      "description": "Canonical parameter `holiday_calendar` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "voicemail",
+              "level": "feature",
+              "name_en": "Voicemail",
+              "name_ru": "Voicemail",
+              "definition": "Feature of the Cloud PBX capability covering voicemail.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "cloud-pbx"
+              },
+              "functions": [
+                {
+                  "id": "voicemail-to-email",
+                  "level": "function",
+                  "name_en": "Voicemail To Email",
+                  "name_ru": "Voicemail To Email",
+                  "definition": "Executes the Voicemail feature within the Cloud PBX capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "cloud-pbx",
+                    "feature": "voicemail"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "mailbox_id",
+                      "description": "Canonical parameter `mailbox_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "delivery_format",
+                      "description": "Canonical parameter `delivery_format` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "sip-connectivity",
+          "level": "capability",
+          "name_en": "SIP Connectivity",
+          "name_ru": "SIP-подключение",
+          "definition": "SIP trunking, codec negotiation, and resilient routing capabilities.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "voice-ucaas"
+          },
+          "features": [
+            {
+              "id": "sip-trunking",
+              "level": "feature",
+              "name_en": "SIP Trunking",
+              "name_ru": "SIP-транк",
+              "definition": "Feature of the SIP Connectivity capability covering sip trunking.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "sip-connectivity"
+              },
+              "functions": [
+                {
+                  "id": "sip-trunk-registration",
+                  "level": "function",
+                  "name_en": "SIP Trunk Registration",
+                  "name_ru": "SIP Trunk Registration",
+                  "definition": "Executes the SIP Trunking feature within the SIP Connectivity capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "sip-connectivity",
+                    "feature": "sip-trunking"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "trunk_id",
+                      "description": "Canonical parameter `trunk_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "auth_credentials",
+                      "description": "Canonical parameter `auth_credentials` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "codec-negotiation",
+              "level": "feature",
+              "name_en": "Codec Negotiation",
+              "name_ru": "Codec Negotiation",
+              "definition": "Feature of the SIP Connectivity capability covering codec negotiation.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "sip-connectivity"
+              },
+              "functions": [
+                {
+                  "id": "codec-selection",
+                  "level": "function",
+                  "name_en": "Codec Selection",
+                  "name_ru": "Codec Selection",
+                  "definition": "Executes the Codec Negotiation feature within the SIP Connectivity capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "sip-connectivity",
+                    "feature": "codec-negotiation"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "codec_priority",
+                      "description": "Canonical parameter `codec_priority` for configuring or executing this function."
+                    },
+                    {
+                      "name": "dtmf_mode",
+                      "description": "Canonical parameter `dtmf_mode` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "failover-routing",
+              "level": "feature",
+              "name_en": "Failover Routing",
+              "name_ru": "Failover Routing",
+              "definition": "Feature of the SIP Connectivity capability covering failover routing.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "sip-connectivity"
+              },
+              "functions": [
+                {
+                  "id": "trunk-failover",
+                  "level": "function",
+                  "name_en": "Trunk Failover",
+                  "name_ru": "Trunk Failover",
+                  "definition": "Executes the Failover Routing feature within the SIP Connectivity capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "sip-connectivity",
+                    "feature": "failover-routing"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "backup_trunk_id",
+                      "description": "Canonical parameter `backup_trunk_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "retry_interval",
+                      "description": "Canonical parameter `retry_interval` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "number-management",
+          "level": "capability",
+          "name_en": "Number Management",
+          "name_ru": "Управление номерами",
+          "definition": "Provisioning, assignment, routing, and porting of telephone numbers.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "voice-ucaas"
+          },
+          "features": [
+            {
+              "id": "virtual-numbers",
+              "level": "feature",
+              "name_en": "Virtual Numbers",
+              "name_ru": "Virtual Numbers",
+              "definition": "Feature of the Number Management capability covering virtual numbers.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "number-management"
+              },
+              "functions": [
+                {
+                  "id": "number-assignment",
+                  "level": "function",
+                  "name_en": "Number Assignment",
+                  "name_ru": "Number Assignment",
+                  "definition": "Executes the Virtual Numbers feature within the Number Management capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "number-management",
+                    "feature": "virtual-numbers"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "number_type",
+                      "description": "Canonical parameter `number_type` for configuring or executing this function."
+                    },
+                    {
+                      "name": "region_code",
+                      "description": "Canonical parameter `region_code` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "toll-free-8800",
+              "level": "feature",
+              "name_en": "Toll Free 8800",
+              "name_ru": "Toll Free 8800",
+              "definition": "Feature of the Number Management capability covering toll free 8800.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "number-management"
+              },
+              "functions": [
+                {
+                  "id": "tollfree-routing",
+                  "level": "function",
+                  "name_en": "Tollfree Routing",
+                  "name_ru": "Tollfree Routing",
+                  "definition": "Executes the Toll Free 8800 feature within the Number Management capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "number-management",
+                    "feature": "toll-free-8800"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "number_8800",
+                      "description": "Canonical parameter `number_8800` for configuring or executing this function."
+                    },
+                    {
+                      "name": "destination_map",
+                      "description": "Canonical parameter `destination_map` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "mobile-numbers",
+              "level": "feature",
+              "name_en": "Mobile Numbers",
+              "name_ru": "Mobile Numbers",
+              "definition": "Feature of the Number Management capability covering mobile numbers.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "number-management"
+              },
+              "functions": [
+                {
+                  "id": "mobile-number-assignment",
+                  "level": "function",
+                  "name_en": "Mobile Number Assignment",
+                  "name_ru": "Mobile Number Assignment",
+                  "definition": "Executes the Mobile Numbers feature within the Number Management capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "number-management",
+                    "feature": "mobile-numbers"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "number_type",
+                      "description": "Canonical parameter `number_type` for configuring or executing this function."
+                    },
+                    {
+                      "name": "region_code",
+                      "description": "Canonical parameter `region_code` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "number-porting",
+              "level": "feature",
+              "name_en": "Number Porting",
+              "name_ru": "Number Porting",
+              "definition": "Feature of the Number Management capability covering number porting.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "number-management"
+              },
+              "functions": [
+                {
+                  "id": "number-porting",
+                  "level": "function",
+                  "name_en": "Number Porting",
+                  "name_ru": "Number Porting",
+                  "definition": "Executes the Number Porting feature within the Number Management capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "number-management",
+                    "feature": "number-porting"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "donor_operator",
+                      "description": "Canonical parameter `donor_operator` for configuring or executing this function."
+                    },
+                    {
+                      "name": "port_window",
+                      "description": "Canonical parameter `port_window` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "ivr-voice-menu",
+          "level": "capability",
+          "name_en": "IVR Voice Menu",
+          "name_ru": "Голосовое меню IVR",
+          "definition": "Interactive voice response scenarios, greetings, and auto-secretary behavior.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "voice-ucaas"
+          },
+          "features": [
+            {
+              "id": "ivr-scenarios",
+              "level": "feature",
+              "name_en": "IVR Scenarios",
+              "name_ru": "Сценарии IVR",
+              "definition": "Feature of the IVR Voice Menu capability covering ivr scenarios.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "ivr-voice-menu"
+              },
+              "functions": [
+                {
+                  "id": "ivr-menu-navigation",
+                  "level": "function",
+                  "name_en": "IVR Menu Navigation",
+                  "name_ru": "IVR Menu Navigation",
+                  "definition": "Executes the IVR Scenarios feature within the IVR Voice Menu capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "ivr-voice-menu",
+                    "feature": "ivr-scenarios"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "menu_tree",
+                      "description": "Canonical parameter `menu_tree` for configuring or executing this function."
+                    },
+                    {
+                      "name": "timeout_action",
+                      "description": "Canonical parameter `timeout_action` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "auto-secretary",
+              "level": "feature",
+              "name_en": "Auto Secretary",
+              "name_ru": "Auto Secretary",
+              "definition": "Feature of the IVR Voice Menu capability covering auto secretary.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "ivr-voice-menu"
+              },
+              "functions": [
+                {
+                  "id": "auto-secretary-greeting",
+                  "level": "function",
+                  "name_en": "Auto Secretary Greeting",
+                  "name_ru": "Auto Secretary Greeting",
+                  "definition": "Executes the Auto Secretary feature within the IVR Voice Menu capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "ivr-voice-menu",
+                    "feature": "auto-secretary"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "greeting_id",
+                      "description": "Canonical parameter `greeting_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "dtmf_map",
+                      "description": "Canonical parameter `dtmf_map` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "voice-announcement",
+              "level": "feature",
+              "name_en": "Voice Announcement",
+              "name_ru": "Voice Announcement",
+              "definition": "Feature of the IVR Voice Menu capability covering voice announcement.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "ivr-voice-menu"
+              },
+              "functions": [
+                {
+                  "id": "service-availability-routing",
+                  "level": "function",
+                  "name_en": "Service Availability Routing",
+                  "name_ru": "Service Availability Routing",
+                  "definition": "Executes the Voice Announcement feature within the IVR Voice Menu capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "ivr-voice-menu",
+                    "feature": "voice-announcement"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "queue_id",
+                      "description": "Canonical parameter `queue_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "overflow_target",
+                      "description": "Canonical parameter `overflow_target` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "call-recording",
+          "level": "capability",
+          "name_en": "Call Recording",
+          "name_ru": "Запись звонков",
+          "definition": "Recording, logs, statistics, and controlled access for voice interactions.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "voice-ucaas"
+          },
+          "features": [
+            {
+              "id": "call-recording",
+              "level": "feature",
+              "name_en": "Call Recording",
+              "name_ru": "Call Recording",
+              "definition": "Feature of the Call Recording capability covering call recording.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "call-recording"
+              },
+              "functions": [
+                {
+                  "id": "call-recording-capture",
+                  "level": "function",
+                  "name_en": "Call Recording Capture",
+                  "name_ru": "Call Recording Capture",
+                  "definition": "Executes the Call Recording feature within the Call Recording capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "call-recording",
+                    "feature": "call-recording"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "retention_period",
+                      "description": "Canonical parameter `retention_period` for configuring or executing this function."
+                    },
+                    {
+                      "name": "storage_target",
+                      "description": "Canonical parameter `storage_target` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "call-log",
+              "level": "feature",
+              "name_en": "Call Log",
+              "name_ru": "Call Log",
+              "definition": "Feature of the Call Recording capability covering call log.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "call-recording"
+              },
+              "functions": [
+                {
+                  "id": "call-log-export",
+                  "level": "function",
+                  "name_en": "Call Log Export",
+                  "name_ru": "Call Log Export",
+                  "definition": "Executes the Call Log feature within the Call Recording capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "call-recording",
+                    "feature": "call-log"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "date_range",
+                      "description": "Canonical parameter `date_range` for configuring or executing this function."
+                    },
+                    {
+                      "name": "export_format",
+                      "description": "Canonical parameter `export_format` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "usage-statistics",
+              "level": "feature",
+              "name_en": "Usage Statistics",
+              "name_ru": "Usage Statistics",
+              "definition": "Feature of the Call Recording capability covering usage statistics.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "call-recording"
+              },
+              "functions": [
+                {
+                  "id": "voice-usage-statistics",
+                  "level": "function",
+                  "name_en": "Voice Usage Statistics",
+                  "name_ru": "Voice Usage Statistics",
+                  "definition": "Executes the Usage Statistics feature within the Call Recording capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "call-recording",
+                    "feature": "usage-statistics"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "date_range",
+                      "description": "Canonical parameter `date_range` for configuring or executing this function."
+                    },
+                    {
+                      "name": "aggregation_level",
+                      "description": "Canonical parameter `aggregation_level` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "callback",
+          "level": "capability",
+          "name_en": "Callback",
+          "name_ru": "Обратный звонок",
+          "definition": "Web callback requests, consent capture, and callback scheduling.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "voice-ucaas"
+          },
+          "features": [
+            {
+              "id": "web-callback-widget",
+              "level": "feature",
+              "name_en": "Web Callback Widget",
+              "name_ru": "Web Callback Widget",
+              "definition": "Feature of the Callback capability covering web callback widget.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "callback"
+              },
+              "functions": [
+                {
+                  "id": "callback-request-intake",
+                  "level": "function",
+                  "name_en": "Callback Request Intake",
+                  "name_ru": "Callback Request Intake",
+                  "definition": "Executes the Web Callback Widget feature within the Callback capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "callback",
+                    "feature": "web-callback-widget"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "widget_id",
+                      "description": "Canonical parameter `widget_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "consent_flag",
+                      "description": "Canonical parameter `consent_flag` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "consent-capture",
+              "level": "feature",
+              "name_en": "Consent Capture",
+              "name_ru": "Consent Capture",
+              "definition": "Feature of the Callback capability covering consent capture.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "callback"
+              },
+              "functions": [
+                {
+                  "id": "callback-consent-capture",
+                  "level": "function",
+                  "name_en": "Callback Consent Capture",
+                  "name_ru": "Callback Consent Capture",
+                  "definition": "Executes the Consent Capture feature within the Callback capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "callback",
+                    "feature": "consent-capture"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "consent_flag",
+                      "description": "Canonical parameter `consent_flag` for configuring or executing this function."
+                    },
+                    {
+                      "name": "consent_source",
+                      "description": "Canonical parameter `consent_source` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "callback-scheduling",
+              "level": "feature",
+              "name_en": "Callback Scheduling",
+              "name_ru": "Callback Scheduling",
+              "definition": "Feature of the Callback capability covering callback scheduling.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "callback"
+              },
+              "functions": [
+                {
+                  "id": "callback-scheduling",
+                  "level": "function",
+                  "name_en": "Callback Scheduling",
+                  "name_ru": "Callback Scheduling",
+                  "definition": "Executes the Callback Scheduling feature within the Callback capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "callback",
+                    "feature": "callback-scheduling"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "max_attempts",
+                      "description": "Canonical parameter `max_attempts` for configuring or executing this function."
+                    },
+                    {
+                      "name": "time_window",
+                      "description": "Canonical parameter `time_window` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "unified-communications",
+          "level": "capability",
+          "name_en": "Unified Communications",
+          "name_ru": "Унифицированные коммуникации",
+          "definition": "Softphone, internal messaging, presence, and related collaboration features.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "voice-ucaas"
+          },
+          "features": [
+            {
+              "id": "softphone",
+              "level": "feature",
+              "name_en": "Softphone",
+              "name_ru": "Softphone",
+              "definition": "Feature of the Unified Communications capability covering softphone.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "unified-communications"
+              },
+              "functions": [
+                {
+                  "id": "softphone-call",
+                  "level": "function",
+                  "name_en": "Softphone Call",
+                  "name_ru": "Softphone Call",
+                  "definition": "Executes the Softphone feature within the Unified Communications capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "unified-communications",
+                    "feature": "softphone"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "device_id",
+                      "description": "Canonical parameter `device_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "sip_account",
+                      "description": "Canonical parameter `sip_account` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "corporate-messaging",
+              "level": "feature",
+              "name_en": "Corporate Messaging",
+              "name_ru": "Corporate Messaging",
+              "definition": "Feature of the Unified Communications capability covering corporate messaging.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "unified-communications"
+              },
+              "functions": [
+                {
+                  "id": "corporate-chat",
+                  "level": "function",
+                  "name_en": "Corporate Chat",
+                  "name_ru": "Corporate Chat",
+                  "definition": "Executes the Corporate Messaging feature within the Unified Communications capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "unified-communications",
+                    "feature": "corporate-messaging"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "channel_id",
+                      "description": "Canonical parameter `channel_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "retention_period",
+                      "description": "Canonical parameter `retention_period` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "presence-status",
+              "level": "feature",
+              "name_en": "Presence Status",
+              "name_ru": "Presence Status",
+              "definition": "Feature of the Unified Communications capability covering presence status.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "unified-communications"
+              },
+              "functions": [
+                {
+                  "id": "presence-update",
+                  "level": "function",
+                  "name_en": "Presence Update",
+                  "name_ru": "Presence Update",
+                  "definition": "Executes the Presence Status feature within the Unified Communications capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "unified-communications",
+                    "feature": "presence-status"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "status_code",
+                      "description": "Canonical parameter `status_code` for configuring or executing this function."
+                    },
+                    {
+                      "name": "visibility_scope",
+                      "description": "Canonical parameter `visibility_scope` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "video-conferencing",
+          "level": "capability",
+          "name_en": "Video Conferencing",
+          "name_ru": "Видеоконференции",
+          "definition": "Video meetings, recording, and screen sharing.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "voice-ucaas"
+          },
+          "features": [
+            {
+              "id": "video-meetings",
+              "level": "feature",
+              "name_en": "Video Meetings",
+              "name_ru": "Video Meetings",
+              "definition": "Feature of the Video Conferencing capability covering video meetings.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "video-conferencing"
+              },
+              "functions": [
+                {
+                  "id": "meeting-host",
+                  "level": "function",
+                  "name_en": "Meeting Host",
+                  "name_ru": "Meeting Host",
+                  "definition": "Executes the Video Meetings feature within the Video Conferencing capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "video-conferencing",
+                    "feature": "video-meetings"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "max_participants",
+                      "description": "Canonical parameter `max_participants` for configuring or executing this function."
+                    },
+                    {
+                      "name": "meeting_id",
+                      "description": "Canonical parameter `meeting_id` for configuring or executing this function."
+                    }
+                  ],
+                  "facets": {
+                    "channel": {
+                      "channel_kind": "video",
+                      "synchronicity": "sync",
+                      "direction": "inbound"
+                    }
+                  }
+                }
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "video",
+                  "synchronicity": "sync",
+                  "direction": "inbound"
+                }
+              }
+            },
+            {
+              "id": "meeting-recording",
+              "level": "feature",
+              "name_en": "Meeting Recording",
+              "name_ru": "Meeting Recording",
+              "definition": "Feature of the Video Conferencing capability covering meeting recording.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "video-conferencing"
+              },
+              "functions": [
+                {
+                  "id": "meeting-recording",
+                  "level": "function",
+                  "name_en": "Meeting Recording",
+                  "name_ru": "Meeting Recording",
+                  "definition": "Executes the Meeting Recording feature within the Video Conferencing capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "video-conferencing",
+                    "feature": "meeting-recording"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "retention_period",
+                      "description": "Canonical parameter `retention_period` for configuring or executing this function."
+                    },
+                    {
+                      "name": "consent_flag",
+                      "description": "Canonical parameter `consent_flag` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "screen-sharing",
+              "level": "feature",
+              "name_en": "Screen Sharing",
+              "name_ru": "Screen Sharing",
+              "definition": "Feature of the Video Conferencing capability covering screen sharing.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "video-conferencing"
+              },
+              "functions": [
+                {
+                  "id": "screen-share",
+                  "level": "function",
+                  "name_en": "Screen Share",
+                  "name_ru": "Screen Share",
+                  "definition": "Executes the Screen Sharing feature within the Video Conferencing capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "video-conferencing",
+                    "feature": "screen-sharing"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "session_id",
+                      "description": "Canonical parameter `session_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "quality_profile",
+                      "description": "Canonical parameter `quality_profile` for configuring or executing this function."
+                    }
+                  ],
+                  "facets": {
+                    "channel": {
+                      "channel_kind": "video",
+                      "synchronicity": "sync",
+                      "direction": "inbound"
+                    }
+                  }
+                }
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "video",
+                  "synchronicity": "sync",
+                  "direction": "inbound"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "number-branding",
+          "level": "capability",
+          "name_en": "Number Branding",
+          "name_ru": "Брендирование номеров",
+          "definition": "Number labeling, rotation, and reachability protection patterns that may vary by market.",
+          "lifecycle_status": "proposed",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "voice-ucaas"
+          },
+          "features": [
+            {
+              "id": "number-labeling",
+              "level": "feature",
+              "name_en": "Number Labeling",
+              "name_ru": "Number Labeling",
+              "definition": "Feature of the Number Branding capability covering number labeling.",
+              "lifecycle_status": "proposed",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "number-branding"
+              },
+              "functions": [
+                {
+                  "id": "caller-id-labeling",
+                  "level": "function",
+                  "name_en": "Caller Id Labeling",
+                  "name_ru": "Caller Id Labeling",
+                  "definition": "Executes the Number Labeling feature within the Number Branding capability.",
+                  "lifecycle_status": "proposed",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "number-branding",
+                    "feature": "number-labeling"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "brand_label",
+                      "description": "Canonical parameter `brand_label` for configuring or executing this function."
+                    },
+                    {
+                      "name": "aggregator_id",
+                      "description": "Canonical parameter `aggregator_id` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "carousel-numbers",
+              "level": "feature",
+              "name_en": "Carousel Numbers",
+              "name_ru": "Carousel Numbers",
+              "definition": "Feature of the Number Branding capability covering carousel numbers.",
+              "lifecycle_status": "proposed",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "number-branding"
+              },
+              "functions": [
+                {
+                  "id": "carousel-number-rotation",
+                  "level": "function",
+                  "name_en": "Carousel Number Rotation",
+                  "name_ru": "Carousel Number Rotation",
+                  "definition": "Executes the Carousel Numbers feature within the Number Branding capability.",
+                  "lifecycle_status": "proposed",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "number-branding",
+                    "feature": "carousel-numbers"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "number_pool",
+                      "description": "Canonical parameter `number_pool` for configuring or executing this function."
+                    },
+                    {
+                      "name": "rotation_policy",
+                      "description": "Canonical parameter `rotation_policy` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "reachability-protection",
+              "level": "feature",
+              "name_en": "Reachability Protection",
+              "name_ru": "Reachability Protection",
+              "definition": "Feature of the Number Branding capability covering reachability protection.",
+              "lifecycle_status": "proposed",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "number-branding"
+              },
+              "functions": [
+                {
+                  "id": "reachability-monitoring",
+                  "level": "function",
+                  "name_en": "Reachability Monitoring",
+                  "name_ru": "Reachability Monitoring",
+                  "definition": "Executes the Reachability Protection feature within the Number Branding capability.",
+                  "lifecycle_status": "proposed",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "number-branding",
+                    "feature": "reachability-protection"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "spam_score_threshold",
+                      "description": "Canonical parameter `spam_score_threshold` for configuring or executing this function."
+                    },
+                    {
+                      "name": "alert_channel",
+                      "description": "Canonical parameter `alert_channel` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "anti-spam-marking",
+              "level": "feature",
+              "name_en": "Anti Spam Marking",
+              "name_ru": "Anti Spam Marking",
+              "definition": "Feature of the Number Branding capability covering anti spam marking.",
+              "lifecycle_status": "proposed",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "number-branding"
+              },
+              "functions": [
+                {
+                  "id": "spam-marking-appeal",
+                  "level": "function",
+                  "name_en": "Spam Marking Appeal",
+                  "name_ru": "Spam Marking Appeal",
+                  "definition": "Executes the Anti Spam Marking feature within the Number Branding capability.",
+                  "lifecycle_status": "proposed",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "number-branding",
+                    "feature": "anti-spam-marking"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "number_id",
+                      "description": "Canonical parameter `number_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "appeal_reason",
+                      "description": "Canonical parameter `appeal_reason` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "source_status": "candidate-or-market-specific"
+        },
+        {
+          "id": "voice-sms-broadcast",
+          "level": "capability",
+          "name_en": "Voice and SMS Broadcast",
+          "name_ru": "Голосовые и SMS-рассылки",
+          "definition": "Outbound broadcast messaging and delivery-confirmation patterns.",
+          "lifecycle_status": "proposed",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "voice-ucaas"
+          },
+          "features": [
+            {
+              "id": "voice-campaign-broadcast",
+              "level": "feature",
+              "name_en": "Voice Campaign Broadcast",
+              "name_ru": "Voice Campaign Broadcast",
+              "definition": "Feature of the Voice SMS Broadcast capability covering voice campaign broadcast.",
+              "lifecycle_status": "proposed",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "voice-sms-broadcast"
+              },
+              "functions": [
+                {
+                  "id": "voice-message-broadcast",
+                  "level": "function",
+                  "name_en": "Voice Message Broadcast",
+                  "name_ru": "Voice Message Broadcast",
+                  "definition": "Executes the Voice Campaign Broadcast feature within the Voice SMS Broadcast capability.",
+                  "lifecycle_status": "proposed",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "voice-sms-broadcast",
+                    "feature": "voice-campaign-broadcast"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "contact_list",
+                      "description": "Canonical parameter `contact_list` for configuring or executing this function."
+                    },
+                    {
+                      "name": "voice_template",
+                      "description": "Canonical parameter `voice_template` for configuring or executing this function."
+                    }
+                  ],
+                  "facets": {
+                    "channel": {
+                      "channel_kind": "voice",
+                      "synchronicity": "async",
+                      "direction": "broadcast"
+                    }
+                  }
+                }
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "async",
+                  "direction": "broadcast"
+                }
+              }
+            },
+            {
+              "id": "auto-notification",
+              "level": "feature",
+              "name_en": "Auto Notification",
+              "name_ru": "Auto Notification",
+              "definition": "Feature of the Voice SMS Broadcast capability covering auto notification.",
+              "lifecycle_status": "proposed",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "voice-sms-broadcast"
+              },
+              "functions": [
+                {
+                  "id": "automated-notification-send",
+                  "level": "function",
+                  "name_en": "Automated Notification Send",
+                  "name_ru": "Automated Notification Send",
+                  "definition": "Executes the Auto Notification feature within the Voice SMS Broadcast capability.",
+                  "lifecycle_status": "proposed",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "voice-sms-broadcast",
+                    "feature": "auto-notification"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "notification_template",
+                      "description": "Canonical parameter `notification_template` for configuring or executing this function."
+                    },
+                    {
+                      "name": "contact_list",
+                      "description": "Canonical parameter `contact_list` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "delivery-confirmation",
+              "level": "feature",
+              "name_en": "Delivery Confirmation",
+              "name_ru": "Delivery Confirmation",
+              "definition": "Feature of the Voice SMS Broadcast capability covering delivery confirmation.",
+              "lifecycle_status": "proposed",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "voice-ucaas",
+                "capability": "voice-sms-broadcast"
+              },
+              "functions": [
+                {
+                  "id": "delivery-confirmation",
+                  "level": "function",
+                  "name_en": "Delivery Confirmation",
+                  "name_ru": "Delivery Confirmation",
+                  "definition": "Executes the Delivery Confirmation feature within the Voice SMS Broadcast capability.",
+                  "lifecycle_status": "proposed",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "voice-ucaas",
+                    "capability": "voice-sms-broadcast",
+                    "feature": "delivery-confirmation"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "dtmf_confirm",
+                      "description": "Canonical parameter `dtmf_confirm` for configuring or executing this function."
+                    },
+                    {
+                      "name": "retry_policy",
+                      "description": "Canonical parameter `retry_policy` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "source_status": "candidate-or-market-specific"
+        }
+      ]
+    },
+    {
+      "id": "contact-center",
+      "level": "domain",
+      "name_en": "Contact Center",
+      "name_ru": "Контакт-центр",
+      "definition": "Customer interaction operations, routing, agent workspaces, outbound campaigns, quality, workforce, and contact-center adjacent CRM workflows.",
+      "lifecycle_status": "active",
+      "evidence_refs": [
+        "standards/decisions/ADR-011-industry-taxonomy.md",
+        "standards/industry-taxonomy-standard.md",
+        "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+      ],
+      "capabilities": [
+        {
+          "id": "call-routing",
+          "level": "capability",
+          "name_en": "Call Routing",
+          "name_ru": "Маршрутизация обращений",
+          "definition": "Skill, queue, and overflow routing for contact-center interactions.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "contact-center"
+          },
+          "features": [
+            {
+              "id": "skill-based-routing",
+              "level": "feature",
+              "name_en": "Skill Based Routing",
+              "name_ru": "Skill Based Routing",
+              "definition": "Feature of the Call Routing capability covering skill based routing.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "call-routing"
+              },
+              "functions": [
+                {
+                  "id": "skill-based-routing",
+                  "level": "function",
+                  "name_en": "Skill Based Routing",
+                  "name_ru": "Skill Based Routing",
+                  "definition": "Executes the Skill Based Routing feature within the Call Routing capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "call-routing",
+                    "feature": "skill-based-routing"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "skill_group",
+                      "description": "Canonical parameter `skill_group` for configuring or executing this function."
+                    },
+                    {
+                      "name": "priority_weight",
+                      "description": "Canonical parameter `priority_weight` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "queue-management",
+              "level": "feature",
+              "name_en": "Queue Management",
+              "name_ru": "Queue Management",
+              "definition": "Feature of the Call Routing capability covering queue management.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "call-routing"
+              },
+              "functions": [
+                {
+                  "id": "queue-management",
+                  "level": "function",
+                  "name_en": "Queue Management",
+                  "name_ru": "Queue Management",
+                  "definition": "Executes the Queue Management feature within the Call Routing capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "call-routing",
+                    "feature": "queue-management"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "max_wait_time",
+                      "description": "Canonical parameter `max_wait_time` for configuring or executing this function."
+                    },
+                    {
+                      "name": "sla_threshold",
+                      "description": "Canonical parameter `sla_threshold` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "overflow-rules",
+              "level": "feature",
+              "name_en": "Overflow Rules",
+              "name_ru": "Overflow Rules",
+              "definition": "Feature of the Call Routing capability covering overflow rules.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "call-routing"
+              },
+              "functions": [
+                {
+                  "id": "overflow-routing",
+                  "level": "function",
+                  "name_en": "Overflow Routing",
+                  "name_ru": "Overflow Routing",
+                  "definition": "Executes the Overflow Rules feature within the Call Routing capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "call-routing",
+                    "feature": "overflow-rules"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "overflow_target",
+                      "description": "Canonical parameter `overflow_target` for configuring or executing this function."
+                    },
+                    {
+                      "name": "abandon_threshold",
+                      "description": "Canonical parameter `abandon_threshold` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "omnichannel-contact-center",
+          "level": "capability",
+          "name_en": "Omnichannel Contact Center",
+          "name_ru": "Омниканальный контакт-центр",
+          "definition": "Unified contact-center handling across voice and digital channels.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "contact-center"
+          },
+          "features": [
+            {
+              "id": "inbound-handling",
+              "level": "feature",
+              "name_en": "Inbound Handling",
+              "name_ru": "Inbound Handling",
+              "definition": "Feature of the Omnichannel Contact Center capability covering inbound handling.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "omnichannel-contact-center"
+              },
+              "functions": [
+                {
+                  "id": "interaction-routing",
+                  "level": "function",
+                  "name_en": "Interaction Routing",
+                  "name_ru": "Interaction Routing",
+                  "definition": "Executes the Inbound Handling feature within the Omnichannel Contact Center capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "omnichannel-contact-center",
+                    "feature": "inbound-handling"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "channel_type",
+                      "description": "Canonical parameter `channel_type` for configuring or executing this function."
+                    },
+                    {
+                      "name": "routing_profile",
+                      "description": "Canonical parameter `routing_profile` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "omnichannel-desktop",
+              "level": "feature",
+              "name_en": "Omnichannel Desktop",
+              "name_ru": "Omnichannel Desktop",
+              "definition": "Feature of the Omnichannel Contact Center capability covering omnichannel desktop.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "omnichannel-contact-center"
+              },
+              "functions": [
+                {
+                  "id": "unified-agent-desktop",
+                  "level": "function",
+                  "name_en": "Unified Agent Desktop",
+                  "name_ru": "Unified Agent Desktop",
+                  "definition": "Executes the Omnichannel Desktop feature within the Omnichannel Contact Center capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "omnichannel-contact-center",
+                    "feature": "omnichannel-desktop"
+                  },
+                  "function_type": "ui-action",
+                  "parameters": [
+                    {
+                      "name": "layout_id",
+                      "description": "Canonical parameter `layout_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "channel_set",
+                      "description": "Canonical parameter `channel_set` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "channel-blending",
+              "level": "feature",
+              "name_en": "Channel Blending",
+              "name_ru": "Channel Blending",
+              "definition": "Feature of the Omnichannel Contact Center capability covering channel blending.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "omnichannel-contact-center"
+              },
+              "functions": [
+                {
+                  "id": "channel-blending",
+                  "level": "function",
+                  "name_en": "Channel Blending",
+                  "name_ru": "Channel Blending",
+                  "definition": "Executes the Channel Blending feature within the Omnichannel Contact Center capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "omnichannel-contact-center",
+                    "feature": "channel-blending"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "channel_set",
+                      "description": "Canonical parameter `channel_set` for configuring or executing this function."
+                    },
+                    {
+                      "name": "priority_policy",
+                      "description": "Canonical parameter `priority_policy` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "agent-workspace",
+          "level": "capability",
+          "name_en": "Agent Workspace",
+          "name_ru": "Рабочее место оператора",
+          "definition": "Agent desktop, customer context, and interaction history capabilities.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "contact-center"
+          },
+          "features": [
+            {
+              "id": "agent-desktop",
+              "level": "feature",
+              "name_en": "Agent Desktop",
+              "name_ru": "Рабочий стол оператора",
+              "definition": "Feature of the Agent Workspace capability covering agent desktop.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "agent-workspace"
+              },
+              "functions": [
+                {
+                  "id": "interaction-handling",
+                  "level": "function",
+                  "name_en": "Interaction Handling",
+                  "name_ru": "Interaction Handling",
+                  "definition": "Executes the Agent Desktop feature within the Agent Workspace capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "agent-workspace",
+                    "feature": "agent-desktop"
+                  },
+                  "function_type": "ui-action",
+                  "parameters": [
+                    {
+                      "name": "interaction_id",
+                      "description": "Canonical parameter `interaction_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "disposition_code",
+                      "description": "Canonical parameter `disposition_code` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "customer-card",
+              "level": "feature",
+              "name_en": "Customer Card",
+              "name_ru": "Customer Card",
+              "definition": "Feature of the Agent Workspace capability covering customer card.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "agent-workspace"
+              },
+              "functions": [
+                {
+                  "id": "customer-card-popup",
+                  "level": "function",
+                  "name_en": "Customer Card Popup",
+                  "name_ru": "Customer Card Popup",
+                  "definition": "Executes the Customer Card feature within the Agent Workspace capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "agent-workspace",
+                    "feature": "customer-card"
+                  },
+                  "function_type": "ui-action",
+                  "parameters": [
+                    {
+                      "name": "crm_lookup_key",
+                      "description": "Canonical parameter `crm_lookup_key` for configuring or executing this function."
+                    },
+                    {
+                      "name": "screen_pop_layout",
+                      "description": "Canonical parameter `screen_pop_layout` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "interaction-history",
+              "level": "feature",
+              "name_en": "Interaction History",
+              "name_ru": "Interaction History",
+              "definition": "Feature of the Agent Workspace capability covering interaction history.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "agent-workspace"
+              },
+              "functions": [
+                {
+                  "id": "interaction-history-view",
+                  "level": "function",
+                  "name_en": "Interaction History View",
+                  "name_ru": "Interaction History View",
+                  "definition": "Executes the Interaction History feature within the Agent Workspace capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "agent-workspace",
+                    "feature": "interaction-history"
+                  },
+                  "function_type": "ui-action",
+                  "parameters": [
+                    {
+                      "name": "customer_id",
+                      "description": "Canonical parameter `customer_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "history_window",
+                      "description": "Canonical parameter `history_window` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "outbound-calling",
+          "level": "capability",
+          "name_en": "Outbound Calling",
+          "name_ru": "Исходящие кампании",
+          "definition": "Campaign management, dialing modes, and outbound analytics.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "contact-center"
+          },
+          "features": [
+            {
+              "id": "campaign-management",
+              "level": "feature",
+              "name_en": "Campaign Management",
+              "name_ru": "Управление кампаниями",
+              "definition": "Feature of the Outbound Calling capability covering campaign management.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "outbound-calling"
+              },
+              "functions": [
+                {
+                  "id": "campaign-configuration",
+                  "level": "function",
+                  "name_en": "Campaign Configuration",
+                  "name_ru": "Campaign Configuration",
+                  "definition": "Executes the Campaign Management feature within the Outbound Calling capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "outbound-calling",
+                    "feature": "campaign-management"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "campaign_id",
+                      "description": "Canonical parameter `campaign_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "contact_list",
+                      "description": "Canonical parameter `contact_list` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "dialing-modes",
+              "level": "feature",
+              "name_en": "Dialing Modes",
+              "name_ru": "Dialing Modes",
+              "definition": "Feature of the Outbound Calling capability covering dialing modes.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "outbound-calling"
+              },
+              "functions": [
+                {
+                  "id": "predictive-dialing",
+                  "level": "function",
+                  "name_en": "Predictive Dialing",
+                  "name_ru": "Predictive Dialing",
+                  "definition": "Executes the Dialing Modes feature within the Outbound Calling capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "outbound-calling",
+                    "feature": "dialing-modes"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "dial_ratio",
+                      "description": "Canonical parameter `dial_ratio` for configuring or executing this function."
+                    },
+                    {
+                      "name": "abandon_rate_limit",
+                      "description": "Canonical parameter `abandon_rate_limit` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "realtime-analytics",
+              "level": "feature",
+              "name_en": "Realtime Analytics",
+              "name_ru": "Realtime Analytics",
+              "definition": "Feature of the Outbound Calling capability covering realtime analytics.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "outbound-calling"
+              },
+              "functions": [
+                {
+                  "id": "outbound-realtime-monitoring",
+                  "level": "function",
+                  "name_en": "Outbound Realtime Monitoring",
+                  "name_ru": "Outbound Realtime Monitoring",
+                  "definition": "Executes the Realtime Analytics feature within the Outbound Calling capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "outbound-calling",
+                    "feature": "realtime-analytics"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "campaign_id",
+                      "description": "Canonical parameter `campaign_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "metric_set",
+                      "description": "Canonical parameter `metric_set` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "historical-reports",
+              "level": "feature",
+              "name_en": "Historical Reports",
+              "name_ru": "Historical Reports",
+              "definition": "Feature of the Outbound Calling capability covering historical reports.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "outbound-calling"
+              },
+              "functions": [
+                {
+                  "id": "outbound-history-report",
+                  "level": "function",
+                  "name_en": "Outbound History Report",
+                  "name_ru": "Outbound History Report",
+                  "definition": "Executes the Historical Reports feature within the Outbound Calling capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "outbound-calling",
+                    "feature": "historical-reports"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "date_range",
+                      "description": "Canonical parameter `date_range` for configuring or executing this function."
+                    },
+                    {
+                      "name": "report_template",
+                      "description": "Canonical parameter `report_template` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "quality-management",
+          "level": "capability",
+          "name_en": "Quality Management",
+          "name_ru": "Управление качеством",
+          "definition": "Evaluation, scorecards, sampling, and appeal workflows.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "contact-center"
+          },
+          "features": [
+            {
+              "id": "scorecards",
+              "level": "feature",
+              "name_en": "Scorecards",
+              "name_ru": "Оценочные листы",
+              "definition": "Feature of the Quality Management capability covering scorecards.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "quality-management"
+              },
+              "functions": [
+                {
+                  "id": "scorecard-evaluation",
+                  "level": "function",
+                  "name_en": "Scorecard Evaluation",
+                  "name_ru": "Scorecard Evaluation",
+                  "definition": "Executes the Scorecards feature within the Quality Management capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "quality-management",
+                    "feature": "scorecards"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "checklist_id",
+                      "description": "Canonical parameter `checklist_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "sampling_rate",
+                      "description": "Canonical parameter `sampling_rate` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "call-sampling",
+              "level": "feature",
+              "name_en": "Call Sampling",
+              "name_ru": "Call Sampling",
+              "definition": "Feature of the Quality Management capability covering call sampling.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "quality-management"
+              },
+              "functions": [
+                {
+                  "id": "quality-call-sampling",
+                  "level": "function",
+                  "name_en": "Quality Call Sampling",
+                  "name_ru": "Quality Call Sampling",
+                  "definition": "Executes the Call Sampling feature within the Quality Management capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "quality-management",
+                    "feature": "call-sampling"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "sampling_rate",
+                      "description": "Canonical parameter `sampling_rate` for configuring or executing this function."
+                    },
+                    {
+                      "name": "filter_query",
+                      "description": "Canonical parameter `filter_query` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "evaluation-workflow",
+              "level": "feature",
+              "name_en": "Evaluation Workflow",
+              "name_ru": "Evaluation Workflow",
+              "definition": "Feature of the Quality Management capability covering evaluation workflow.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "quality-management"
+              },
+              "functions": [
+                {
+                  "id": "evaluation-appeal",
+                  "level": "function",
+                  "name_en": "Evaluation Appeal",
+                  "name_ru": "Evaluation Appeal",
+                  "definition": "Executes the Evaluation Workflow feature within the Quality Management capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "quality-management",
+                    "feature": "evaluation-workflow"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "case_id",
+                      "description": "Canonical parameter `case_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "reviewer_role",
+                      "description": "Canonical parameter `reviewer_role` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "workforce-management",
+          "level": "capability",
+          "name_en": "Workforce Management",
+          "name_ru": "Управление персоналом",
+          "definition": "Forecasting, scheduling, and adherence tracking for contact-center teams.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "contact-center"
+          },
+          "features": [
+            {
+              "id": "shift-scheduling",
+              "level": "feature",
+              "name_en": "Shift Scheduling",
+              "name_ru": "Shift Scheduling",
+              "definition": "Feature of the Workforce Management capability covering shift scheduling.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "workforce-management"
+              },
+              "functions": [
+                {
+                  "id": "shift-scheduling",
+                  "level": "function",
+                  "name_en": "Shift Scheduling",
+                  "name_ru": "Shift Scheduling",
+                  "definition": "Executes the Shift Scheduling feature within the Workforce Management capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "workforce-management",
+                    "feature": "shift-scheduling"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "agent_pool",
+                      "description": "Canonical parameter `agent_pool` for configuring or executing this function."
+                    },
+                    {
+                      "name": "coverage_target",
+                      "description": "Canonical parameter `coverage_target` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "load-forecasting",
+              "level": "feature",
+              "name_en": "Load Forecasting",
+              "name_ru": "Load Forecasting",
+              "definition": "Feature of the Workforce Management capability covering load forecasting.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "workforce-management"
+              },
+              "functions": [
+                {
+                  "id": "load-forecasting",
+                  "level": "function",
+                  "name_en": "Load Forecasting",
+                  "name_ru": "Load Forecasting",
+                  "definition": "Executes the Load Forecasting feature within the Workforce Management capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "workforce-management",
+                    "feature": "load-forecasting"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "history_window",
+                      "description": "Canonical parameter `history_window` for configuring or executing this function."
+                    },
+                    {
+                      "name": "forecast_horizon",
+                      "description": "Canonical parameter `forecast_horizon` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "adherence-tracking",
+              "level": "feature",
+              "name_en": "Adherence Tracking",
+              "name_ru": "Adherence Tracking",
+              "definition": "Feature of the Workforce Management capability covering adherence tracking.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "workforce-management"
+              },
+              "functions": [
+                {
+                  "id": "schedule-adherence-tracking",
+                  "level": "function",
+                  "name_en": "Schedule Adherence Tracking",
+                  "name_ru": "Schedule Adherence Tracking",
+                  "definition": "Executes the Adherence Tracking feature within the Workforce Management capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "workforce-management",
+                    "feature": "adherence-tracking"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "agent_id",
+                      "description": "Canonical parameter `agent_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "time_window",
+                      "description": "Canonical parameter `time_window` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "knowledge-base",
+          "level": "capability",
+          "name_en": "Knowledge Base",
+          "name_ru": "База знаний",
+          "definition": "Articles, scripts, and version control for agent guidance.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "contact-center"
+          },
+          "features": [
+            {
+              "id": "knowledge-articles",
+              "level": "feature",
+              "name_en": "Knowledge Articles",
+              "name_ru": "Knowledge Articles",
+              "definition": "Feature of the Knowledge Base capability covering knowledge articles.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "knowledge-base"
+              },
+              "functions": [
+                {
+                  "id": "article-lifecycle",
+                  "level": "function",
+                  "name_en": "Article Lifecycle",
+                  "name_ru": "Article Lifecycle",
+                  "definition": "Executes the Knowledge Articles feature within the Knowledge Base capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "knowledge-base",
+                    "feature": "knowledge-articles"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "article_id",
+                      "description": "Canonical parameter `article_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "review_status",
+                      "description": "Canonical parameter `review_status` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "agent-scripts",
+              "level": "feature",
+              "name_en": "Agent Scripts",
+              "name_ru": "Agent Scripts",
+              "definition": "Feature of the Knowledge Base capability covering agent scripts.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "knowledge-base"
+              },
+              "functions": [
+                {
+                  "id": "script-guidance",
+                  "level": "function",
+                  "name_en": "Script Guidance",
+                  "name_ru": "Script Guidance",
+                  "definition": "Executes the Agent Scripts feature within the Knowledge Base capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "knowledge-base",
+                    "feature": "agent-scripts"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "scenario_id",
+                      "description": "Canonical parameter `scenario_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "branching_rules",
+                      "description": "Canonical parameter `branching_rules` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "knowledge-version-control",
+              "level": "feature",
+              "name_en": "Knowledge Version Control",
+              "name_ru": "Knowledge Version Control",
+              "definition": "Feature of the Knowledge Base capability covering knowledge version control.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "knowledge-base"
+              },
+              "functions": [
+                {
+                  "id": "knowledge-version-control",
+                  "level": "function",
+                  "name_en": "Knowledge Version Control",
+                  "name_ru": "Knowledge Version Control",
+                  "definition": "Executes the Knowledge Version Control feature within the Knowledge Base capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "knowledge-base",
+                    "feature": "knowledge-version-control"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "article_id",
+                      "description": "Canonical parameter `article_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "version_label",
+                      "description": "Canonical parameter `version_label` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "deal-management",
+          "level": "capability",
+          "name_en": "Deal Management",
+          "name_ru": "Управление сделками",
+          "definition": "Pipeline, contact, and communication-history workflows adjacent to contact centers.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "contact-center"
+          },
+          "features": [
+            {
+              "id": "deal-pipeline",
+              "level": "feature",
+              "name_en": "Deal Pipeline",
+              "name_ru": "Deal Pipeline",
+              "definition": "Feature of the Deal Management capability covering deal pipeline.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "deal-management"
+              },
+              "functions": [
+                {
+                  "id": "deal-pipeline-tracking",
+                  "level": "function",
+                  "name_en": "Deal Pipeline Tracking",
+                  "name_ru": "Deal Pipeline Tracking",
+                  "definition": "Executes the Deal Pipeline feature within the Deal Management capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "deal-management",
+                    "feature": "deal-pipeline"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "pipeline_id",
+                      "description": "Canonical parameter `pipeline_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "stage_map",
+                      "description": "Canonical parameter `stage_map` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "contact-management",
+              "level": "feature",
+              "name_en": "Contact Management",
+              "name_ru": "Contact Management",
+              "definition": "Feature of the Deal Management capability covering contact management.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "deal-management"
+              },
+              "functions": [
+                {
+                  "id": "contact-record-management",
+                  "level": "function",
+                  "name_en": "Contact Record Management",
+                  "name_ru": "Contact Record Management",
+                  "definition": "Executes the Contact Management feature within the Deal Management capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "deal-management",
+                    "feature": "contact-management"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "contact_id",
+                      "description": "Canonical parameter `contact_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "field_schema",
+                      "description": "Canonical parameter `field_schema` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "communication-history",
+              "level": "feature",
+              "name_en": "Communication History",
+              "name_ru": "Communication History",
+              "definition": "Feature of the Deal Management capability covering communication history.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "deal-management"
+              },
+              "functions": [
+                {
+                  "id": "communication-logging",
+                  "level": "function",
+                  "name_en": "Communication Logging",
+                  "name_ru": "Communication Logging",
+                  "definition": "Executes the Communication History feature within the Deal Management capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "deal-management",
+                    "feature": "communication-history"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "contact_id",
+                      "description": "Canonical parameter `contact_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "channel_type",
+                      "description": "Canonical parameter `channel_type` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "facets": {
+            "commercial": {
+              "applicable": true
+            }
+          }
+        },
+        {
+          "id": "crm-platform",
+          "level": "capability",
+          "name_en": "CRM Platform",
+          "name_ru": "CRM-платформа",
+          "definition": "Core CRM records and sales automation adjacent to communications workflows.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "contact-center"
+          },
+          "features": [
+            {
+              "id": "crm-core",
+              "level": "feature",
+              "name_en": "CRM Core",
+              "name_ru": "CRM Core",
+              "definition": "Feature of the CRM Platform capability covering crm core.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "crm-platform"
+              },
+              "functions": [
+                {
+                  "id": "crm-record-management",
+                  "level": "function",
+                  "name_en": "CRM Record Management",
+                  "name_ru": "CRM Record Management",
+                  "definition": "Executes the CRM Core feature within the CRM Platform capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "crm-platform",
+                    "feature": "crm-core"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "entity_type",
+                      "description": "Canonical parameter `entity_type` for configuring or executing this function."
+                    },
+                    {
+                      "name": "field_schema",
+                      "description": "Canonical parameter `field_schema` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "sales-automation",
+              "level": "feature",
+              "name_en": "Sales Automation",
+              "name_ru": "Sales Automation",
+              "definition": "Feature of the CRM Platform capability covering sales automation.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "crm-platform"
+              },
+              "functions": [
+                {
+                  "id": "sales-automation-rule",
+                  "level": "function",
+                  "name_en": "Sales Automation Rule",
+                  "name_ru": "Sales Automation Rule",
+                  "definition": "Executes the Sales Automation feature within the CRM Platform capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "crm-platform",
+                    "feature": "sales-automation"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "trigger_event",
+                      "description": "Canonical parameter `trigger_event` for configuring or executing this function."
+                    },
+                    {
+                      "name": "action_set",
+                      "description": "Canonical parameter `action_set` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "facets": {
+            "commercial": {
+              "applicable": true
+            }
+          }
+        },
+        {
+          "id": "self-service-portal",
+          "level": "capability",
+          "name_en": "Self-Service Portal",
+          "name_ru": "Портал самообслуживания",
+          "definition": "Customer self-service, onboarding, recording access, and catalog selection.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "contact-center"
+          },
+          "features": [
+            {
+              "id": "customer-portal",
+              "level": "feature",
+              "name_en": "Customer Portal",
+              "name_ru": "Customer Portal",
+              "definition": "Feature of the Self Service Portal capability covering customer portal.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "self-service-portal"
+              },
+              "functions": [
+                {
+                  "id": "self-service-login",
+                  "level": "function",
+                  "name_en": "Self Service Login",
+                  "name_ru": "Self Service Login",
+                  "definition": "Executes the Customer Portal feature within the Self Service Portal capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "self-service-portal",
+                    "feature": "customer-portal"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "account_id",
+                      "description": "Canonical parameter `account_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "auth_method",
+                      "description": "Canonical parameter `auth_method` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "self-onboarding",
+              "level": "feature",
+              "name_en": "Self Onboarding",
+              "name_ru": "Self Onboarding",
+              "definition": "Feature of the Self Service Portal capability covering self onboarding.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "self-service-portal"
+              },
+              "functions": [
+                {
+                  "id": "self-onboarding-flow",
+                  "level": "function",
+                  "name_en": "Self Onboarding Flow",
+                  "name_ru": "Self Onboarding Flow",
+                  "definition": "Executes the Self Onboarding feature within the Self Service Portal capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "self-service-portal",
+                    "feature": "self-onboarding"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "account_id",
+                      "description": "Canonical parameter `account_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "approval_flow",
+                      "description": "Canonical parameter `approval_flow` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "recording-access",
+              "level": "feature",
+              "name_en": "Recording Access",
+              "name_ru": "Recording Access",
+              "definition": "Feature of the Self Service Portal capability covering recording access.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "self-service-portal"
+              },
+              "functions": [
+                {
+                  "id": "self-service-recording-access",
+                  "level": "function",
+                  "name_en": "Self Service Recording Access",
+                  "name_ru": "Self Service Recording Access",
+                  "definition": "Executes the Recording Access feature within the Self Service Portal capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "self-service-portal",
+                    "feature": "recording-access"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "masking_policy",
+                      "description": "Canonical parameter `masking_policy` for configuring or executing this function."
+                    },
+                    {
+                      "name": "retention_period",
+                      "description": "Canonical parameter `retention_period` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "service-catalog-selection",
+              "level": "feature",
+              "name_en": "Service Catalog Selection",
+              "name_ru": "Service Catalog Selection",
+              "definition": "Feature of the Self Service Portal capability covering service catalog selection.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "self-service-portal"
+              },
+              "functions": [
+                {
+                  "id": "service-self-provisioning",
+                  "level": "function",
+                  "name_en": "Service Self Provisioning",
+                  "name_ru": "Service Self Provisioning",
+                  "definition": "Executes the Service Catalog Selection feature within the Self Service Portal capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "self-service-portal",
+                    "feature": "service-catalog-selection"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "catalog_item",
+                      "description": "Canonical parameter `catalog_item` for configuring or executing this function."
+                    },
+                    {
+                      "name": "approval_flow",
+                      "description": "Canonical parameter `approval_flow` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "operator-mobile-app",
+          "level": "capability",
+          "name_en": "Operator Mobile App",
+          "name_ru": "Мобильное приложение оператора",
+          "definition": "Mobile agent workspace, notifications, and offline-mode capabilities.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "contact-center"
+          },
+          "features": [
+            {
+              "id": "mobile-agent-desktop",
+              "level": "feature",
+              "name_en": "Mobile Agent Desktop",
+              "name_ru": "Mobile Agent Desktop",
+              "definition": "Feature of the Operator Mobile App capability covering mobile agent desktop.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "operator-mobile-app"
+              },
+              "functions": [
+                {
+                  "id": "mobile-interaction-handling",
+                  "level": "function",
+                  "name_en": "Mobile Interaction Handling",
+                  "name_ru": "Mobile Interaction Handling",
+                  "definition": "Executes the Mobile Agent Desktop feature within the Operator Mobile App capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "operator-mobile-app",
+                    "feature": "mobile-agent-desktop"
+                  },
+                  "function_type": "ui-action",
+                  "parameters": [
+                    {
+                      "name": "device_id",
+                      "description": "Canonical parameter `device_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "channel_set",
+                      "description": "Canonical parameter `channel_set` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "push-notifications",
+              "level": "feature",
+              "name_en": "Push Notifications",
+              "name_ru": "Push Notifications",
+              "definition": "Feature of the Operator Mobile App capability covering push notifications.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "operator-mobile-app"
+              },
+              "functions": [
+                {
+                  "id": "push-notification-delivery",
+                  "level": "function",
+                  "name_en": "Push Notification Delivery",
+                  "name_ru": "Push Notification Delivery",
+                  "definition": "Executes the Push Notifications feature within the Operator Mobile App capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "operator-mobile-app",
+                    "feature": "push-notifications"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "notification_type",
+                      "description": "Canonical parameter `notification_type` for configuring or executing this function."
+                    },
+                    {
+                      "name": "priority",
+                      "description": "Canonical parameter `priority` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "offline-mode",
+              "level": "feature",
+              "name_en": "Offline Mode",
+              "name_ru": "Offline Mode",
+              "definition": "Feature of the Operator Mobile App capability covering offline mode.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "operator-mobile-app"
+              },
+              "functions": [
+                {
+                  "id": "mobile-offline-sync",
+                  "level": "function",
+                  "name_en": "Mobile Offline Sync",
+                  "name_ru": "Mobile Offline Sync",
+                  "definition": "Executes the Offline Mode feature within the Operator Mobile App capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "operator-mobile-app",
+                    "feature": "offline-mode"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "device_id",
+                      "description": "Canonical parameter `device_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "sync_window",
+                      "description": "Canonical parameter `sync_window` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "agent-assist",
+          "level": "capability",
+          "name_en": "Agent Assist",
+          "name_ru": "Подсказки оператору",
+          "definition": "AI-assisted recommendations, guidance, and summaries for agents.",
+          "lifecycle_status": "proposed",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md"
+          ],
+          "parent": {
+            "domain": "contact-center"
+          },
+          "features": [
+            {
+              "id": "next-best-action",
+              "level": "feature",
+              "name_en": "Next Best Action",
+              "name_ru": "Next Best Action",
+              "definition": "Feature of the Agent Assist capability covering next best action.",
+              "lifecycle_status": "proposed",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "agent-assist"
+              },
+              "functions": [
+                {
+                  "id": "manage-next-best-action",
+                  "level": "function",
+                  "name_en": "Manage Next Best Action",
+                  "name_ru": "Manage Next Best Action",
+                  "definition": "Executes the Next Best Action feature within the Agent Assist capability.",
+                  "lifecycle_status": "proposed",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "agent-assist",
+                    "feature": "next-best-action"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "scope",
+                      "description": "Canonical parameter `scope` for configuring or executing this function."
+                    }
+                  ],
+                  "source_status": "derived-completion"
+                }
+              ]
+            },
+            {
+              "id": "realtime-agent-guidance",
+              "level": "feature",
+              "name_en": "Realtime Agent Guidance",
+              "name_ru": "Realtime Agent Guidance",
+              "definition": "Feature of the Agent Assist capability covering realtime agent guidance.",
+              "lifecycle_status": "proposed",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "agent-assist"
+              },
+              "functions": [
+                {
+                  "id": "manage-realtime-agent-guidance",
+                  "level": "function",
+                  "name_en": "Manage Realtime Agent Guidance",
+                  "name_ru": "Manage Realtime Agent Guidance",
+                  "definition": "Executes the Realtime Agent Guidance feature within the Agent Assist capability.",
+                  "lifecycle_status": "proposed",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "agent-assist",
+                    "feature": "realtime-agent-guidance"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "scope",
+                      "description": "Canonical parameter `scope` for configuring or executing this function."
+                    }
+                  ],
+                  "source_status": "derived-completion"
+                }
+              ]
+            },
+            {
+              "id": "conversation-summaries",
+              "level": "feature",
+              "name_en": "Conversation Summaries",
+              "name_ru": "Conversation Summaries",
+              "definition": "Feature of the Agent Assist capability covering conversation summaries.",
+              "lifecycle_status": "proposed",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "agent-assist"
+              },
+              "functions": [
+                {
+                  "id": "manage-conversation-summaries",
+                  "level": "function",
+                  "name_en": "Manage Conversation Summaries",
+                  "name_ru": "Manage Conversation Summaries",
+                  "definition": "Executes the Conversation Summaries feature within the Agent Assist capability.",
+                  "lifecycle_status": "proposed",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "agent-assist",
+                    "feature": "conversation-summaries"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "scope",
+                      "description": "Canonical parameter `scope` for configuring or executing this function."
+                    }
+                  ],
+                  "source_status": "derived-completion"
+                }
+              ]
+            }
+          ],
+          "facets": {
+            "ai_assisted": {
+              "applicable": true
+            }
+          },
+          "source_status": "candidate-or-market-specific"
+        },
+        {
+          "id": "supervisor-assist",
+          "level": "capability",
+          "name_en": "Supervisor Assist",
+          "name_ru": "Подсказки супервизору",
+          "definition": "AI-assisted monitoring, alerts, and intervention guidance for supervisors.",
+          "lifecycle_status": "proposed",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md"
+          ],
+          "parent": {
+            "domain": "contact-center"
+          },
+          "features": [
+            {
+              "id": "supervisor-alerting",
+              "level": "feature",
+              "name_en": "Supervisor Alerting",
+              "name_ru": "Supervisor Alerting",
+              "definition": "Feature of the Supervisor Assist capability covering supervisor alerting.",
+              "lifecycle_status": "proposed",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "supervisor-assist"
+              },
+              "functions": [
+                {
+                  "id": "manage-supervisor-alerting",
+                  "level": "function",
+                  "name_en": "Manage Supervisor Alerting",
+                  "name_ru": "Manage Supervisor Alerting",
+                  "definition": "Executes the Supervisor Alerting feature within the Supervisor Assist capability.",
+                  "lifecycle_status": "proposed",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "supervisor-assist",
+                    "feature": "supervisor-alerting"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "scope",
+                      "description": "Canonical parameter `scope` for configuring or executing this function."
+                    }
+                  ],
+                  "source_status": "derived-completion"
+                }
+              ]
+            },
+            {
+              "id": "live-monitoring",
+              "level": "feature",
+              "name_en": "Live Monitoring",
+              "name_ru": "Live Monitoring",
+              "definition": "Feature of the Supervisor Assist capability covering live monitoring.",
+              "lifecycle_status": "proposed",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "supervisor-assist"
+              },
+              "functions": [
+                {
+                  "id": "manage-live-monitoring",
+                  "level": "function",
+                  "name_en": "Manage Live Monitoring",
+                  "name_ru": "Manage Live Monitoring",
+                  "definition": "Executes the Live Monitoring feature within the Supervisor Assist capability.",
+                  "lifecycle_status": "proposed",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "supervisor-assist",
+                    "feature": "live-monitoring"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "scope",
+                      "description": "Canonical parameter `scope` for configuring or executing this function."
+                    }
+                  ],
+                  "source_status": "derived-completion"
+                }
+              ]
+            },
+            {
+              "id": "intervention-guidance",
+              "level": "feature",
+              "name_en": "Intervention Guidance",
+              "name_ru": "Intervention Guidance",
+              "definition": "Feature of the Supervisor Assist capability covering intervention guidance.",
+              "lifecycle_status": "proposed",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "supervisor-assist"
+              },
+              "functions": [
+                {
+                  "id": "manage-intervention-guidance",
+                  "level": "function",
+                  "name_en": "Manage Intervention Guidance",
+                  "name_ru": "Manage Intervention Guidance",
+                  "definition": "Executes the Intervention Guidance feature within the Supervisor Assist capability.",
+                  "lifecycle_status": "proposed",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "supervisor-assist",
+                    "feature": "intervention-guidance"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "scope",
+                      "description": "Canonical parameter `scope` for configuring or executing this function."
+                    }
+                  ],
+                  "source_status": "derived-completion"
+                }
+              ]
+            }
+          ],
+          "facets": {
+            "ai_assisted": {
+              "applicable": true
+            }
+          },
+          "source_status": "candidate-or-market-specific"
+        },
+        {
+          "id": "conversation-orchestration",
+          "level": "capability",
+          "name_en": "Conversation Orchestration",
+          "name_ru": "Оркестрация диалогов",
+          "definition": "Cross-channel state, journey, and handoff orchestration patterns proposed for future standardization.",
+          "lifecycle_status": "proposed",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md"
+          ],
+          "parent": {
+            "domain": "contact-center"
+          },
+          "features": [
+            {
+              "id": "journey-orchestration",
+              "level": "feature",
+              "name_en": "Journey Orchestration",
+              "name_ru": "Journey Orchestration",
+              "definition": "Feature of the Conversation Orchestration capability covering journey orchestration.",
+              "lifecycle_status": "proposed",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "conversation-orchestration"
+              },
+              "functions": [
+                {
+                  "id": "manage-journey-orchestration",
+                  "level": "function",
+                  "name_en": "Manage Journey Orchestration",
+                  "name_ru": "Manage Journey Orchestration",
+                  "definition": "Executes the Journey Orchestration feature within the Conversation Orchestration capability.",
+                  "lifecycle_status": "proposed",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "conversation-orchestration",
+                    "feature": "journey-orchestration"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "scope",
+                      "description": "Canonical parameter `scope` for configuring or executing this function."
+                    }
+                  ],
+                  "source_status": "derived-completion"
+                }
+              ]
+            },
+            {
+              "id": "dialog-state-management",
+              "level": "feature",
+              "name_en": "Dialog State Management",
+              "name_ru": "Dialog State Management",
+              "definition": "Feature of the Conversation Orchestration capability covering dialog state management.",
+              "lifecycle_status": "proposed",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "conversation-orchestration"
+              },
+              "functions": [
+                {
+                  "id": "manage-dialog-state-management",
+                  "level": "function",
+                  "name_en": "Manage Dialog State Management",
+                  "name_ru": "Manage Dialog State Management",
+                  "definition": "Executes the Dialog State Management feature within the Conversation Orchestration capability.",
+                  "lifecycle_status": "proposed",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "conversation-orchestration",
+                    "feature": "dialog-state-management"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "scope",
+                      "description": "Canonical parameter `scope` for configuring or executing this function."
+                    }
+                  ],
+                  "source_status": "derived-completion"
+                }
+              ]
+            },
+            {
+              "id": "cross-channel-handoff",
+              "level": "feature",
+              "name_en": "Cross Channel Handoff",
+              "name_ru": "Cross Channel Handoff",
+              "definition": "Feature of the Conversation Orchestration capability covering cross channel handoff.",
+              "lifecycle_status": "proposed",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md"
+              ],
+              "parent": {
+                "domain": "contact-center",
+                "capability": "conversation-orchestration"
+              },
+              "functions": [
+                {
+                  "id": "manage-cross-channel-handoff",
+                  "level": "function",
+                  "name_en": "Manage Cross Channel Handoff",
+                  "name_ru": "Manage Cross Channel Handoff",
+                  "definition": "Executes the Cross Channel Handoff feature within the Conversation Orchestration capability.",
+                  "lifecycle_status": "proposed",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/capability-decomposition-2026-05.md"
+                  ],
+                  "parent": {
+                    "domain": "contact-center",
+                    "capability": "conversation-orchestration",
+                    "feature": "cross-channel-handoff"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "scope",
+                      "description": "Canonical parameter `scope` for configuring or executing this function."
+                    }
+                  ],
+                  "source_status": "derived-completion"
+                }
+              ]
+            }
+          ],
+          "facets": {
+            "ai_assisted": {
+              "applicable": true
+            }
+          },
+          "source_status": "candidate-or-market-specific"
+        }
+      ]
+    },
+    {
+      "id": "digital-channels",
+      "level": "domain",
+      "name_en": "Digital Channels",
+      "name_ru": "Цифровые каналы",
+      "definition": "Text and digital customer communication channels such as SMS, messengers, email, web chat, and unified inboxes.",
+      "lifecycle_status": "active",
+      "evidence_refs": [
+        "standards/decisions/ADR-011-industry-taxonomy.md",
+        "standards/industry-taxonomy-standard.md",
+        "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+      ],
+      "capabilities": [
+        {
+          "id": "sms-messaging",
+          "level": "capability",
+          "name_en": "SMS Messaging",
+          "name_ru": "SMS-сообщения",
+          "definition": "Bulk, transactional, and consent-aware SMS messaging.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "digital-channels"
+          },
+          "features": [
+            {
+              "id": "bulk-sms",
+              "level": "feature",
+              "name_en": "Bulk SMS",
+              "name_ru": "Bulk SMS",
+              "definition": "Feature of the SMS Messaging capability covering bulk sms.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "digital-channels",
+                "capability": "sms-messaging"
+              },
+              "functions": [
+                {
+                  "id": "bulk-sms-dispatch",
+                  "level": "function",
+                  "name_en": "Bulk SMS Dispatch",
+                  "name_ru": "Bulk SMS Dispatch",
+                  "definition": "Executes the Bulk SMS feature within the SMS Messaging capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "digital-channels",
+                    "capability": "sms-messaging",
+                    "feature": "bulk-sms"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "contact_list",
+                      "description": "Canonical parameter `contact_list` for configuring or executing this function."
+                    },
+                    {
+                      "name": "message_template",
+                      "description": "Canonical parameter `message_template` for configuring or executing this function."
+                    }
+                  ],
+                  "facets": {
+                    "channel": {
+                      "channel_kind": "text",
+                      "synchronicity": "async",
+                      "direction": "broadcast"
+                    }
+                  }
+                }
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "broadcast"
+                }
+              }
+            },
+            {
+              "id": "transactional-sms",
+              "level": "feature",
+              "name_en": "Transactional SMS",
+              "name_ru": "Transactional SMS",
+              "definition": "Feature of the SMS Messaging capability covering transactional sms.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "digital-channels",
+                "capability": "sms-messaging"
+              },
+              "functions": [
+                {
+                  "id": "transactional-sms-send",
+                  "level": "function",
+                  "name_en": "Transactional SMS Send",
+                  "name_ru": "Transactional SMS Send",
+                  "definition": "Executes the Transactional SMS feature within the SMS Messaging capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "digital-channels",
+                    "capability": "sms-messaging",
+                    "feature": "transactional-sms"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "recipient_number",
+                      "description": "Canonical parameter `recipient_number` for configuring or executing this function."
+                    },
+                    {
+                      "name": "message_template",
+                      "description": "Canonical parameter `message_template` for configuring or executing this function."
+                    }
+                  ],
+                  "facets": {
+                    "channel": {
+                      "channel_kind": "text",
+                      "synchronicity": "async",
+                      "direction": "outbound"
+                    }
+                  }
+                }
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "outbound"
+                }
+              }
+            },
+            {
+              "id": "opt-out-management",
+              "level": "feature",
+              "name_en": "Opt Out Management",
+              "name_ru": "Opt Out Management",
+              "definition": "Feature of the SMS Messaging capability covering opt out management.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "digital-channels",
+                "capability": "sms-messaging"
+              },
+              "functions": [
+                {
+                  "id": "opt-out-handling",
+                  "level": "function",
+                  "name_en": "Opt Out Handling",
+                  "name_ru": "Opt Out Handling",
+                  "definition": "Executes the Opt Out Management feature within the SMS Messaging capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "digital-channels",
+                    "capability": "sms-messaging",
+                    "feature": "opt-out-management"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "subscriber_id",
+                      "description": "Canonical parameter `subscriber_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "opt_out_source",
+                      "description": "Canonical parameter `opt_out_source` for configuring or executing this function."
+                    }
+                  ],
+                  "facets": {
+                    "channel": {
+                      "channel_kind": "text",
+                      "synchronicity": "async",
+                      "direction": "inbound"
+                    }
+                  }
+                }
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "inbound"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "omnichannel-messaging",
+          "level": "capability",
+          "name_en": "Omnichannel Messaging",
+          "name_ru": "Омниканальные сообщения",
+          "definition": "Messenger, social, email, and unified inbox capabilities.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "digital-channels"
+          },
+          "features": [
+            {
+              "id": "messenger-integration",
+              "level": "feature",
+              "name_en": "Messenger Integration",
+              "name_ru": "Интеграция мессенджеров",
+              "definition": "Feature of the Omnichannel Messaging capability covering messenger integration.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "digital-channels",
+                "capability": "omnichannel-messaging"
+              },
+              "functions": [
+                {
+                  "id": "channel-ingestion",
+                  "level": "function",
+                  "name_en": "Channel Ingestion",
+                  "name_ru": "Channel Ingestion",
+                  "definition": "Executes the Messenger Integration feature within the Omnichannel Messaging capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "digital-channels",
+                    "capability": "omnichannel-messaging",
+                    "feature": "messenger-integration"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "channel_type",
+                      "description": "Canonical parameter `channel_type` for configuring or executing this function."
+                    },
+                    {
+                      "name": "integration_id",
+                      "description": "Canonical parameter `integration_id` for configuring or executing this function."
+                    }
+                  ],
+                  "facets": {
+                    "channel": {
+                      "channel_kind": "text",
+                      "synchronicity": "async",
+                      "direction": "inbound"
+                    }
+                  }
+                }
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "inbound"
+                }
+              }
+            },
+            {
+              "id": "social-channels",
+              "level": "feature",
+              "name_en": "Social Channels",
+              "name_ru": "Social Channels",
+              "definition": "Feature of the Omnichannel Messaging capability covering social channels.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "digital-channels",
+                "capability": "omnichannel-messaging"
+              },
+              "functions": [
+                {
+                  "id": "social-channel-ingestion",
+                  "level": "function",
+                  "name_en": "Social Channel Ingestion",
+                  "name_ru": "Social Channel Ingestion",
+                  "definition": "Executes the Social Channels feature within the Omnichannel Messaging capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "digital-channels",
+                    "capability": "omnichannel-messaging",
+                    "feature": "social-channels"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "channel_type",
+                      "description": "Canonical parameter `channel_type` for configuring or executing this function."
+                    },
+                    {
+                      "name": "integration_id",
+                      "description": "Canonical parameter `integration_id` for configuring or executing this function."
+                    }
+                  ],
+                  "facets": {
+                    "channel": {
+                      "channel_kind": "text",
+                      "synchronicity": "async",
+                      "direction": "inbound"
+                    }
+                  }
+                }
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "inbound"
+                }
+              }
+            },
+            {
+              "id": "email-channel",
+              "level": "feature",
+              "name_en": "Email Channel",
+              "name_ru": "Email Channel",
+              "definition": "Feature of the Omnichannel Messaging capability covering email channel.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "digital-channels",
+                "capability": "omnichannel-messaging"
+              },
+              "functions": [
+                {
+                  "id": "email-channel-ingestion",
+                  "level": "function",
+                  "name_en": "Email Channel Ingestion",
+                  "name_ru": "Email Channel Ingestion",
+                  "definition": "Executes the Email Channel feature within the Omnichannel Messaging capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "digital-channels",
+                    "capability": "omnichannel-messaging",
+                    "feature": "email-channel"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "mailbox_id",
+                      "description": "Canonical parameter `mailbox_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "routing_profile",
+                      "description": "Canonical parameter `routing_profile` for configuring or executing this function."
+                    }
+                  ],
+                  "facets": {
+                    "channel": {
+                      "channel_kind": "text",
+                      "synchronicity": "async",
+                      "direction": "inbound"
+                    }
+                  }
+                }
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "inbound"
+                }
+              }
+            },
+            {
+              "id": "unified-inbox",
+              "level": "feature",
+              "name_en": "Unified Inbox",
+              "name_ru": "Unified Inbox",
+              "definition": "Feature of the Omnichannel Messaging capability covering unified inbox.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "digital-channels",
+                "capability": "omnichannel-messaging"
+              },
+              "functions": [
+                {
+                  "id": "unified-inbox-routing",
+                  "level": "function",
+                  "name_en": "Unified Inbox Routing",
+                  "name_ru": "Unified Inbox Routing",
+                  "definition": "Executes the Unified Inbox feature within the Omnichannel Messaging capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "digital-channels",
+                    "capability": "omnichannel-messaging",
+                    "feature": "unified-inbox"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "inbox_id",
+                      "description": "Canonical parameter `inbox_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "routing_profile",
+                      "description": "Canonical parameter `routing_profile` for configuring or executing this function."
+                    }
+                  ],
+                  "facets": {
+                    "channel": {
+                      "channel_kind": "text",
+                      "synchronicity": "async",
+                      "direction": "inbound"
+                    }
+                  }
+                }
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "inbound"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "website-chat",
+          "level": "capability",
+          "name_en": "Website Chat",
+          "name_ru": "Чат на сайте",
+          "definition": "Web chat widgets, proactive invitations, and visitor tracking.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "digital-channels"
+          },
+          "features": [
+            {
+              "id": "chat-widget",
+              "level": "feature",
+              "name_en": "Chat Widget",
+              "name_ru": "Чат-виджет",
+              "definition": "Feature of the Website Chat capability covering chat widget.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "digital-channels",
+                "capability": "website-chat"
+              },
+              "functions": [
+                {
+                  "id": "chat-widget-embed",
+                  "level": "function",
+                  "name_en": "Chat Widget Embed",
+                  "name_ru": "Chat Widget Embed",
+                  "definition": "Executes the Chat Widget feature within the Website Chat capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "digital-channels",
+                    "capability": "website-chat",
+                    "feature": "chat-widget"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "widget_id",
+                      "description": "Canonical parameter `widget_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "site_id",
+                      "description": "Canonical parameter `site_id` for configuring or executing this function."
+                    }
+                  ],
+                  "facets": {
+                    "channel": {
+                      "channel_kind": "text",
+                      "synchronicity": "sync",
+                      "direction": "inbound"
+                    }
+                  }
+                }
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "sync",
+                  "direction": "inbound"
+                }
+              }
+            },
+            {
+              "id": "proactive-invitations",
+              "level": "feature",
+              "name_en": "Proactive Invitations",
+              "name_ru": "Proactive Invitations",
+              "definition": "Feature of the Website Chat capability covering proactive invitations.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "digital-channels",
+                "capability": "website-chat"
+              },
+              "functions": [
+                {
+                  "id": "proactive-chat-invite",
+                  "level": "function",
+                  "name_en": "Proactive Chat Invite",
+                  "name_ru": "Proactive Chat Invite",
+                  "definition": "Executes the Proactive Invitations feature within the Website Chat capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "digital-channels",
+                    "capability": "website-chat",
+                    "feature": "proactive-invitations"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "visitor_segment",
+                      "description": "Canonical parameter `visitor_segment` for configuring or executing this function."
+                    },
+                    {
+                      "name": "invite_rule",
+                      "description": "Canonical parameter `invite_rule` for configuring or executing this function."
+                    }
+                  ],
+                  "facets": {
+                    "channel": {
+                      "channel_kind": "text",
+                      "synchronicity": "sync",
+                      "direction": "outbound"
+                    }
+                  }
+                }
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "sync",
+                  "direction": "outbound"
+                }
+              }
+            },
+            {
+              "id": "visitor-tracking",
+              "level": "feature",
+              "name_en": "Visitor Tracking",
+              "name_ru": "Visitor Tracking",
+              "definition": "Feature of the Website Chat capability covering visitor tracking.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "digital-channels",
+                "capability": "website-chat"
+              },
+              "functions": [
+                {
+                  "id": "visitor-data-capture",
+                  "level": "function",
+                  "name_en": "Visitor Data Capture",
+                  "name_ru": "Visitor Data Capture",
+                  "definition": "Executes the Visitor Tracking feature within the Website Chat capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "digital-channels",
+                    "capability": "website-chat",
+                    "feature": "visitor-tracking"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "visitor_id",
+                      "description": "Canonical parameter `visitor_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "tracking_window",
+                      "description": "Canonical parameter `tracking_window` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "messenger-marketing",
+          "level": "capability",
+          "name_en": "Messenger Marketing",
+          "name_ru": "Маркетинг в мессенджерах",
+          "definition": "Template-based campaigns, broadcast lists, and opt-in management in messengers.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "digital-channels"
+          },
+          "features": [
+            {
+              "id": "campaign-templates",
+              "level": "feature",
+              "name_en": "Campaign Templates",
+              "name_ru": "Campaign Templates",
+              "definition": "Feature of the Messenger Marketing capability covering campaign templates.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "digital-channels",
+                "capability": "messenger-marketing"
+              },
+              "functions": [
+                {
+                  "id": "messenger-campaign-template",
+                  "level": "function",
+                  "name_en": "Messenger Campaign Template",
+                  "name_ru": "Messenger Campaign Template",
+                  "definition": "Executes the Campaign Templates feature within the Messenger Marketing capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "digital-channels",
+                    "capability": "messenger-marketing",
+                    "feature": "campaign-templates"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "template_id",
+                      "description": "Canonical parameter `template_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "approval_status",
+                      "description": "Canonical parameter `approval_status` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "broadcast-lists",
+              "level": "feature",
+              "name_en": "Broadcast Lists",
+              "name_ru": "Broadcast Lists",
+              "definition": "Feature of the Messenger Marketing capability covering broadcast lists.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "digital-channels",
+                "capability": "messenger-marketing"
+              },
+              "functions": [
+                {
+                  "id": "messenger-campaign-dispatch",
+                  "level": "function",
+                  "name_en": "Messenger Campaign Dispatch",
+                  "name_ru": "Messenger Campaign Dispatch",
+                  "definition": "Executes the Broadcast Lists feature within the Messenger Marketing capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "digital-channels",
+                    "capability": "messenger-marketing",
+                    "feature": "broadcast-lists"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "broadcast_list",
+                      "description": "Canonical parameter `broadcast_list` for configuring or executing this function."
+                    },
+                    {
+                      "name": "message_template",
+                      "description": "Canonical parameter `message_template` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "opt-in-management",
+              "level": "feature",
+              "name_en": "Opt In Management",
+              "name_ru": "Opt In Management",
+              "definition": "Feature of the Messenger Marketing capability covering opt in management.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "digital-channels",
+                "capability": "messenger-marketing"
+              },
+              "functions": [
+                {
+                  "id": "messenger-optin-management",
+                  "level": "function",
+                  "name_en": "Messenger Optin Management",
+                  "name_ru": "Messenger Optin Management",
+                  "definition": "Executes the Opt In Management feature within the Messenger Marketing capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "digital-channels",
+                    "capability": "messenger-marketing",
+                    "feature": "opt-in-management"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "subscriber_id",
+                      "description": "Canonical parameter `subscriber_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "opt_in_source",
+                      "description": "Canonical parameter `opt_in_source` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "facets": {
+            "commercial": {
+              "applicable": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "ai-automation",
+      "level": "domain",
+      "name_en": "AI Automation",
+      "name_ru": "AI-автоматизация",
+      "definition": "Bots, robotic process automation, speech analytics, and AI-assisted interaction automation capabilities.",
+      "lifecycle_status": "active",
+      "evidence_refs": [
+        "standards/decisions/ADR-011-industry-taxonomy.md",
+        "standards/industry-taxonomy-standard.md",
+        "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+      ],
+      "capabilities": [
+        {
+          "id": "chatbot",
+          "level": "capability",
+          "name_en": "Chatbot",
+          "name_ru": "Чат-бот",
+          "definition": "Text bot dialog, intent, and handoff capabilities.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "ai-automation"
+          },
+          "features": [
+            {
+              "id": "dialog-scenarios",
+              "level": "feature",
+              "name_en": "Dialog Scenarios",
+              "name_ru": "Dialog Scenarios",
+              "definition": "Feature of the Chatbot capability covering dialog scenarios.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "ai-automation",
+                "capability": "chatbot"
+              },
+              "functions": [
+                {
+                  "id": "dialog-scenario-execution",
+                  "level": "function",
+                  "name_en": "Dialog Scenario Execution",
+                  "name_ru": "Dialog Scenario Execution",
+                  "definition": "Executes the Dialog Scenarios feature within the Chatbot capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "ai-automation",
+                    "capability": "chatbot",
+                    "feature": "dialog-scenarios"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "scenario_id",
+                      "description": "Canonical parameter `scenario_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "context_payload",
+                      "description": "Canonical parameter `context_payload` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "intent-recognition",
+              "level": "feature",
+              "name_en": "Intent Recognition",
+              "name_ru": "Intent Recognition",
+              "definition": "Feature of the Chatbot capability covering intent recognition.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "ai-automation",
+                "capability": "chatbot"
+              },
+              "functions": [
+                {
+                  "id": "intent-classification",
+                  "level": "function",
+                  "name_en": "Intent Classification",
+                  "name_ru": "Intent Classification",
+                  "definition": "Executes the Intent Recognition feature within the Chatbot capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "ai-automation",
+                    "capability": "chatbot",
+                    "feature": "intent-recognition"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "utterance_text",
+                      "description": "Canonical parameter `utterance_text` for configuring or executing this function."
+                    },
+                    {
+                      "name": "intent_model",
+                      "description": "Canonical parameter `intent_model` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "agent-handoff",
+              "level": "feature",
+              "name_en": "Agent Handoff",
+              "name_ru": "Agent Handoff",
+              "definition": "Feature of the Chatbot capability covering agent handoff.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "ai-automation",
+                "capability": "chatbot"
+              },
+              "functions": [
+                {
+                  "id": "agent-handoff",
+                  "level": "function",
+                  "name_en": "Agent Handoff",
+                  "name_ru": "Agent Handoff",
+                  "definition": "Executes the Agent Handoff feature within the Chatbot capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "ai-automation",
+                    "capability": "chatbot",
+                    "feature": "agent-handoff"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "conversation_id",
+                      "description": "Canonical parameter `conversation_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "handoff_reason",
+                      "description": "Canonical parameter `handoff_reason` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "facets": {
+            "ai_assisted": {
+              "applicable": true
+            }
+          }
+        },
+        {
+          "id": "voice-bot",
+          "level": "capability",
+          "name_en": "Voice Bot",
+          "name_ru": "Голосовой бот",
+          "definition": "Speech recognition, voice dialog orchestration, and text-to-speech capabilities.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "ai-automation"
+          },
+          "features": [
+            {
+              "id": "speech-recognition",
+              "level": "feature",
+              "name_en": "Speech Recognition",
+              "name_ru": "Speech Recognition",
+              "definition": "Feature of the Voice Bot capability covering speech recognition.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "ai-automation",
+                "capability": "voice-bot"
+              },
+              "functions": [
+                {
+                  "id": "speech-to-text",
+                  "level": "function",
+                  "name_en": "Speech To Text",
+                  "name_ru": "Speech To Text",
+                  "definition": "Executes the Speech Recognition feature within the Voice Bot capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "ai-automation",
+                    "capability": "voice-bot",
+                    "feature": "speech-recognition"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "audio_stream",
+                      "description": "Canonical parameter `audio_stream` for configuring or executing this function."
+                    },
+                    {
+                      "name": "language_code",
+                      "description": "Canonical parameter `language_code` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "voice-dialog-orchestration",
+              "level": "feature",
+              "name_en": "Voice Dialog Orchestration",
+              "name_ru": "Voice Dialog Orchestration",
+              "definition": "Feature of the Voice Bot capability covering voice dialog orchestration.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "ai-automation",
+                "capability": "voice-bot"
+              },
+              "functions": [
+                {
+                  "id": "voice-dialog-flow",
+                  "level": "function",
+                  "name_en": "Voice Dialog Flow",
+                  "name_ru": "Voice Dialog Flow",
+                  "definition": "Executes the Voice Dialog Orchestration feature within the Voice Bot capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "ai-automation",
+                    "capability": "voice-bot",
+                    "feature": "voice-dialog-orchestration"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "scenario_id",
+                      "description": "Canonical parameter `scenario_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "dialog_state",
+                      "description": "Canonical parameter `dialog_state` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "tts-synthesis",
+              "level": "feature",
+              "name_en": "TTS Synthesis",
+              "name_ru": "TTS Synthesis",
+              "definition": "Feature of the Voice Bot capability covering tts synthesis.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "ai-automation",
+                "capability": "voice-bot"
+              },
+              "functions": [
+                {
+                  "id": "text-to-speech",
+                  "level": "function",
+                  "name_en": "Text To Speech",
+                  "name_ru": "Text To Speech",
+                  "definition": "Executes the TTS Synthesis feature within the Voice Bot capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "ai-automation",
+                    "capability": "voice-bot",
+                    "feature": "tts-synthesis"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "text_payload",
+                      "description": "Canonical parameter `text_payload` for configuring or executing this function."
+                    },
+                    {
+                      "name": "voice_profile",
+                      "description": "Canonical parameter `voice_profile` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "facets": {
+            "ai_assisted": {
+              "applicable": true
+            }
+          }
+        },
+        {
+          "id": "process-robot",
+          "level": "capability",
+          "name_en": "Process Robot",
+          "name_ru": "Процессный робот",
+          "definition": "Robotic action execution, orchestration, and audit logging.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "ai-automation"
+          },
+          "features": [
+            {
+              "id": "process-automation",
+              "level": "feature",
+              "name_en": "Process Automation",
+              "name_ru": "Process Automation",
+              "definition": "Feature of the Process Robot capability covering process automation.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "ai-automation",
+                "capability": "process-robot"
+              },
+              "functions": [
+                {
+                  "id": "automated-action-execution",
+                  "level": "function",
+                  "name_en": "Automated Action Execution",
+                  "name_ru": "Automated Action Execution",
+                  "definition": "Executes the Process Automation feature within the Process Robot capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "ai-automation",
+                    "capability": "process-robot",
+                    "feature": "process-automation"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "process_id",
+                      "description": "Canonical parameter `process_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "action_set",
+                      "description": "Canonical parameter `action_set` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "action-orchestration",
+              "level": "feature",
+              "name_en": "Action Orchestration",
+              "name_ru": "Action Orchestration",
+              "definition": "Feature of the Process Robot capability covering action orchestration.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "ai-automation",
+                "capability": "process-robot"
+              },
+              "functions": [
+                {
+                  "id": "action-orchestration",
+                  "level": "function",
+                  "name_en": "Action Orchestration",
+                  "name_ru": "Action Orchestration",
+                  "definition": "Executes the Action Orchestration feature within the Process Robot capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "ai-automation",
+                    "capability": "process-robot",
+                    "feature": "action-orchestration"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "workflow_id",
+                      "description": "Canonical parameter `workflow_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "action_set",
+                      "description": "Canonical parameter `action_set` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "action-audit-logging",
+              "level": "feature",
+              "name_en": "Action Audit Logging",
+              "name_ru": "Action Audit Logging",
+              "definition": "Feature of the Process Robot capability covering action audit logging.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "ai-automation",
+                "capability": "process-robot"
+              },
+              "functions": [
+                {
+                  "id": "action-audit-logging",
+                  "level": "function",
+                  "name_en": "Action Audit Logging",
+                  "name_ru": "Action Audit Logging",
+                  "definition": "Executes the Action Audit Logging feature within the Process Robot capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "ai-automation",
+                    "capability": "process-robot",
+                    "feature": "action-audit-logging"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "action_id",
+                      "description": "Canonical parameter `action_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "audit_context",
+                      "description": "Canonical parameter `audit_context` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "facets": {
+            "ai_assisted": {
+              "applicable": true
+            }
+          }
+        },
+        {
+          "id": "speech-analytics",
+          "level": "capability",
+          "name_en": "Speech Analytics",
+          "name_ru": "Речевая аналитика",
+          "definition": "Transcription, sentiment, and keyword detection on recorded or live speech.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "ai-automation"
+          },
+          "features": [
+            {
+              "id": "transcription",
+              "level": "feature",
+              "name_en": "Transcription",
+              "name_ru": "Транскрибация",
+              "definition": "Feature of the Speech Analytics capability covering transcription.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "ai-automation",
+                "capability": "speech-analytics"
+              },
+              "functions": [
+                {
+                  "id": "call-transcription",
+                  "level": "function",
+                  "name_en": "Call Transcription",
+                  "name_ru": "Call Transcription",
+                  "definition": "Executes the Transcription feature within the Speech Analytics capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "ai-automation",
+                    "capability": "speech-analytics",
+                    "feature": "transcription"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "recording_id",
+                      "description": "Canonical parameter `recording_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "language_code",
+                      "description": "Canonical parameter `language_code` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "sentiment-analysis",
+              "level": "feature",
+              "name_en": "Sentiment Analysis",
+              "name_ru": "Sentiment Analysis",
+              "definition": "Feature of the Speech Analytics capability covering sentiment analysis.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "ai-automation",
+                "capability": "speech-analytics"
+              },
+              "functions": [
+                {
+                  "id": "sentiment-scoring",
+                  "level": "function",
+                  "name_en": "Sentiment Scoring",
+                  "name_ru": "Sentiment Scoring",
+                  "definition": "Executes the Sentiment Analysis feature within the Speech Analytics capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "ai-automation",
+                    "capability": "speech-analytics",
+                    "feature": "sentiment-analysis"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "transcript_id",
+                      "description": "Canonical parameter `transcript_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "model_id",
+                      "description": "Canonical parameter `model_id` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "keyword-detection",
+              "level": "feature",
+              "name_en": "Keyword Detection",
+              "name_ru": "Keyword Detection",
+              "definition": "Feature of the Speech Analytics capability covering keyword detection.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "ai-automation",
+                "capability": "speech-analytics"
+              },
+              "functions": [
+                {
+                  "id": "keyword-spotting",
+                  "level": "function",
+                  "name_en": "Keyword Spotting",
+                  "name_ru": "Keyword Spotting",
+                  "definition": "Executes the Keyword Detection feature within the Speech Analytics capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "ai-automation",
+                    "capability": "speech-analytics",
+                    "feature": "keyword-detection"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "transcript_id",
+                      "description": "Canonical parameter `transcript_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "keyword_set",
+                      "description": "Canonical parameter `keyword_set` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "facets": {
+            "ai_assisted": {
+              "applicable": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "analytics",
+      "level": "domain",
+      "name_en": "Analytics",
+      "name_ru": "Аналитика",
+      "definition": "Attribution, tracking, multichannel, product, email, and market analytics capabilities.",
+      "lifecycle_status": "active",
+      "evidence_refs": [
+        "standards/decisions/ADR-011-industry-taxonomy.md",
+        "standards/industry-taxonomy-standard.md",
+        "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+      ],
+      "capabilities": [
+        {
+          "id": "call-tracking",
+          "level": "capability",
+          "name_en": "Call Tracking",
+          "name_ru": "Коллтрекинг",
+          "definition": "Dynamic number substitution, source attribution, and call analytics.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "analytics"
+          },
+          "features": [
+            {
+              "id": "dynamic-number-pool",
+              "level": "feature",
+              "name_en": "Dynamic Number Pool",
+              "name_ru": "Динамический пул номеров",
+              "definition": "Feature of the Call Tracking capability covering dynamic number pool.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "analytics",
+                "capability": "call-tracking"
+              },
+              "functions": [
+                {
+                  "id": "dynamic-number-substitution",
+                  "level": "function",
+                  "name_en": "Dynamic Number Substitution",
+                  "name_ru": "Dynamic Number Substitution",
+                  "definition": "Executes the Dynamic Number Pool feature within the Call Tracking capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "analytics",
+                    "capability": "call-tracking",
+                    "feature": "dynamic-number-pool"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "number_pool",
+                      "description": "Canonical parameter `number_pool` for configuring or executing this function."
+                    },
+                    {
+                      "name": "traffic_source",
+                      "description": "Canonical parameter `traffic_source` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "source-attribution",
+              "level": "feature",
+              "name_en": "Source Attribution",
+              "name_ru": "Source Attribution",
+              "definition": "Feature of the Call Tracking capability covering source attribution.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "analytics",
+                "capability": "call-tracking"
+              },
+              "functions": [
+                {
+                  "id": "source-attribution",
+                  "level": "function",
+                  "name_en": "Source Attribution",
+                  "name_ru": "Source Attribution",
+                  "definition": "Executes the Source Attribution feature within the Call Tracking capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "analytics",
+                    "capability": "call-tracking",
+                    "feature": "source-attribution"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "call_id",
+                      "description": "Canonical parameter `call_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "utm_source",
+                      "description": "Canonical parameter `utm_source` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "call-analytics",
+              "level": "feature",
+              "name_en": "Call Analytics",
+              "name_ru": "Call Analytics",
+              "definition": "Feature of the Call Tracking capability covering call analytics.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "analytics",
+                "capability": "call-tracking"
+              },
+              "functions": [
+                {
+                  "id": "call-analytics-reporting",
+                  "level": "function",
+                  "name_en": "Call Analytics Reporting",
+                  "name_ru": "Call Analytics Reporting",
+                  "definition": "Executes the Call Analytics feature within the Call Tracking capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "analytics",
+                    "capability": "call-tracking",
+                    "feature": "call-analytics"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "date_range",
+                      "description": "Canonical parameter `date_range` for configuring or executing this function."
+                    },
+                    {
+                      "name": "metric_set",
+                      "description": "Canonical parameter `metric_set` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "end-to-end-analytics",
+          "level": "capability",
+          "name_en": "End-to-End Analytics",
+          "name_ru": "Сквозная аналитика",
+          "definition": "Revenue attribution, ROMI, and funnel analytics.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "analytics"
+          },
+          "features": [
+            {
+              "id": "revenue-attribution",
+              "level": "feature",
+              "name_en": "Revenue Attribution",
+              "name_ru": "Revenue Attribution",
+              "definition": "Feature of the End To End Analytics capability covering revenue attribution.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "analytics",
+                "capability": "end-to-end-analytics"
+              },
+              "functions": [
+                {
+                  "id": "revenue-attribution",
+                  "level": "function",
+                  "name_en": "Revenue Attribution",
+                  "name_ru": "Revenue Attribution",
+                  "definition": "Executes the Revenue Attribution feature within the End To End Analytics capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "analytics",
+                    "capability": "end-to-end-analytics",
+                    "feature": "revenue-attribution"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "deal_id",
+                      "description": "Canonical parameter `deal_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "source_id",
+                      "description": "Canonical parameter `source_id` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "romi-calculation",
+              "level": "feature",
+              "name_en": "ROMI Calculation",
+              "name_ru": "ROMI Calculation",
+              "definition": "Feature of the End To End Analytics capability covering romi calculation.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "analytics",
+                "capability": "end-to-end-analytics"
+              },
+              "functions": [
+                {
+                  "id": "romi-calculation",
+                  "level": "function",
+                  "name_en": "ROMI Calculation",
+                  "name_ru": "ROMI Calculation",
+                  "definition": "Executes the ROMI Calculation feature within the End To End Analytics capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "analytics",
+                    "capability": "end-to-end-analytics",
+                    "feature": "romi-calculation"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "revenue_amount",
+                      "description": "Canonical parameter `revenue_amount` for configuring or executing this function."
+                    },
+                    {
+                      "name": "campaign_cost",
+                      "description": "Canonical parameter `campaign_cost` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "funnel-analysis",
+              "level": "feature",
+              "name_en": "Funnel Analysis",
+              "name_ru": "Funnel Analysis",
+              "definition": "Feature of the End To End Analytics capability covering funnel analysis.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "analytics",
+                "capability": "end-to-end-analytics"
+              },
+              "functions": [
+                {
+                  "id": "funnel-tracking",
+                  "level": "function",
+                  "name_en": "Funnel Tracking",
+                  "name_ru": "Funnel Tracking",
+                  "definition": "Executes the Funnel Analysis feature within the End To End Analytics capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "analytics",
+                    "capability": "end-to-end-analytics",
+                    "feature": "funnel-analysis"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "funnel_id",
+                      "description": "Canonical parameter `funnel_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "stage_map",
+                      "description": "Canonical parameter `stage_map` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "facets": {
+            "commercial": {
+              "applicable": true
+            }
+          }
+        },
+        {
+          "id": "multichannel-analytics",
+          "level": "capability",
+          "name_en": "Multichannel Analytics",
+          "name_ru": "Мультиканальная аналитика",
+          "definition": "Cross-channel attribution, deduplication, and conversion tracking.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "analytics"
+          },
+          "features": [
+            {
+              "id": "channel-attribution",
+              "level": "feature",
+              "name_en": "Channel Attribution",
+              "name_ru": "Channel Attribution",
+              "definition": "Feature of the Multichannel Analytics capability covering channel attribution.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "analytics",
+                "capability": "multichannel-analytics"
+              },
+              "functions": [
+                {
+                  "id": "attribution-modeling",
+                  "level": "function",
+                  "name_en": "Attribution Modeling",
+                  "name_ru": "Attribution Modeling",
+                  "definition": "Executes the Channel Attribution feature within the Multichannel Analytics capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "analytics",
+                    "capability": "multichannel-analytics",
+                    "feature": "channel-attribution"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "model_type",
+                      "description": "Canonical parameter `model_type` for configuring or executing this function."
+                    },
+                    {
+                      "name": "touchpoint_set",
+                      "description": "Canonical parameter `touchpoint_set` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "deduplication",
+              "level": "feature",
+              "name_en": "Deduplication",
+              "name_ru": "Deduplication",
+              "definition": "Feature of the Multichannel Analytics capability covering deduplication.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "analytics",
+                "capability": "multichannel-analytics"
+              },
+              "functions": [
+                {
+                  "id": "lead-deduplication",
+                  "level": "function",
+                  "name_en": "Lead Deduplication",
+                  "name_ru": "Lead Deduplication",
+                  "definition": "Executes the Deduplication feature within the Multichannel Analytics capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "analytics",
+                    "capability": "multichannel-analytics",
+                    "feature": "deduplication"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "lead_id",
+                      "description": "Canonical parameter `lead_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "match_rules",
+                      "description": "Canonical parameter `match_rules` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "conversion-tracking",
+              "level": "feature",
+              "name_en": "Conversion Tracking",
+              "name_ru": "Conversion Tracking",
+              "definition": "Feature of the Multichannel Analytics capability covering conversion tracking.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "analytics",
+                "capability": "multichannel-analytics"
+              },
+              "functions": [
+                {
+                  "id": "conversion-tracking",
+                  "level": "function",
+                  "name_en": "Conversion Tracking",
+                  "name_ru": "Conversion Tracking",
+                  "definition": "Executes the Conversion Tracking feature within the Multichannel Analytics capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "analytics",
+                    "capability": "multichannel-analytics",
+                    "feature": "conversion-tracking"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "conversion_id",
+                      "description": "Canonical parameter `conversion_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "source_id",
+                      "description": "Canonical parameter `source_id` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "email-tracking",
+          "level": "capability",
+          "name_en": "Email Tracking",
+          "name_ru": "Email-трекинг",
+          "definition": "Open, click, and unsubscribe event tracking for email campaigns.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "analytics"
+          },
+          "features": [
+            {
+              "id": "open-tracking",
+              "level": "feature",
+              "name_en": "Open Tracking",
+              "name_ru": "Open Tracking",
+              "definition": "Feature of the Email Tracking capability covering open tracking.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "analytics",
+                "capability": "email-tracking"
+              },
+              "functions": [
+                {
+                  "id": "email-open-tracking",
+                  "level": "function",
+                  "name_en": "Email Open Tracking",
+                  "name_ru": "Email Open Tracking",
+                  "definition": "Executes the Open Tracking feature within the Email Tracking capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "analytics",
+                    "capability": "email-tracking",
+                    "feature": "open-tracking"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "message_id",
+                      "description": "Canonical parameter `message_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "recipient_id",
+                      "description": "Canonical parameter `recipient_id` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "click-tracking",
+              "level": "feature",
+              "name_en": "Click Tracking",
+              "name_ru": "Click Tracking",
+              "definition": "Feature of the Email Tracking capability covering click tracking.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "analytics",
+                "capability": "email-tracking"
+              },
+              "functions": [
+                {
+                  "id": "email-click-tracking",
+                  "level": "function",
+                  "name_en": "Email Click Tracking",
+                  "name_ru": "Email Click Tracking",
+                  "definition": "Executes the Click Tracking feature within the Email Tracking capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "analytics",
+                    "capability": "email-tracking",
+                    "feature": "click-tracking"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "message_id",
+                      "description": "Canonical parameter `message_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "link_id",
+                      "description": "Canonical parameter `link_id` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "unsubscribe-management",
+              "level": "feature",
+              "name_en": "Unsubscribe Management",
+              "name_ru": "Unsubscribe Management",
+              "definition": "Feature of the Email Tracking capability covering unsubscribe management.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "analytics",
+                "capability": "email-tracking"
+              },
+              "functions": [
+                {
+                  "id": "unsubscribe-handling",
+                  "level": "function",
+                  "name_en": "Unsubscribe Handling",
+                  "name_ru": "Unsubscribe Handling",
+                  "definition": "Executes the Unsubscribe Management feature within the Email Tracking capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "analytics",
+                    "capability": "email-tracking",
+                    "feature": "unsubscribe-management"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "subscriber_id",
+                      "description": "Canonical parameter `subscriber_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "unsubscribe_source",
+                      "description": "Canonical parameter `unsubscribe_source` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "product-analytics",
+          "level": "capability",
+          "name_en": "Product Analytics",
+          "name_ru": "Продуктовая аналитика",
+          "definition": "Demand, SKU, and data-quality analytics.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "analytics"
+          },
+          "features": [
+            {
+              "id": "demand-analysis",
+              "level": "feature",
+              "name_en": "Demand Analysis",
+              "name_ru": "Demand Analysis",
+              "definition": "Feature of the Product Analytics capability covering demand analysis.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "analytics",
+                "capability": "product-analytics"
+              },
+              "functions": [
+                {
+                  "id": "demand-analysis",
+                  "level": "function",
+                  "name_en": "Demand Analysis",
+                  "name_ru": "Demand Analysis",
+                  "definition": "Executes the Demand Analysis feature within the Product Analytics capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "analytics",
+                    "capability": "product-analytics",
+                    "feature": "demand-analysis"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "product_group",
+                      "description": "Canonical parameter `product_group` for configuring or executing this function."
+                    },
+                    {
+                      "name": "date_range",
+                      "description": "Canonical parameter `date_range` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "sku-performance",
+              "level": "feature",
+              "name_en": "Sku Performance",
+              "name_ru": "Sku Performance",
+              "definition": "Feature of the Product Analytics capability covering sku performance.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "analytics",
+                "capability": "product-analytics"
+              },
+              "functions": [
+                {
+                  "id": "sku-performance-analysis",
+                  "level": "function",
+                  "name_en": "Sku Performance Analysis",
+                  "name_ru": "Sku Performance Analysis",
+                  "definition": "Executes the Sku Performance feature within the Product Analytics capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "analytics",
+                    "capability": "product-analytics",
+                    "feature": "sku-performance"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "sku_id",
+                      "description": "Canonical parameter `sku_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "date_range",
+                      "description": "Canonical parameter `date_range` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "data-quality",
+              "level": "feature",
+              "name_en": "Data Quality",
+              "name_ru": "Data Quality",
+              "definition": "Feature of the Product Analytics capability covering data quality.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "analytics",
+                "capability": "product-analytics"
+              },
+              "functions": [
+                {
+                  "id": "data-quality-check",
+                  "level": "function",
+                  "name_en": "Data Quality Check",
+                  "name_ru": "Data Quality Check",
+                  "definition": "Executes the Data Quality feature within the Product Analytics capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "analytics",
+                    "capability": "product-analytics",
+                    "feature": "data-quality"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "dataset_id",
+                      "description": "Canonical parameter `dataset_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "quality_rule",
+                      "description": "Canonical parameter `quality_rule` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "facets": {
+            "commercial": {
+              "applicable": true
+            }
+          }
+        },
+        {
+          "id": "competitor-analysis",
+          "level": "capability",
+          "name_en": "Competitor Analysis",
+          "name_ru": "Конкурентный анализ",
+          "definition": "Market monitoring and benchmark reporting.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "analytics"
+          },
+          "features": [
+            {
+              "id": "market-monitoring",
+              "level": "feature",
+              "name_en": "Market Monitoring",
+              "name_ru": "Market Monitoring",
+              "definition": "Feature of the Competitor Analysis capability covering market monitoring.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "analytics",
+                "capability": "competitor-analysis"
+              },
+              "functions": [
+                {
+                  "id": "competitor-data-collection",
+                  "level": "function",
+                  "name_en": "Competitor Data Collection",
+                  "name_ru": "Competitor Data Collection",
+                  "definition": "Executes the Market Monitoring feature within the Competitor Analysis capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "analytics",
+                    "capability": "competitor-analysis",
+                    "feature": "market-monitoring"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "competitor_id",
+                      "description": "Canonical parameter `competitor_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "market_segment",
+                      "description": "Canonical parameter `market_segment` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "benchmark-reports",
+              "level": "feature",
+              "name_en": "Benchmark Reports",
+              "name_ru": "Benchmark Reports",
+              "definition": "Feature of the Competitor Analysis capability covering benchmark reports.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "analytics",
+                "capability": "competitor-analysis"
+              },
+              "functions": [
+                {
+                  "id": "benchmark-reporting",
+                  "level": "function",
+                  "name_en": "Benchmark Reporting",
+                  "name_ru": "Benchmark Reporting",
+                  "definition": "Executes the Benchmark Reports feature within the Competitor Analysis capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "analytics",
+                    "capability": "competitor-analysis",
+                    "feature": "benchmark-reports"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "benchmark_set",
+                      "description": "Canonical parameter `benchmark_set` for configuring or executing this function."
+                    },
+                    {
+                      "name": "report_period",
+                      "description": "Canonical parameter `report_period` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "facets": {
+            "commercial": {
+              "applicable": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "hardware",
+      "level": "domain",
+      "name_en": "Hardware",
+      "name_ru": "Оборудование",
+      "definition": "Physical telephony equipment and endpoint accessories used with communications services.",
+      "lifecycle_status": "active",
+      "evidence_refs": [
+        "standards/decisions/ADR-011-industry-taxonomy.md",
+        "standards/industry-taxonomy-standard.md",
+        "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+      ],
+      "capabilities": [
+        {
+          "id": "telephony-equipment",
+          "level": "capability",
+          "name_en": "Telephony Equipment",
+          "name_ru": "Телефонное оборудование",
+          "definition": "SIP phones, headsets, and accessories used as communications endpoints.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "hardware"
+          },
+          "features": [
+            {
+              "id": "sip-phones",
+              "level": "feature",
+              "name_en": "SIP Phones",
+              "name_ru": "SIP Phones",
+              "definition": "Feature of the Telephony Equipment capability covering sip phones.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "hardware",
+                "capability": "telephony-equipment"
+              },
+              "functions": [
+                {
+                  "id": "device-provisioning",
+                  "level": "function",
+                  "name_en": "Device Provisioning",
+                  "name_ru": "Device Provisioning",
+                  "definition": "Executes the SIP Phones feature within the Telephony Equipment capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "hardware",
+                    "capability": "telephony-equipment",
+                    "feature": "sip-phones"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "device_id",
+                      "description": "Canonical parameter `device_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "sip_account",
+                      "description": "Canonical parameter `sip_account` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "headsets",
+              "level": "feature",
+              "name_en": "Headsets",
+              "name_ru": "Headsets",
+              "definition": "Feature of the Telephony Equipment capability covering headsets.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "hardware",
+                "capability": "telephony-equipment"
+              },
+              "functions": [
+                {
+                  "id": "device-compatibility-check",
+                  "level": "function",
+                  "name_en": "Device Compatibility Check",
+                  "name_ru": "Device Compatibility Check",
+                  "definition": "Executes the Headsets feature within the Telephony Equipment capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "hardware",
+                    "capability": "telephony-equipment",
+                    "feature": "headsets"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "device_model",
+                      "description": "Canonical parameter `device_model` for configuring or executing this function."
+                    },
+                    {
+                      "name": "compatibility_matrix",
+                      "description": "Canonical parameter `compatibility_matrix` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "accessories",
+              "level": "feature",
+              "name_en": "Accessories",
+              "name_ru": "Accessories",
+              "definition": "Feature of the Telephony Equipment capability covering accessories.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "hardware",
+                "capability": "telephony-equipment"
+              },
+              "functions": [
+                {
+                  "id": "accessory-inventory-check",
+                  "level": "function",
+                  "name_en": "Accessory Inventory Check",
+                  "name_ru": "Accessory Inventory Check",
+                  "definition": "Executes the Accessories feature within the Telephony Equipment capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "hardware",
+                    "capability": "telephony-equipment",
+                    "feature": "accessories"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "accessory_model",
+                      "description": "Canonical parameter `accessory_model` for configuring or executing this function."
+                    },
+                    {
+                      "name": "stock_location",
+                      "description": "Canonical parameter `stock_location` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "security",
+      "level": "domain",
+      "name_en": "Security",
+      "name_ru": "Безопасность",
+      "definition": "Information security, access control, audit, data classification, and incident-management capabilities.",
+      "lifecycle_status": "active",
+      "evidence_refs": [
+        "standards/decisions/ADR-011-industry-taxonomy.md",
+        "standards/industry-taxonomy-standard.md",
+        "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+      ],
+      "capabilities": [
+        {
+          "id": "information-security",
+          "level": "capability",
+          "name_en": "Information Security",
+          "name_ru": "Информационная безопасность",
+          "definition": "Access control, audit logging, data classification, and incident response.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "security"
+          },
+          "features": [
+            {
+              "id": "access-control",
+              "level": "feature",
+              "name_en": "Access Control",
+              "name_ru": "Контроль доступа",
+              "definition": "Feature of the Information Security capability covering access control.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "security",
+                "capability": "information-security"
+              },
+              "functions": [
+                {
+                  "id": "role-based-access-control",
+                  "level": "function",
+                  "name_en": "Role Based Access Control",
+                  "name_ru": "Role Based Access Control",
+                  "definition": "Executes the Access Control feature within the Information Security capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "security",
+                    "capability": "information-security",
+                    "feature": "access-control"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "role_id",
+                      "description": "Canonical parameter `role_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "permission_set",
+                      "description": "Canonical parameter `permission_set` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "security-audit-logging",
+              "level": "feature",
+              "name_en": "Security Audit Logging",
+              "name_ru": "Security Audit Logging",
+              "definition": "Feature of the Information Security capability covering security audit logging.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "security",
+                "capability": "information-security"
+              },
+              "functions": [
+                {
+                  "id": "security-audit-logging",
+                  "level": "function",
+                  "name_en": "Security Audit Logging",
+                  "name_ru": "Security Audit Logging",
+                  "definition": "Executes the Security Audit Logging feature within the Information Security capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "security",
+                    "capability": "information-security",
+                    "feature": "security-audit-logging"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "event_type",
+                      "description": "Canonical parameter `event_type` for configuring or executing this function."
+                    },
+                    {
+                      "name": "retention_period",
+                      "description": "Canonical parameter `retention_period` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "data-classification",
+              "level": "feature",
+              "name_en": "Data Classification",
+              "name_ru": "Data Classification",
+              "definition": "Feature of the Information Security capability covering data classification.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "security",
+                "capability": "information-security"
+              },
+              "functions": [
+                {
+                  "id": "data-classification",
+                  "level": "function",
+                  "name_en": "Data Classification",
+                  "name_ru": "Data Classification",
+                  "definition": "Executes the Data Classification feature within the Information Security capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "security",
+                    "capability": "information-security",
+                    "feature": "data-classification"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "dataset_id",
+                      "description": "Canonical parameter `dataset_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "classification_policy",
+                      "description": "Canonical parameter `classification_policy` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "security-incident-management",
+              "level": "feature",
+              "name_en": "Security Incident Management",
+              "name_ru": "Security Incident Management",
+              "definition": "Feature of the Information Security capability covering security incident management.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "security",
+                "capability": "information-security"
+              },
+              "functions": [
+                {
+                  "id": "security-incident-response",
+                  "level": "function",
+                  "name_en": "Security Incident Response",
+                  "name_ru": "Security Incident Response",
+                  "definition": "Executes the Security Incident Management feature within the Information Security capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "security",
+                    "capability": "information-security",
+                    "feature": "security-incident-management"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "incident_id",
+                      "description": "Canonical parameter `incident_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "response_playbook",
+                      "description": "Canonical parameter `response_playbook` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "facets": {
+            "security_compliance": {
+              "applicable": true
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "cross_domain_layers": [
+    {
+      "id": "platform",
+      "level": "domain",
+      "name_en": "Platform",
+      "name_ru": "Платформа",
+      "definition": "Cross-domain integration, API, CPaaS, service desk, and support capabilities productized across domains.",
+      "lifecycle_status": "active",
+      "evidence_refs": [
+        "standards/decisions/ADR-011-industry-taxonomy.md",
+        "standards/industry-taxonomy-standard.md",
+        "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+      ],
+      "taxonomy_role": "cross-domain-layer",
+      "capabilities": [
+        {
+          "id": "platform-integration",
+          "level": "capability",
+          "name_en": "Platform Integration",
+          "name_ru": "Платформенные интеграции",
+          "definition": "CRM, ERP, directory, and marketplace integrations across domains.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "platform"
+          },
+          "features": [
+            {
+              "id": "crm-connectors",
+              "level": "feature",
+              "name_en": "CRM Connectors",
+              "name_ru": "CRM Connectors",
+              "definition": "Feature of the Platform Integration capability covering crm connectors.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "platform",
+                "capability": "platform-integration"
+              },
+              "functions": [
+                {
+                  "id": "crm-bidirectional-sync",
+                  "level": "function",
+                  "name_en": "CRM Bidirectional Sync",
+                  "name_ru": "CRM Bidirectional Sync",
+                  "definition": "Executes the CRM Connectors feature within the Platform Integration capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "platform",
+                    "capability": "platform-integration",
+                    "feature": "crm-connectors"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "crm_system",
+                      "description": "Canonical parameter `crm_system` for configuring or executing this function."
+                    },
+                    {
+                      "name": "sync_mapping",
+                      "description": "Canonical parameter `sync_mapping` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "erp-connectors",
+              "level": "feature",
+              "name_en": "ERP Connectors",
+              "name_ru": "ERP Connectors",
+              "definition": "Feature of the Platform Integration capability covering erp connectors.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "platform",
+                "capability": "platform-integration"
+              },
+              "functions": [
+                {
+                  "id": "erp-bidirectional-sync",
+                  "level": "function",
+                  "name_en": "ERP Bidirectional Sync",
+                  "name_ru": "ERP Bidirectional Sync",
+                  "definition": "Executes the ERP Connectors feature within the Platform Integration capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "platform",
+                    "capability": "platform-integration",
+                    "feature": "erp-connectors"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "erp_system",
+                      "description": "Canonical parameter `erp_system` for configuring or executing this function."
+                    },
+                    {
+                      "name": "sync_mapping",
+                      "description": "Canonical parameter `sync_mapping` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "directory-sync",
+              "level": "feature",
+              "name_en": "Directory Sync",
+              "name_ru": "Directory Sync",
+              "definition": "Feature of the Platform Integration capability covering directory sync.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "platform",
+                "capability": "platform-integration"
+              },
+              "functions": [
+                {
+                  "id": "directory-sync",
+                  "level": "function",
+                  "name_en": "Directory Sync",
+                  "name_ru": "Directory Sync",
+                  "definition": "Executes the Directory Sync feature within the Platform Integration capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "platform",
+                    "capability": "platform-integration",
+                    "feature": "directory-sync"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "directory_id",
+                      "description": "Canonical parameter `directory_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "sync_scope",
+                      "description": "Canonical parameter `sync_scope` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "marketplace-apps",
+              "level": "feature",
+              "name_en": "Marketplace Apps",
+              "name_ru": "Marketplace Apps",
+              "definition": "Feature of the Platform Integration capability covering marketplace apps.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "platform",
+                "capability": "platform-integration"
+              },
+              "functions": [
+                {
+                  "id": "marketplace-app-installation",
+                  "level": "function",
+                  "name_en": "Marketplace App Installation",
+                  "name_ru": "Marketplace App Installation",
+                  "definition": "Executes the Marketplace Apps feature within the Platform Integration capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "platform",
+                    "capability": "platform-integration",
+                    "feature": "marketplace-apps"
+                  },
+                  "function_type": "ui-action",
+                  "parameters": [
+                    {
+                      "name": "app_id",
+                      "description": "Canonical parameter `app_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "tenant_id",
+                      "description": "Canonical parameter `tenant_id` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "open-api",
+          "level": "capability",
+          "name_en": "Open API",
+          "name_ru": "Открытый API",
+          "definition": "REST API, webhooks, and event streaming extension surfaces.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "platform"
+          },
+          "features": [
+            {
+              "id": "rest-api",
+              "level": "feature",
+              "name_en": "Rest API",
+              "name_ru": "Rest API",
+              "definition": "Feature of the Open API capability covering rest api.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "platform",
+                "capability": "open-api"
+              },
+              "functions": [
+                {
+                  "id": "api-rate-limiting",
+                  "level": "function",
+                  "name_en": "API Rate Limiting",
+                  "name_ru": "API Rate Limiting",
+                  "definition": "Executes the Rest API feature within the Open API capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "platform",
+                    "capability": "open-api",
+                    "feature": "rest-api"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "api_client",
+                      "description": "Canonical parameter `api_client` for configuring or executing this function."
+                    },
+                    {
+                      "name": "rate_limit",
+                      "description": "Canonical parameter `rate_limit` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "webhooks",
+              "level": "feature",
+              "name_en": "Webhooks",
+              "name_ru": "Вебхуки",
+              "definition": "Feature of the Open API capability covering webhooks.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "platform",
+                "capability": "open-api"
+              },
+              "functions": [
+                {
+                  "id": "webhook-subscription",
+                  "level": "function",
+                  "name_en": "Webhook Subscription",
+                  "name_ru": "Webhook Subscription",
+                  "definition": "Executes the Webhooks feature within the Open API capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "platform",
+                    "capability": "open-api",
+                    "feature": "webhooks"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "event_type",
+                      "description": "Canonical parameter `event_type` for configuring or executing this function."
+                    },
+                    {
+                      "name": "callback_url",
+                      "description": "Canonical parameter `callback_url` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "event-streaming",
+              "level": "feature",
+              "name_en": "Event Streaming",
+              "name_ru": "Event Streaming",
+              "definition": "Feature of the Open API capability covering event streaming.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "platform",
+                "capability": "open-api"
+              },
+              "functions": [
+                {
+                  "id": "event-stream-subscription",
+                  "level": "function",
+                  "name_en": "Event Stream Subscription",
+                  "name_ru": "Event Stream Subscription",
+                  "definition": "Executes the Event Streaming feature within the Open API capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "platform",
+                    "capability": "open-api",
+                    "feature": "event-streaming"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "topic_name",
+                      "description": "Canonical parameter `topic_name` for configuring or executing this function."
+                    },
+                    {
+                      "name": "consumer_group",
+                      "description": "Canonical parameter `consumer_group` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "cpaas",
+          "level": "capability",
+          "name_en": "CPaaS",
+          "name_ru": "CPaaS",
+          "definition": "Programmable communications APIs for voice, messaging, and numbers.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "platform"
+          },
+          "features": [
+            {
+              "id": "programmable-voice",
+              "level": "feature",
+              "name_en": "Programmable Voice",
+              "name_ru": "Programmable Voice",
+              "definition": "Feature of the CPaaS capability covering programmable voice.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "platform",
+                "capability": "cpaas"
+              },
+              "functions": [
+                {
+                  "id": "programmable-voice-call",
+                  "level": "function",
+                  "name_en": "Programmable Voice Call",
+                  "name_ru": "Programmable Voice Call",
+                  "definition": "Executes the Programmable Voice feature within the CPaaS capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "platform",
+                    "capability": "cpaas",
+                    "feature": "programmable-voice"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "from_number",
+                      "description": "Canonical parameter `from_number` for configuring or executing this function."
+                    },
+                    {
+                      "name": "to_number",
+                      "description": "Canonical parameter `to_number` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "programmable-messaging",
+              "level": "feature",
+              "name_en": "Programmable Messaging",
+              "name_ru": "Programmable Messaging",
+              "definition": "Feature of the CPaaS capability covering programmable messaging.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "platform",
+                "capability": "cpaas"
+              },
+              "functions": [
+                {
+                  "id": "programmable-message-send",
+                  "level": "function",
+                  "name_en": "Programmable Message Send",
+                  "name_ru": "Programmable Message Send",
+                  "definition": "Executes the Programmable Messaging feature within the CPaaS capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "platform",
+                    "capability": "cpaas",
+                    "feature": "programmable-messaging"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "recipient_id",
+                      "description": "Canonical parameter `recipient_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "message_template",
+                      "description": "Canonical parameter `message_template` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "number-api",
+              "level": "feature",
+              "name_en": "Number API",
+              "name_ru": "Number API",
+              "definition": "Feature of the CPaaS capability covering number api.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "platform",
+                "capability": "cpaas"
+              },
+              "functions": [
+                {
+                  "id": "number-api-provisioning",
+                  "level": "function",
+                  "name_en": "Number API Provisioning",
+                  "name_ru": "Number API Provisioning",
+                  "definition": "Executes the Number API feature within the CPaaS capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "platform",
+                    "capability": "cpaas",
+                    "feature": "number-api"
+                  },
+                  "function_type": "configuration",
+                  "parameters": [
+                    {
+                      "name": "number_type",
+                      "description": "Canonical parameter `number_type` for configuring or executing this function."
+                    },
+                    {
+                      "name": "region_code",
+                      "description": "Canonical parameter `region_code` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "service-desk",
+          "level": "capability",
+          "name_en": "Service Desk",
+          "name_ru": "Сервис-деск",
+          "definition": "Ticket, incident, and request fulfilment capabilities around communications operations.",
+          "lifecycle_status": "active",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "platform"
+          },
+          "features": [
+            {
+              "id": "ticketing",
+              "level": "feature",
+              "name_en": "Ticketing",
+              "name_ru": "Ticketing",
+              "definition": "Feature of the Service Desk capability covering ticketing.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "platform",
+                "capability": "service-desk"
+              },
+              "functions": [
+                {
+                  "id": "ticket-lifecycle",
+                  "level": "function",
+                  "name_en": "Ticket Lifecycle",
+                  "name_ru": "Ticket Lifecycle",
+                  "definition": "Executes the Ticketing feature within the Service Desk capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "platform",
+                    "capability": "service-desk",
+                    "feature": "ticketing"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "ticket_id",
+                      "description": "Canonical parameter `ticket_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "status_code",
+                      "description": "Canonical parameter `status_code` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "service-incident-management",
+              "level": "feature",
+              "name_en": "Service Incident Management",
+              "name_ru": "Service Incident Management",
+              "definition": "Feature of the Service Desk capability covering service incident management.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "platform",
+                "capability": "service-desk"
+              },
+              "functions": [
+                {
+                  "id": "service-incident-management",
+                  "level": "function",
+                  "name_en": "Service Incident Management",
+                  "name_ru": "Service Incident Management",
+                  "definition": "Executes the Service Incident Management feature within the Service Desk capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "platform",
+                    "capability": "service-desk",
+                    "feature": "service-incident-management"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "incident_id",
+                      "description": "Canonical parameter `incident_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "priority",
+                      "description": "Canonical parameter `priority` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "request-fulfilment",
+              "level": "feature",
+              "name_en": "Request Fulfilment",
+              "name_ru": "Request Fulfilment",
+              "definition": "Feature of the Service Desk capability covering request fulfilment.",
+              "lifecycle_status": "active",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "platform",
+                "capability": "service-desk"
+              },
+              "functions": [
+                {
+                  "id": "request-fulfilment",
+                  "level": "function",
+                  "name_en": "Request Fulfilment",
+                  "name_ru": "Request Fulfilment",
+                  "definition": "Executes the Request Fulfilment feature within the Service Desk capability.",
+                  "lifecycle_status": "active",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "platform",
+                    "capability": "service-desk",
+                    "feature": "request-fulfilment"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "request_id",
+                      "description": "Canonical parameter `request_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "approval_flow",
+                      "description": "Canonical parameter `approval_flow` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "vendor-support-services",
+          "level": "capability",
+          "name_en": "Vendor Support Services",
+          "name_ru": "Услуги поддержки вендора",
+          "definition": "Application maintenance, CRM development, and professional services around the platform.",
+          "lifecycle_status": "proposed",
+          "evidence_refs": [
+            "standards/decisions/ADR-011-industry-taxonomy.md",
+            "standards/industry-taxonomy-standard.md",
+            "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+          ],
+          "parent": {
+            "domain": "platform"
+          },
+          "features": [
+            {
+              "id": "application-maintenance",
+              "level": "feature",
+              "name_en": "Application Maintenance",
+              "name_ru": "Application Maintenance",
+              "definition": "Feature of the Vendor Support Services capability covering application maintenance.",
+              "lifecycle_status": "proposed",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "platform",
+                "capability": "vendor-support-services"
+              },
+              "functions": [
+                {
+                  "id": "application-maintenance",
+                  "level": "function",
+                  "name_en": "Application Maintenance",
+                  "name_ru": "Application Maintenance",
+                  "definition": "Executes the Application Maintenance feature within the Vendor Support Services capability.",
+                  "lifecycle_status": "proposed",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "platform",
+                    "capability": "vendor-support-services",
+                    "feature": "application-maintenance"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "application_id",
+                      "description": "Canonical parameter `application_id` for configuring or executing this function."
+                    },
+                    {
+                      "name": "maintenance_window",
+                      "description": "Canonical parameter `maintenance_window` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "crm-development",
+              "level": "feature",
+              "name_en": "CRM Development",
+              "name_ru": "CRM Development",
+              "definition": "Feature of the Vendor Support Services capability covering crm development.",
+              "lifecycle_status": "proposed",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "platform",
+                "capability": "vendor-support-services"
+              },
+              "functions": [
+                {
+                  "id": "crm-customization",
+                  "level": "function",
+                  "name_en": "CRM Customization",
+                  "name_ru": "CRM Customization",
+                  "definition": "Executes the CRM Development feature within the Vendor Support Services capability.",
+                  "lifecycle_status": "proposed",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "platform",
+                    "capability": "vendor-support-services",
+                    "feature": "crm-development"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "crm_system",
+                      "description": "Canonical parameter `crm_system` for configuring or executing this function."
+                    },
+                    {
+                      "name": "customization_scope",
+                      "description": "Canonical parameter `customization_scope` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "professional-services",
+              "level": "feature",
+              "name_en": "Professional Services",
+              "name_ru": "Professional Services",
+              "definition": "Feature of the Vendor Support Services capability covering professional services.",
+              "lifecycle_status": "proposed",
+              "evidence_refs": [
+                "standards/decisions/ADR-011-industry-taxonomy.md",
+                "standards/industry-taxonomy-standard.md",
+                "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+              ],
+              "parent": {
+                "domain": "platform",
+                "capability": "vendor-support-services"
+              },
+              "functions": [
+                {
+                  "id": "professional-service-delivery",
+                  "level": "function",
+                  "name_en": "Professional Service Delivery",
+                  "name_ru": "Professional Service Delivery",
+                  "definition": "Executes the Professional Services feature within the Vendor Support Services capability.",
+                  "lifecycle_status": "proposed",
+                  "evidence_refs": [
+                    "standards/decisions/ADR-011-industry-taxonomy.md",
+                    "standards/industry-taxonomy-standard.md",
+                    "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/blob/038868ddde36e1409ee32d43c0421e59c72eb9f3/classification.md"
+                  ],
+                  "parent": {
+                    "domain": "platform",
+                    "capability": "vendor-support-services",
+                    "feature": "professional-services"
+                  },
+                  "function_type": "business",
+                  "parameters": [
+                    {
+                      "name": "service_package",
+                      "description": "Canonical parameter `service_package` for configuring or executing this function."
+                    },
+                    {
+                      "name": "delivery_scope",
+                      "description": "Canonical parameter `delivery_scope` for configuring or executing this function."
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "source_status": "candidate-or-market-specific"
+        }
+      ]
+    }
+  ]
+}

--- a/kb/industry/reference-taxonomy.schema.json
+++ b/kb/industry/reference-taxonomy.schema.json
@@ -1,0 +1,482 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "reference-taxonomy.schema.json",
+  "title": "Industry Taxonomy Reference Registry",
+  "type": "object",
+  "required": [
+    "$schema",
+    "taxonomy_id",
+    "schema_version",
+    "version",
+    "last_updated",
+    "status",
+    "levels",
+    "lifecycle_statuses",
+    "function_types",
+    "sources",
+    "facets",
+    "domains",
+    "cross_domain_layers"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "reference-taxonomy.schema.json"
+    },
+    "taxonomy_id": {
+      "const": "industry-taxonomy"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "version": {
+      "type": "string"
+    },
+    "last_updated": {
+      "type": "string",
+      "format": "date"
+    },
+    "status": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "levels": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "lifecycle_statuses": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/lifecycle_status"
+      }
+    },
+    "function_types": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/function_type"
+      }
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "facets": {
+      "type": "object"
+    },
+    "registry_notes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "domains": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/domain"
+      }
+    },
+    "cross_domain_layers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/domain"
+      }
+    }
+  },
+  "$defs": {
+    "slug": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$"
+    },
+    "parameter_name": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$"
+    },
+    "lifecycle_status": {
+      "enum": [
+        "proposed",
+        "active",
+        "deprecated",
+        "removed"
+      ]
+    },
+    "function_type": {
+      "enum": [
+        "business",
+        "configuration",
+        "ui-action"
+      ]
+    },
+    "node_base": {
+      "type": "object",
+      "required": [
+        "id",
+        "level",
+        "name_en",
+        "name_ru",
+        "definition",
+        "lifecycle_status",
+        "evidence_refs"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/slug"
+        },
+        "level": {
+          "enum": [
+            "domain",
+            "capability",
+            "feature",
+            "function"
+          ]
+        },
+        "name_en": {
+          "type": "string"
+        },
+        "name_ru": {
+          "type": "string"
+        },
+        "definition": {
+          "type": "string"
+        },
+        "lifecycle_status": {
+          "$ref": "#/$defs/lifecycle_status"
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "parent": {
+          "type": "object"
+        },
+        "facets": {
+          "type": "object"
+        },
+        "source_status": {
+          "type": "string"
+        }
+      }
+    },
+    "domain": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/node_base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "level": {
+              "const": "domain"
+            },
+            "taxonomy_role": {
+              "type": "string"
+            },
+            "capabilities": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/capability"
+              }
+            }
+          },
+          "required": [
+            "capabilities"
+          ]
+        }
+      ]
+    },
+    "capability": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/node_base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "level": {
+              "const": "capability"
+            },
+            "features": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/feature"
+              }
+            }
+          },
+          "required": [
+            "features"
+          ]
+        }
+      ]
+    },
+    "feature": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/node_base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "level": {
+              "const": "feature"
+            },
+            "functions": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/function"
+              }
+            }
+          },
+          "required": [
+            "functions"
+          ]
+        }
+      ]
+    },
+    "function": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/node_base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "level": {
+              "const": "function"
+            },
+            "function_type": {
+              "$ref": "#/$defs/function_type"
+            },
+            "parameters": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "description"
+                ],
+                "properties": {
+                  "name": {
+                    "$ref": "#/$defs/parameter_name"
+                  },
+                  "description": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "required": [
+            "function_type",
+            "parameters"
+          ]
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "slug": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$"
+    },
+    "parameter_name": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$"
+    },
+    "lifecycle_status": {
+      "enum": [
+        "proposed",
+        "active",
+        "deprecated",
+        "removed"
+      ]
+    },
+    "function_type": {
+      "enum": [
+        "business",
+        "configuration",
+        "ui-action"
+      ]
+    },
+    "node_base": {
+      "type": "object",
+      "required": [
+        "id",
+        "level",
+        "name_en",
+        "name_ru",
+        "definition",
+        "lifecycle_status",
+        "evidence_refs"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/slug"
+        },
+        "level": {
+          "enum": [
+            "domain",
+            "capability",
+            "feature",
+            "function"
+          ]
+        },
+        "name_en": {
+          "type": "string"
+        },
+        "name_ru": {
+          "type": "string"
+        },
+        "definition": {
+          "type": "string"
+        },
+        "lifecycle_status": {
+          "$ref": "#/$defs/lifecycle_status"
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "parent": {
+          "type": "object"
+        },
+        "facets": {
+          "type": "object"
+        },
+        "source_status": {
+          "type": "string"
+        }
+      }
+    },
+    "domain": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/node_base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "level": {
+              "const": "domain"
+            },
+            "taxonomy_role": {
+              "type": "string"
+            },
+            "capabilities": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/capability"
+              }
+            }
+          },
+          "required": [
+            "capabilities"
+          ]
+        }
+      ]
+    },
+    "capability": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/node_base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "level": {
+              "const": "capability"
+            },
+            "features": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/feature"
+              }
+            }
+          },
+          "required": [
+            "features"
+          ]
+        }
+      ]
+    },
+    "feature": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/node_base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "level": {
+              "const": "feature"
+            },
+            "functions": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/function"
+              }
+            }
+          },
+          "required": [
+            "functions"
+          ]
+        }
+      ]
+    },
+    "function": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/node_base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "level": {
+              "const": "function"
+            },
+            "function_type": {
+              "$ref": "#/$defs/function_type"
+            },
+            "parameters": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "description"
+                ],
+                "properties": {
+                  "name": {
+                    "$ref": "#/$defs/parameter_name"
+                  },
+                  "description": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "required": [
+            "function_type",
+            "parameters"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/scripts/validate_issue_144_kb_structure_readmes.py
+++ b/scripts/validate_issue_144_kb_structure_readmes.py
@@ -5,7 +5,7 @@ Issue #144 follows the product-docs migration from issue #137 and locks the
 documentation boundary for the generic ``kb/`` namespace:
 
 - the root KB README describes ``mango-product-docs/``, ``fragments/``,
-  ``practices/`` and planned taxonomy namespaces;
+  ``practices/`` and taxonomy namespaces;
 - ``kb/mango-product-docs/README.md`` exists and owns product-documentation
   sources, generated outputs, and human usage guides;
 - ``kb/fragments/`` and ``kb/practices/`` stay as independent KB material, not
@@ -64,7 +64,8 @@ def check_readmes() -> list[str]:
         "kb/mango-product-docs/",
         "kb/fragments/",
         "kb/practices/",
-        "kb/industry/ (будущий)",
+        "kb/industry/",
+        "Industry Taxonomy",
         "kb/mango/ (будущий)",
         "kb/mango-product-docs/README.md",
         "USAGE.md",

--- a/scripts/validate_issue_156_industry_taxonomy_registry.py
+++ b/scripts/validate_issue_156_industry_taxonomy_registry.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""Regression check for issue #156: Industry Taxonomy registry.
+
+Issue #156 requires a machine-readable Industry Taxonomy registry under
+``kb/industry/`` aligned with ADR-011 canonical v1.0 and the Industry Taxonomy
+standard. The validator intentionally uses only Python stdlib so it can run in
+the lightweight KB CI job.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REGISTRY = "kb/industry/reference-taxonomy.json"
+SCHEMA = "kb/industry/reference-taxonomy.schema.json"
+README = "kb/industry/README.md"
+KB_README = "kb/README.md"
+CHANGELOG = "CHANGELOG.md"
+MAKEFILE = "Makefile"
+KB_WORKFLOW = ".github/workflows/kb.yml"
+VALIDATOR = "scripts/validate_issue_156_industry_taxonomy_registry.py"
+
+SLUG_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
+PARAM_RE = re.compile(r"^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$")
+
+CANONICAL_DOMAINS = {
+    "voice-ucaas",
+    "contact-center",
+    "digital-channels",
+    "ai-automation",
+    "analytics",
+    "hardware",
+    "security",
+}
+
+REQUIRED_CAPABILITIES = {
+    "voice-channel",
+    "cloud-pbx",
+    "sip-connectivity",
+    "number-management",
+    "ivr-voice-menu",
+    "call-recording",
+    "callback",
+    "unified-communications",
+    "video-conferencing",
+    "call-routing",
+    "omnichannel-contact-center",
+    "agent-workspace",
+    "outbound-calling",
+    "quality-management",
+    "workforce-management",
+    "knowledge-base",
+    "sms-messaging",
+    "omnichannel-messaging",
+    "website-chat",
+    "chatbot",
+    "voice-bot",
+    "speech-analytics",
+    "platform-integration",
+    "open-api",
+    "cpaas",
+}
+
+REQUIRED_FEATURES = {
+    "inbound-voice-call",
+    "outbound-voice-call",
+    "sip-trunking",
+    "ivr-scenarios",
+    "call-routing-rules",
+    "campaign-management",
+    "agent-desktop",
+    "scorecards",
+    "messenger-integration",
+    "chat-widget",
+    "transcription",
+    "dynamic-number-pool",
+    "access-control",
+    "webhooks",
+}
+
+REQUIRED_FUNCTIONS = {
+    "accept-inbound-voice-call",
+    "initiate-outbound-voice-call",
+    "sip-trunk-registration",
+    "ivr-menu-navigation",
+    "call-recording-capture",
+    "predictive-dialing",
+    "interaction-routing",
+    "scorecard-evaluation",
+    "bulk-sms-dispatch",
+    "intent-classification",
+    "call-transcription",
+    "dynamic-number-substitution",
+    "role-based-access-control",
+    "webhook-subscription",
+    "programmable-message-send",
+}
+
+ALLOWED_LEVELS = {"domain", "capability", "feature", "function"}
+ALLOWED_LIFECYCLE = {"proposed", "active", "deprecated", "removed"}
+ALLOWED_FUNCTION_TYPES = {"business", "configuration", "ui-action"}
+
+
+def read_text(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def read_json(path: str) -> Any:
+    return json.loads(read_text(path))
+
+
+def require_path(path: str) -> list[str]:
+    return [] if (ROOT / path).exists() else [f"{path}: missing"]
+
+
+def require_text(path: str, *needles: str) -> list[str]:
+    errors = require_path(path)
+    if errors:
+        return errors
+    text = read_text(path)
+    return [f"{path}: missing {needle!r}" for needle in needles if needle not in text]
+
+
+def valid_evidence(ref: str) -> bool:
+    if ref.startswith(("http://", "https://")):
+        return True
+    return (ROOT / ref).exists()
+
+
+def check_slug(value: str, path: str, errors: list[str]) -> None:
+    if not SLUG_RE.fullmatch(value):
+        errors.append(f"{path}: invalid slug {value!r}")
+
+
+def require_node_fields(node: dict[str, Any], path: str, level: str, errors: list[str]) -> None:
+    for field in ("id", "level", "name_en", "name_ru", "definition", "lifecycle_status", "evidence_refs"):
+        if field not in node:
+            errors.append(f"{path}: missing {field}")
+    if node.get("level") != level:
+        errors.append(f"{path}: expected level {level!r}, got {node.get('level')!r}")
+    if node.get("level") not in ALLOWED_LEVELS:
+        errors.append(f"{path}: invalid level {node.get('level')!r}")
+    if isinstance(node.get("id"), str):
+        check_slug(node["id"], path, errors)
+    if node.get("lifecycle_status") not in ALLOWED_LIFECYCLE:
+        errors.append(f"{path}: invalid lifecycle_status {node.get('lifecycle_status')!r}")
+    refs = node.get("evidence_refs")
+    if not isinstance(refs, list) or not refs:
+        errors.append(f"{path}: evidence_refs must be a non-empty list")
+    else:
+        for ref in refs:
+            if not isinstance(ref, str) or not valid_evidence(ref):
+                errors.append(f"{path}: evidence ref does not resolve: {ref!r}")
+
+
+def check_parameters(function: dict[str, Any], path: str, errors: list[str]) -> None:
+    parameters = function.get("parameters")
+    if not isinstance(parameters, list):
+        errors.append(f"{path}: parameters must be a list")
+        return
+    for index, parameter in enumerate(parameters):
+        param_path = f"{path}.parameters[{index}]"
+        if not isinstance(parameter, dict):
+            errors.append(f"{param_path}: must be an object")
+            continue
+        for field in ("name", "description"):
+            if field not in parameter:
+                errors.append(f"{param_path}: missing {field}")
+        name = parameter.get("name")
+        if isinstance(name, str) and not PARAM_RE.fullmatch(name):
+            errors.append(f"{param_path}: invalid parameter name {name!r}")
+
+
+def check_registry_nodes(registry: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    ids_by_level: dict[str, set[str]] = {level: set() for level in ALLOWED_LEVELS}
+    counts = {"domains": 0, "layers": 0, "capabilities": 0, "features": 0, "functions": 0}
+
+    domains = registry.get("domains")
+    if not isinstance(domains, list):
+        return ["kb/industry/reference-taxonomy.json: domains must be a list"]
+
+    domain_ids = {domain.get("id") for domain in domains if isinstance(domain, dict)}
+    if domain_ids != CANONICAL_DOMAINS:
+        errors.append(f"{REGISTRY}: canonical domains mismatch: {sorted(domain_ids)!r}")
+
+    cross_layers = registry.get("cross_domain_layers")
+    if not isinstance(cross_layers, list):
+        errors.append(f"{REGISTRY}: cross_domain_layers must be a list")
+        cross_layers = []
+    if {layer.get("id") for layer in cross_layers if isinstance(layer, dict)} != {"platform"}:
+        errors.append(f"{REGISTRY}: platform must be the only cross-domain layer")
+
+    def walk_container(container: dict[str, Any], container_path: str, is_layer: bool = False) -> None:
+        level = "domain"
+        require_node_fields(container, container_path, level, errors)
+        if isinstance(container.get("id"), str):
+            ids_by_level[level].add(container["id"])
+        if is_layer:
+            counts["layers"] += 1
+            if container.get("taxonomy_role") != "cross-domain-layer":
+                errors.append(f"{container_path}: platform must declare taxonomy_role=cross-domain-layer")
+        else:
+            counts["domains"] += 1
+        capabilities = container.get("capabilities")
+        if not isinstance(capabilities, list) or not capabilities:
+            errors.append(f"{container_path}: capabilities must be a non-empty list")
+            return
+        for capability in capabilities:
+            if not isinstance(capability, dict):
+                errors.append(f"{container_path}.capabilities[?]: must be an object")
+                continue
+            cap_path = f"{container_path}.capabilities[{capability.get('id', '?')}]"
+            require_node_fields(capability, cap_path, "capability", errors)
+            if isinstance(capability.get("id"), str):
+                ids_by_level["capability"].add(capability["id"])
+            counts["capabilities"] += 1
+            features = capability.get("features")
+            if not isinstance(features, list) or not features:
+                errors.append(f"{cap_path}: features must be a non-empty list")
+                continue
+            for feature in features:
+                if not isinstance(feature, dict):
+                    errors.append(f"{cap_path}.features[?]: must be an object")
+                    continue
+                feat_path = f"{cap_path}.features[{feature.get('id', '?')}]"
+                require_node_fields(feature, feat_path, "feature", errors)
+                if isinstance(feature.get("id"), str):
+                    ids_by_level["feature"].add(feature["id"])
+                counts["features"] += 1
+                functions = feature.get("functions")
+                if not isinstance(functions, list) or not functions:
+                    errors.append(f"{feat_path}: functions must be a non-empty list")
+                    continue
+                for function in functions:
+                    if not isinstance(function, dict):
+                        errors.append(f"{feat_path}.functions[?]: must be an object")
+                        continue
+                    fn_path = f"{feat_path}.functions[{function.get('id', '?')}]"
+                    require_node_fields(function, fn_path, "function", errors)
+                    if isinstance(function.get("id"), str):
+                        ids_by_level["function"].add(function["id"])
+                    counts["functions"] += 1
+                    if function.get("function_type") not in ALLOWED_FUNCTION_TYPES:
+                        errors.append(
+                            f"{fn_path}: invalid function_type {function.get('function_type')!r}"
+                        )
+                    check_parameters(function, fn_path, errors)
+
+    for domain in domains:
+        if isinstance(domain, dict):
+            walk_container(domain, f"domains[{domain.get('id', '?')}]")
+    for layer in cross_layers:
+        if isinstance(layer, dict):
+            walk_container(layer, f"cross_domain_layers[{layer.get('id', '?')}]", is_layer=True)
+
+    minimums = {
+        "domains": 7,
+        "layers": 1,
+        "capabilities": 43,
+        "features": 120,
+        "functions": 100,
+    }
+    for key, minimum in minimums.items():
+        if counts[key] < minimum:
+            errors.append(f"{REGISTRY}: expected at least {minimum} {key}, got {counts[key]}")
+
+    missing_capabilities = REQUIRED_CAPABILITIES - ids_by_level["capability"]
+    missing_features = REQUIRED_FEATURES - ids_by_level["feature"]
+    missing_functions = REQUIRED_FUNCTIONS - ids_by_level["function"]
+    if missing_capabilities:
+        errors.append(f"{REGISTRY}: missing capabilities {sorted(missing_capabilities)!r}")
+    if missing_features:
+        errors.append(f"{REGISTRY}: missing features {sorted(missing_features)!r}")
+    if missing_functions:
+        errors.append(f"{REGISTRY}: missing functions {sorted(missing_functions)!r}")
+
+    return errors
+
+
+def check_registry_contract() -> list[str]:
+    errors = require_path(REGISTRY)
+    errors += require_path(SCHEMA)
+    errors += require_path(README)
+    if errors:
+        return errors
+
+    try:
+        registry = read_json(REGISTRY)
+    except json.JSONDecodeError as exc:
+        return [f"{REGISTRY}: invalid JSON: {exc}"]
+    try:
+        schema = read_json(SCHEMA)
+    except json.JSONDecodeError as exc:
+        return [f"{SCHEMA}: invalid JSON: {exc}"]
+
+    for field in ("taxonomy_id", "schema_version", "version", "last_updated", "status", "sources"):
+        if field not in registry:
+            errors.append(f"{REGISTRY}: missing top-level {field}")
+    if registry.get("$schema") != "reference-taxonomy.schema.json":
+        errors.append(f"{REGISTRY}: must reference local schema")
+    if registry.get("taxonomy_id") != "industry-taxonomy":
+        errors.append(f"{REGISTRY}: taxonomy_id must be industry-taxonomy")
+    if registry.get("schema_version") != 1:
+        errors.append(f"{REGISTRY}: schema_version must be 1")
+
+    expected_levels = ["domain", "capability", "feature", "function"]
+    if registry.get("levels") != expected_levels:
+        errors.append(f"{REGISTRY}: levels must be {expected_levels!r}")
+    if set(registry.get("lifecycle_statuses", [])) != ALLOWED_LIFECYCLE:
+        errors.append(f"{REGISTRY}: lifecycle_statuses mismatch")
+    if set(registry.get("function_types", [])) != ALLOWED_FUNCTION_TYPES:
+        errors.append(f"{REGISTRY}: function_types mismatch")
+
+    facets = registry.get("facets", {})
+    channel_values = facets.get("channel", {}).get("allowed_values", {})
+    if channel_values.get("channel_kind") != ["voice", "text", "video"]:
+        errors.append(f"{REGISTRY}: channel_kind values mismatch")
+    if channel_values.get("synchronicity") != ["sync", "async"]:
+        errors.append(f"{REGISTRY}: synchronicity values mismatch")
+    if channel_values.get("direction") != ["inbound", "outbound", "broadcast"]:
+        errors.append(f"{REGISTRY}: direction values mismatch")
+    for facet in ("ai_assisted", "security_compliance", "commercial", "procurement", "industry_vertical", "geography_region"):
+        if facet not in facets:
+            errors.append(f"{REGISTRY}: missing facet {facet!r}")
+
+    if schema.get("$id") != "reference-taxonomy.schema.json":
+        errors.append(f"{SCHEMA}: missing local $id")
+    if "definitions" not in schema:
+        errors.append(f"{SCHEMA}: missing definitions")
+
+    errors += check_registry_nodes(registry)
+    return errors
+
+
+def check_docs_and_ci() -> list[str]:
+    errors: list[str] = []
+    errors += require_text(
+        README,
+        "# Industry Taxonomy",
+        REGISTRY,
+        SCHEMA,
+        "Domain -> Capability -> Feature -> Function",
+        "voice-ucaas",
+        "contact-center",
+        "digital-channels",
+        "ai-automation",
+        "analytics",
+        "hardware",
+        "security",
+        "platform",
+        "channel",
+        "function_type",
+        "evidence_refs",
+    )
+    errors += require_text(KB_README, "kb/industry/", "Industry Taxonomy")
+    errors += require_text(
+        CHANGELOG,
+        "Issue #156",
+        REGISTRY,
+        SCHEMA,
+        README,
+        VALIDATOR,
+    )
+    errors += require_text(MAKEFILE, VALIDATOR)
+    errors += require_text(
+        KB_WORKFLOW,
+        "Validate issue #156 Industry Taxonomy registry",
+        f"python3 {VALIDATOR}",
+    )
+    return errors
+
+
+def main() -> int:
+    errors: list[str] = []
+    errors += check_registry_contract()
+    errors += check_docs_and_ci()
+
+    if errors:
+        print("Issue #156 Industry Taxonomy registry validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("Issue #156 Industry Taxonomy registry validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Fixes G-Ivan-A/mango_ba_prompts#156.

Создан machine-readable Industry Taxonomy registry в `kb/industry/`:

- `kb/industry/reference-taxonomy.json` — JSON-реестр v1.0.0 с 7 canonical domains ADR-011, cross-domain layer `platform`, 46 capabilities, 144 features и 144 functions.
- `kb/industry/reference-taxonomy.schema.json` — локальная JSON Schema для структуры реестра.
- `kb/industry/README.md` — описание namespace, источников, lifecycle, `function_type`, `evidence_refs` и facets включая `channel`.
- `scripts/validate_issue_156_industry_taxonomy_registry.py` — stdlib-only validator, подключённый к `make kb-validate` и KB workflow.

Также обновлён root `kb/README.md`: `kb/industry/` теперь рабочий namespace, а не будущий. Mango product mappings и `industry_ref` в этот реестр не добавлялись.

## Rebase / Conflict Resolution

PR перебазирован на актуальный `main` после merge Issue #154. Конфликты в `.github/workflows/kb.yml`, `Makefile` и `CHANGELOG.md` решены аддитивно: сохранена проверка Issue #154 Mango Taxonomy standard и добавлена проверка Issue #156 Industry Taxonomy registry.

## How To Reproduce

До добавления артефактов новый validator падал с отсутствующими deliverables:

```bash
python3 scripts/validate_issue_156_industry_taxonomy_registry.py
```

Ключевые ошибки до фикса: отсутствовали `kb/industry/reference-taxonomy.json`, `kb/industry/reference-taxonomy.schema.json`, `kb/industry/README.md`, а также Makefile/workflow/CHANGELOG wiring.

## Validation

Пройдено локально:

```bash
python3 scripts/validate_issue_154_mango_taxonomy_standard.py
python3 scripts/validate_issue_156_industry_taxonomy_registry.py
python3 scripts/validate_issue_144_kb_structure_readmes.py && python3 scripts/validate_issue_146_mango_taxonomy.py && python3 scripts/validate_issue_148_taxonomy_extensions.py && python3 scripts/validate_issue_152_industry_taxonomy_standard.py && python3 scripts/validate_issue_154_mango_taxonomy_standard.py && python3 scripts/validate_issue_156_industry_taxonomy_registry.py
python3 -m py_compile scripts/validate_issue_144_kb_structure_readmes.py scripts/validate_issue_154_mango_taxonomy_standard.py scripts/validate_issue_156_industry_taxonomy_registry.py
python3 -m json.tool kb/industry/reference-taxonomy.json
python3 -m json.tool kb/industry/reference-taxonomy.schema.json
git diff --check
```

`make kb-validate` был запущен, но локально останавливается на существующей проверке Issue #131: в этом окружении source PDF остаются Git LFS pointer files. Новый Issue #156 validator и затронутые taxonomy/KB validators проходят.
