### PR TITLE
Add Mango Taxonomy registry

### DIFF
--- a/.github/workflows/kb.yml
+++ b/.github/workflows/kb.yml
@@ -21,12 +21,14 @@ on:
       - "kb/industry/**"
       - "kb/fragments/README.md"
       - "kb/practices/**"
+      - "kb/mango/**"
       - "kb/mango-product-docs/README.md"
       - "kb/mango-product-docs/UPLOAD-GUIDE.md"
       - "kb/mango-product-docs/sources/**"
       - "scripts/kb/**"
       - "scripts/validate_issue_*_kb*.py"
       - "scripts/validate_issue_156_industry_taxonomy_registry.py"
+      - "scripts/validate_issue_160_mango_registry.py"
   workflow_dispatch:
     inputs:
       source_dir:
@@ -119,6 +121,9 @@ jobs:
 
       - name: Validate issue #156 Industry Taxonomy registry
         run: python3 scripts/validate_issue_156_industry_taxonomy_registry.py
+
+      - name: Validate issue #160 Mango registry
+        run: python3 scripts/validate_issue_160_mango_registry.py
 
   # Тяжёлый сквозной прогон извлечения.
   # На workflow_dispatch выполняет выбранный source. На push в main всегда

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-21T19:58:11.218Z for PR creation at branch issue-160-15465885c912 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/160

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-21T19:58:11.218Z for PR creation at branch issue-160-15465885c912 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/160

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,27 @@ ai-generated: true
 
 ## Unreleased
 
+### Added — Issue #160 Mango Taxonomy Registry
+
+- Добавлен machine-readable namespace [`kb/mango/`](kb/mango/README.md) с
+  реестром Mango Taxonomy: Official Layer
+  [`kb/mango/official-products.yaml`](kb/mango/official-products.yaml),
+  Internal Layer
+  [`kb/mango/internal-registry.yaml`](kb/mango/internal-registry.yaml) и
+  crosswalk
+  [`kb/mango/product-mapping.yaml`](kb/mango/product-mapping.yaml) к Industry
+  Taxonomy.
+- Реестр покрывает публичные продукты Mango Office, 8 внутренних кластеров,
+  иерархию `Product -> Service -> Module -> Function`, evidence refs из
+  `kb/mango-product-docs/processed/`, `function_type`, `interaction_surface`,
+  `maps_to.industry_alignment` и явные `mapping_gap` для отсутствующих
+  отраслевых Feature/Function.
+- Добавлена документация [`kb/mango/README.md`](kb/mango/README.md), helper
+  [`experiments/issue-160-generate-mango-registry.py`](experiments/issue-160-generate-mango-registry.py)
+  и регрессионная проверка
+  [`scripts/validate_issue_160_mango_registry.py`](scripts/validate_issue_160_mango_registry.py),
+  подключённая к `make kb-validate` и KB workflow.
+
 ### Added — Issue #158 независимый аудит стандартов таксономии
 
 - Добавлен независимый аудиторский отчёт

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ kb-validate:
 	$(PYTHON) scripts/validate_issue_152_industry_taxonomy_standard.py
 	$(PYTHON) scripts/validate_issue_154_mango_taxonomy_standard.py
 	$(PYTHON) scripts/validate_issue_156_industry_taxonomy_registry.py
+	$(PYTHON) scripts/validate_issue_160_mango_registry.py
 
 # Наглядно: токены индекса vs отдельных разделов (метод — см. token_method).
 kb-tokens:

--- a/experiments/issue-160-generate-mango-registry.py
+++ b/experiments/issue-160-generate-mango-registry.py
@@ -1,0 +1,1051 @@
+#!/usr/bin/env python3
+"""Generate the issue #160 Mango Taxonomy registry artifacts.
+
+The committed registry files intentionally use a JSON-compatible YAML subset so
+the lightweight CI validator can stay stdlib-only.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+OUT = ROOT / "kb" / "mango"
+
+PRODUCTS_URL = "https://www.mango-office.ru/products/"
+VATS_URL = "https://www.mango-office.ru/products/virtualnaya_ats/"
+CC_URL = "https://www.mango-office.ru/products/contact-center/"
+CC_FEATURES_URL = "https://www.mango-office.ru/products/contact-center/vozmozhnosti/"
+CALLTRACKING_URL = "https://www.mango-office.ru/products/calltracking/"
+SPEECH_URL = "https://www.mango-office.ru/products/virtualnaya_ats/vozmozhnosti/speech-analytics/"
+ROBOT_URL = "https://www.mango-office.ru/products/contact-center/ai/voice-robot/"
+TALKER_URL = "https://www.mango-office.ru/products/mango-talker/"
+INTEGRATIONS_URL = "https://www.mango-office.ru/products/integraciya/"
+DEVICES_URL = "https://www.mango-office.ru/shop/devices/"
+
+LK_INDEX = "kb/mango-product-docs/processed/mango-lk-manual/index.md"
+LK_IVR = "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md"
+LK_LINES = "kb/mango-product-docs/processed/mango-lk-manual/sections/105-nastroyki-dlya-vhodyaschih-liniy.md"
+LK_NUMBERS = "kb/mango-product-docs/processed/mango-lk-manual/sections/100-nomera-podklyuchennye-k-ats.md"
+LK_EMPLOYEES = "kb/mango-product-docs/processed/mango-lk-manual/sections/111-sotrudniki-i-gruppy.md"
+LK_GROUPS = "kb/mango-product-docs/processed/mango-lk-manual/sections/118-rabota-s-gruppami.md"
+LK_RECORDING = "kb/mango-product-docs/processed/mango-lk-manual/sections/134-zapis-razgovorov.md"
+LK_RECORDINGS = "kb/mango-product-docs/processed/mango-lk-manual/sections/135-zapisannye-razgovory.md"
+LK_TEXT = "kb/mango-product-docs/processed/mango-lk-manual/sections/179-tekstovye-kommunikacii.md"
+LK_CHAT = "kb/mango-product-docs/processed/mango-lk-manual/sections/189-chat-na-sayte.md"
+LK_WHATSAPP = "kb/mango-product-docs/processed/mango-lk-manual/sections/191-whatsapp.md"
+LK_TELEGRAM = "kb/mango-product-docs/processed/mango-lk-manual/sections/192-telegram.md"
+LK_ANALYTICS = "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+LK_WALLBOARD = "kb/mango-product-docs/processed/mango-lk-manual/sections/234-wallboard.md"
+LK_ROLES = "kb/mango-product-docs/processed/mango-lk-manual/sections/286-nastroyka-prav-dostupa-roli.md"
+LK_SECURITY = "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md"
+
+CC_INDEX = "kb/mango-product-docs/processed/mango-cc-manual/index.md"
+CC_AGENT_STATUS = "kb/mango-product-docs/processed/mango-cc-manual/sections/05-upravlenie-statusom.md"
+CC_QUEUE = "kb/mango-product-docs/processed/mango-cc-manual/sections/07-ochered-obrascheniy.md"
+CC_OUTBOUND = "kb/mango-product-docs/processed/mango-cc-manual/sections/46-sovershenie-ishodyaschih-vyzovov.md"
+CC_ROUTING = "kb/mango-product-docs/processed/mango-cc-manual/sections/64-avtomaticheskoe-raspredelenie-obrascheni.md"
+CC_CAMPAIGNS = "kb/mango-product-docs/processed/mango-cc-manual/sections/123-ishodyaschiy-obzvon.md"
+CC_ADD_CAMPAIGN = "kb/mango-product-docs/processed/mango-cc-manual/sections/127-dobavlenie-kampanii.md"
+CC_DASHBOARD = "kb/mango-product-docs/processed/mango-cc-manual/sections/57-dashboard.md"
+CC_WIDGET = "kb/mango-product-docs/processed/mango-cc-manual/sections/58-sozdanie-i-nastroyka-vidzheta.md"
+CC_WFM = "kb/mango-product-docs/processed/mango-cc-manual/sections/100-planirovanie-vhodyaschih.md"
+CC_SPEECH = "kb/mango-product-docs/processed/mango-cc-manual/sections/178-rechevaya-analitika.md"
+CC_CHECKLIST = "kb/mango-product-docs/processed/mango-cc-manual/sections/184-konstruktor-chek-listov.md"
+CC_ROLES = "kb/mango-product-docs/processed/mango-cc-manual/sections/217-prilozhenie-1-upravlenie-pravami-dostupa.md"
+
+TALKER_INDEX = "kb/mango-product-docs/processed/mtalker/android-user-guide/index.md"
+TALKER_CALL = "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/11-zvonok-sotrudniku.md"
+TALKER_ANSWER = "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/15-kak-prinyat-vhodyaschiy-zvonok.md"
+TALKER_CHAT = "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/17-otpravka-soobscheniya-v-chat.md"
+TALKER_CHANNEL = "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/47-sozdanie-novogo-chata-ili-kanala.md"
+TALKER_VIDEO = "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/14-kak-nachat-gruppovoy-videozvonok.md"
+TALKER_CONFERENCE = "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/42-kak-prisoedinitsya-k-konferencii-po-ssyl.md"
+TALKER_CONTACT = "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/97-opisanie-kartochki-kontakta.md"
+TALKER_HISTORY = "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/78-opisanie-zhurnala-vyzovov.md"
+
+VPBX_API_INDEX = "kb/mango-product-docs/processed/vpbx-api/index.md"
+VPBX_API_CALL = "kb/mango-product-docs/processed/vpbx-api/sections/246-iniciirovanie-ishodyaschego-vyzova.md"
+VPBX_API_ROUTE = "kb/mango-product-docs/processed/vpbx-api/sections/42-marshrutizaciya-vyzova.md"
+VPBX_API_WEBHOOK = "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md"
+VPBX_API_SMS = "kb/mango-product-docs/processed/vpbx-api/sections/39-otpravka-sms.md"
+VPBX_API_RECORD = "kb/mango-product-docs/processed/vpbx-api/sections/40-vklyuchenie-zapisi-razgovora.md"
+VPBX_API_STATS = "kb/mango-product-docs/processed/vpbx-api/sections/58-poluchenie-statistiki-vyzovov.md"
+VPBX_API_CC_TASK = "kb/mango-product-docs/processed/vpbx-api/sections/157-sozdanie-zadachi-na-avtoperezvon.md"
+VPBX_API_CC_EVENT = "kb/mango-product-docs/processed/vpbx-api/sections/215-sobytiya.md"
+VPBX_API_DIALOG_SEND = "kb/mango-product-docs/processed/vpbx-api/sections/238-otpravka-soobscheniya.md"
+VPBX_API_DIALOG_EVENT = "kb/mango-product-docs/processed/vpbx-api/sections/239-opoveschenie-o-tom-chto-polzovatel-nabir.md"
+
+MDIALOGI_API_INDEX = "kb/mango-product-docs/processed/mdialogi-api/index.md"
+BITRIX_INDEX = "kb/mango-product-docs/processed/integration-bitrix24/index.md"
+ONE_C_INDEX = "kb/mango-product-docs/processed/integration_1c/index.md"
+AMOCRM_INDEX = "kb/mango-product-docs/processed/integration_amocrm/index.md"
+SSO_INDEX = "kb/mango-product-docs/processed/lk-vats-sso/index.md"
+ROLE_MODEL_INDEX = "kb/mango-product-docs/processed/Rolevaya-model-vats/index.md"
+QUALITY_INDEX = "kb/mango-product-docs/processed/quality-managment/index.md"
+SPEECH_INDEX = "kb/mango-product-docs/processed/speech-analytics/index.md"
+WALLBOARD_INDEX = "kb/mango-product-docs/processed/wallboard/index.md"
+SIP_TRUNK_INDEX = "kb/mango-product-docs/processed/sip-trunk/index.md"
+
+
+def channel(kind: str, sync: str, direction: str) -> dict[str, Any]:
+    return {
+        "channel": {
+            "channel_kind": kind,
+            "synchronicity": sync,
+            "direction": direction,
+        }
+    }
+
+
+def gap(level: str, proposed_id: str, reason: str) -> dict[str, Any]:
+    return {"missing_level": level, "proposed_id": proposed_id, "reason": reason}
+
+
+def align(
+    domain: str,
+    capability: str | None = None,
+    feature: str | None = None,
+    function: str | None = None,
+    *,
+    alignment_type: str = "primary",
+    evidence_refs: list[str] | None = None,
+    facets: dict[str, Any] | None = None,
+    mapping_gap: dict[str, Any] | None = None,
+    supporting_only_reason: str | None = None,
+) -> dict[str, Any]:
+    industry_ref: dict[str, str] = {"domain": domain}
+    if capability:
+        industry_ref["capability"] = capability
+    if feature:
+        industry_ref["feature"] = feature
+    if function:
+        industry_ref["function"] = function
+    item: dict[str, Any] = {
+        "alignment_type": alignment_type,
+        "industry_ref": industry_ref,
+        "evidence_refs": evidence_refs or [],
+    }
+    if facets:
+        item["facets"] = facets
+    if mapping_gap:
+        item["mapping_gap"] = mapping_gap
+    if supporting_only_reason:
+        item["supporting_only_reason"] = supporting_only_reason
+    return item
+
+
+def with_evidence(alignments: list[dict[str, Any]], evidence_refs: list[str]) -> list[dict[str, Any]]:
+    result = []
+    for item in alignments:
+        clone = dict(item)
+        if not clone.get("evidence_refs"):
+            clone["evidence_refs"] = evidence_refs
+        result.append(clone)
+    return result
+
+
+def entity(
+    entity_id: str,
+    level: str,
+    name_ru: str,
+    description: str,
+    evidence_refs: list[str],
+    alignments: list[dict[str, Any]],
+    **extra: Any,
+) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "id": entity_id,
+        "level": level,
+        "name_ru": name_ru,
+        "description": description,
+        "lifecycle_status": "active",
+        "evidence_refs": evidence_refs,
+        "maps_to": {"industry_alignment": with_evidence(alignments, evidence_refs)},
+    }
+    item.update(extra)
+    return item
+
+
+official_products = [
+    entity(
+        "mango-virtual-pbx-official",
+        "official-product",
+        "Виртуальная АТС",
+        "Публичный продукт Mango Office для облачной офисной телефонии, маршрутизации звонков и управления номерами.",
+        [VATS_URL, LK_INDEX],
+        [align("voice-ucaas", "cloud-pbx")],
+        aliases=["ВАТС", "Virtual PBX", "Облачная АТС"],
+        owner="Mango Office",
+        official_urls=[VATS_URL],
+        supported_by_services=[
+            "vats-inbound-routing-service",
+            "vats-ivr-service",
+            "vats-number-management-service",
+            "vats-recording-history-service",
+        ],
+    ),
+    entity(
+        "mango-sip-trunk-official",
+        "official-product",
+        "SIP Trunk и гибридная телефония",
+        "Публичный набор возможностей подключения внешней телефонии и SIP-инфраструктуры к Виртуальной АТС.",
+        [PRODUCTS_URL, SIP_TRUNK_INDEX],
+        [align("voice-ucaas", "sip-connectivity")],
+        aliases=["SIP Trunk", "Гибридная АТС"],
+        owner="Mango Office",
+        official_urls=[PRODUCTS_URL],
+        supported_by_services=["vats-number-management-service", "vpbx-open-api-service"],
+    ),
+    entity(
+        "mango-contact-center-official",
+        "official-product",
+        "Контакт-центр",
+        "Публичный продукт для обработки обращений, рабочих мест операторов, очередей и супервизорского контроля.",
+        [CC_URL, CC_INDEX],
+        [align("contact-center", "omnichannel-contact-center")],
+        aliases=["КЦ", "Contact Center"],
+        owner="Mango Office",
+        official_urls=[CC_URL, CC_FEATURES_URL],
+        supported_by_services=[
+            "cc-agent-workspace-service",
+            "cc-interaction-routing-service",
+            "cc-outbound-campaign-service",
+            "cc-supervisor-wfm-service",
+            "quality-checklist-service",
+        ],
+    ),
+    entity(
+        "mango-text-communications-official",
+        "official-product",
+        "Текстовые коммуникации",
+        "Публичный продуктовый слой для сайта, мессенджеров, шаблонов и цифровых диалогов.",
+        [PRODUCTS_URL, LK_TEXT],
+        [align("digital-channels", "omnichannel-messaging", facets=channel("text", "async", "inbound"))],
+        aliases=["Текстовые коммуникации", "Digital channels"],
+        owner="Mango Office",
+        official_urls=[PRODUCTS_URL],
+        supported_by_services=[
+            "digital-channel-group-service",
+            "website-chat-service",
+            "messenger-channel-service",
+            "dialog-api-messaging-service",
+        ],
+    ),
+    entity(
+        "mango-calltracking-official",
+        "official-product",
+        "Коллтрекинг и маркетинговая аналитика",
+        "Публичный продукт для привязки звонков к рекламным источникам и оценки эффективности маркетинга.",
+        [CALLTRACKING_URL, LK_ANALYTICS],
+        [align("analytics", "call-tracking")],
+        aliases=["Calltracking", "Коллтрекинг", "Сквозная аналитика"],
+        owner="Mango Office",
+        official_urls=[CALLTRACKING_URL],
+        supported_by_services=[
+            "calltracking-attribution-service",
+            "end-to-end-analytics-service",
+            "reporting-dashboard-service",
+        ],
+    ),
+    entity(
+        "mango-speech-analytics-official",
+        "official-product",
+        "Речевая аналитика",
+        "Публичный AI-продукт для распознавания и анализа разговоров.",
+        [SPEECH_URL, SPEECH_INDEX, CC_SPEECH],
+        [align("ai-automation", "speech-analytics", facets={"ai_assisted": True})],
+        aliases=["Speech Analytics", "Речевая аналитика"],
+        owner="Mango Office",
+        official_urls=[SPEECH_URL],
+        supported_by_services=[
+            "speech-analytics-service",
+            "conversation-summary-service",
+            "quality-checklist-service",
+        ],
+    ),
+    entity(
+        "mango-robots-official",
+        "official-product",
+        "Роботы",
+        "Публичный AI-продукт для автоматизированных голосовых сценариев и диалогов.",
+        [ROBOT_URL, PRODUCTS_URL],
+        [align("ai-automation", "voice-bot", facets={"ai_assisted": True, **channel("voice", "sync", "outbound")})],
+        aliases=["Голосовые роботы", "Voice Robot"],
+        owner="Mango Office",
+        official_urls=[ROBOT_URL],
+        supported_by_services=["voice-robot-service"],
+    ),
+    entity(
+        "mango-talker-official",
+        "official-product",
+        "Mango Talker",
+        "Публичный продукт корпоративных звонков, чатов, видеозвонков и контактной истории.",
+        [TALKER_URL, TALKER_INDEX],
+        [align("voice-ucaas", "unified-communications")],
+        aliases=["Mango Talker", "MTalker"],
+        owner="Mango Office",
+        official_urls=[TALKER_URL],
+        supported_by_services=[
+            "talker-softphone-service",
+            "talker-team-chat-service",
+            "talker-video-meeting-service",
+            "talker-contact-history-service",
+        ],
+    ),
+    entity(
+        "mango-integrations-official",
+        "official-product",
+        "Интеграции",
+        "Публичный продуктовый слой интеграций Mango Office с CRM, ERP, API и webhooks.",
+        [INTEGRATIONS_URL, BITRIX_INDEX, ONE_C_INDEX, AMOCRM_INDEX],
+        [align("platform", "platform-integration")],
+        aliases=["Интеграции", "CRM integrations"],
+        owner="Mango Office",
+        official_urls=[INTEGRATIONS_URL],
+        supported_by_services=[
+            "vpbx-open-api-service",
+            "contact-center-api-service",
+            "crm-erp-integration-service",
+            "webhook-event-service",
+        ],
+    ),
+    entity(
+        "mango-numbers-equipment-official",
+        "official-product",
+        "Номера и оборудование",
+        "Публичный продуктовый слой подключения номеров, устройств и телефонной инфраструктуры.",
+        [DEVICES_URL, LK_NUMBERS],
+        [align("hardware", "device-management")],
+        aliases=["Оборудование", "Номера", "Devices"],
+        owner="Mango Office",
+        official_urls=[DEVICES_URL],
+        supported_by_services=["vats-number-management-service"],
+    ),
+]
+
+
+product_specs = [
+    {
+        "id": "mango-virtual-pbx",
+        "name": "Mango Virtual PBX",
+        "description": "Внутренний продуктовый кластер Виртуальной АТС: входящие сценарии, IVR, номера и записи разговоров.",
+        "official_refs": ["mango-virtual-pbx-official", "mango-sip-trunk-official", "mango-numbers-equipment-official"],
+        "services": [
+            "vats-inbound-routing-service",
+            "vats-ivr-service",
+            "vats-number-management-service",
+            "vats-recording-history-service",
+        ],
+        "evidence": [VATS_URL, LK_INDEX],
+        "alignments": [align("voice-ucaas", "cloud-pbx")],
+    },
+    {
+        "id": "mango-contact-center",
+        "name": "Mango Contact Center",
+        "description": "Внутренний продуктовый кластер Контакт-центра: операторские рабочие места, очереди, кампании и WFM.",
+        "official_refs": ["mango-contact-center-official"],
+        "services": [
+            "cc-agent-workspace-service",
+            "cc-interaction-routing-service",
+            "cc-outbound-campaign-service",
+            "cc-supervisor-wfm-service",
+        ],
+        "evidence": [CC_URL, CC_INDEX],
+        "alignments": [align("contact-center", "omnichannel-contact-center")],
+    },
+    {
+        "id": "mango-digital-communications",
+        "name": "Mango Digital Communications",
+        "description": "Внутренний продуктовый кластер текстовых каналов, чата на сайте, мессенджеров и Dialog API.",
+        "official_refs": ["mango-text-communications-official"],
+        "services": [
+            "digital-channel-group-service",
+            "website-chat-service",
+            "messenger-channel-service",
+            "dialog-api-messaging-service",
+        ],
+        "evidence": [PRODUCTS_URL, LK_TEXT, MDIALOGI_API_INDEX],
+        "alignments": [align("digital-channels", "omnichannel-messaging", facets=channel("text", "async", "inbound"))],
+    },
+    {
+        "id": "mango-talker",
+        "name": "Mango Talker",
+        "description": "Внутренний продуктовый кластер приложения Mango Talker: софтфон, командные чаты, видео и контакты.",
+        "official_refs": ["mango-talker-official"],
+        "services": [
+            "talker-softphone-service",
+            "talker-team-chat-service",
+            "talker-video-meeting-service",
+            "talker-contact-history-service",
+        ],
+        "evidence": [TALKER_URL, TALKER_INDEX],
+        "alignments": [align("voice-ucaas", "unified-communications")],
+    },
+    {
+        "id": "mango-ai-speech-quality",
+        "name": "Mango AI Speech and Quality",
+        "description": "Внутренний продуктовый кластер AI, речевой аналитики, конспектов, чек-листов качества и голосовых роботов.",
+        "official_refs": ["mango-speech-analytics-official", "mango-robots-official"],
+        "services": [
+            "speech-analytics-service",
+            "conversation-summary-service",
+            "quality-checklist-service",
+            "voice-robot-service",
+        ],
+        "evidence": [SPEECH_URL, SPEECH_INDEX, QUALITY_INDEX],
+        "alignments": [align("ai-automation", "speech-analytics", facets={"ai_assisted": True})],
+    },
+    {
+        "id": "mango-marketing-analytics",
+        "name": "Mango Marketing Analytics",
+        "description": "Внутренний продуктовый кластер коллтрекинга, сквозной аналитики, отчётов и real-time панелей.",
+        "official_refs": ["mango-calltracking-official"],
+        "services": [
+            "calltracking-attribution-service",
+            "end-to-end-analytics-service",
+            "reporting-dashboard-service",
+            "wallboard-monitoring-service",
+        ],
+        "evidence": [CALLTRACKING_URL, LK_ANALYTICS, WALLBOARD_INDEX],
+        "alignments": [align("analytics", "call-tracking")],
+    },
+    {
+        "id": "mango-platform-integrations",
+        "name": "Mango Platform Integrations",
+        "description": "Внутренний продуктовый кластер API, webhooks и CRM/ERP-интеграций.",
+        "official_refs": ["mango-integrations-official"],
+        "services": [
+            "vpbx-open-api-service",
+            "contact-center-api-service",
+            "crm-erp-integration-service",
+            "webhook-event-service",
+        ],
+        "evidence": [INTEGRATIONS_URL, VPBX_API_INDEX, BITRIX_INDEX],
+        "alignments": [align("platform", "open-api")],
+    },
+    {
+        "id": "mango-security-access",
+        "name": "Mango Security and Access",
+        "description": "Внутренний cross-product кластер ролей, SSO, доступа к записям и аудита безопасности.",
+        "internal_only_reason": "Кластер выделен как внутренний слой поверх публичных продуктов, потому что права доступа и безопасность обслуживают несколько продуктовых линий.",
+        "services": [
+            "role-access-management-service",
+            "sso-identity-service",
+            "recording-access-security-service",
+            "security-audit-settings-service",
+        ],
+        "evidence": [ROLE_MODEL_INDEX, SSO_INDEX, LK_SECURITY],
+        "alignments": [align("security", "access-control")],
+    },
+]
+
+
+service_specs = [
+    {
+        "id": "vats-inbound-routing-service",
+        "product": "mango-virtual-pbx",
+        "cluster": "vats-core",
+        "name": "Входящая маршрутизация ВАТС",
+        "description": "Сервис входящих схем, правил и распределения голосовых вызовов.",
+        "module": ("vats-inbound-scenarios-module", "Сценарии входящих звонков"),
+        "evidence": [LK_IVR, LK_LINES, VPBX_API_ROUTE],
+        "alignments": [align("voice-ucaas", "call-routing", facets=channel("voice", "sync", "inbound"))],
+        "functions": [
+            ("receive-inbound-call-through-scenario", "Принять входящий звонок по сценарию", "business", "system-rule", [align("voice-ucaas", "voice-channel", "inbound-voice-call", "receive-inbound-call", facets=channel("voice", "sync", "inbound"))], LK_LINES),
+            ("configure-inbound-call-scenario", "Настроить сценарий входящего звонка", "configuration", "admin-ui", [align("voice-ucaas", "call-routing", facets=channel("voice", "sync", "inbound"), mapping_gap=gap("feature", "inbound-call-scenario", "Industry Taxonomy фиксирует capability call-routing, но не выделяет сценарии ВАТС как feature."))], LK_IVR),
+        ],
+    },
+    {
+        "id": "vats-ivr-service",
+        "product": "mango-virtual-pbx",
+        "cluster": "vats-core",
+        "name": "Голосовое меню ВАТС",
+        "description": "Сервис IVR-меню, приветствий и ветвления входящих звонков.",
+        "module": ("vats-ivr-menu-module", "Голосовое меню"),
+        "evidence": [LK_IVR],
+        "alignments": [align("voice-ucaas", "ivr-voice-menu", facets=channel("voice", "sync", "inbound"))],
+        "functions": [
+            ("play-ivr-menu-to-caller", "Проиграть голосовое меню звонящему", "business", "system-rule", [align("voice-ucaas", "ivr-voice-menu", facets=channel("voice", "sync", "inbound"), mapping_gap=gap("function", "play-ivr-menu", "Industry Taxonomy не содержит leaf-функцию проигрывания IVR."))], LK_IVR),
+            ("edit-ivr-menu-branch", "Изменить ветку голосового меню", "configuration", "admin-ui", [align("voice-ucaas", "ivr-voice-menu", facets=channel("voice", "sync", "inbound"), mapping_gap=gap("function", "edit-ivr-branch", "Industry Taxonomy не содержит leaf-функцию редактирования веток IVR."))], LK_IVR),
+        ],
+    },
+    {
+        "id": "vats-number-management-service",
+        "product": "mango-virtual-pbx",
+        "cluster": "vats-core",
+        "name": "Управление номерами ВАТС",
+        "description": "Сервис подключённых номеров, входящих линий и SIP-инфраструктуры.",
+        "module": ("vats-connected-numbers-module", "Подключённые номера"),
+        "evidence": [LK_NUMBERS, SIP_TRUNK_INDEX],
+        "alignments": [align("voice-ucaas", "number-management")],
+        "functions": [
+            ("assign-connected-number-route", "Назначить маршрут подключённому номеру", "configuration", "admin-ui", [align("voice-ucaas", "number-management", mapping_gap=gap("function", "assign-number-route", "Industry Taxonomy не содержит leaf-функцию назначения маршрута номеру."))], LK_NUMBERS),
+            ("view-connected-number-list", "Открыть список подключённых номеров", "ui-action", "admin-ui", [align("voice-ucaas", "number-management", mapping_gap=gap("function", "view-number-list", "Industry Taxonomy не содержит UI leaf-функцию просмотра списка номеров."))], LK_NUMBERS),
+        ],
+    },
+    {
+        "id": "vats-recording-history-service",
+        "product": "mango-virtual-pbx",
+        "cluster": "vats-core",
+        "name": "Записи и история звонков ВАТС",
+        "description": "Сервис записи разговоров, журнала вызовов и доступа к сохранённым разговорам.",
+        "module": ("vats-call-recording-module", "Запись разговоров"),
+        "evidence": [LK_RECORDING, LK_RECORDINGS, VPBX_API_RECORD],
+        "alignments": [align("voice-ucaas", "call-recording", facets=channel("voice", "sync", "inbound"))],
+        "functions": [
+            ("enable-call-recording-rule", "Включить правило записи разговора", "configuration", "admin-ui", [align("voice-ucaas", "call-recording", facets=channel("voice", "sync", "inbound"), mapping_gap=gap("function", "enable-call-recording-rule", "Industry Taxonomy не содержит leaf-функцию включения правила записи."))], LK_RECORDING),
+            ("play-call-recording", "Прослушать запись разговора", "ui-action", "admin-ui", [align("voice-ucaas", "call-recording", facets=channel("voice", "sync", "inbound"), mapping_gap=gap("function", "play-call-recording", "Industry Taxonomy не содержит UI leaf-функцию прослушивания записи."))], LK_RECORDINGS),
+        ],
+    },
+    {
+        "id": "cc-agent-workspace-service",
+        "product": "mango-contact-center",
+        "cluster": "contact-center-core",
+        "name": "Рабочее место оператора КЦ",
+        "description": "Сервис операторского интерфейса для звонков, статусов и обработки обращений.",
+        "module": ("cc-agent-call-handling-module", "Обработка обращений оператором"),
+        "evidence": [CC_AGENT_STATUS, CC_QUEUE, CC_OUTBOUND],
+        "alignments": [align("contact-center", "agent-workspace")],
+        "functions": [
+            ("accept-queue-interaction", "Принять обращение из очереди", "business", "operator-ui", [align("contact-center", "agent-workspace", mapping_gap=gap("function", "accept-queue-interaction", "Industry Taxonomy не содержит leaf-функцию принятия обращения оператором."))], CC_QUEUE),
+            ("set-agent-status", "Изменить статус оператора", "ui-action", "operator-ui", [align("contact-center", "agent-workspace", mapping_gap=gap("function", "set-agent-status", "Industry Taxonomy не содержит UI leaf-функцию смены статуса оператора."))], CC_AGENT_STATUS),
+        ],
+    },
+    {
+        "id": "cc-interaction-routing-service",
+        "product": "mango-contact-center",
+        "cluster": "contact-center-core",
+        "name": "Маршрутизация обращений КЦ",
+        "description": "Сервис очередей, автоматического распределения и правил маршрутизации обращений.",
+        "module": ("cc-queue-routing-module", "Очереди и правила распределения"),
+        "evidence": [CC_QUEUE, CC_ROUTING],
+        "alignments": [align("contact-center", "interaction-routing", "queue-routing")],
+        "functions": [
+            ("route-interaction-to-queue", "Распределить обращение в очередь", "business", "system-rule", [align("contact-center", "interaction-routing", "queue-routing", mapping_gap=gap("function", "route-interaction-to-queue", "Industry Taxonomy фиксирует queue-routing, но не содержит leaf-функцию распределения обращения."))], CC_ROUTING),
+            ("configure-queue-routing-rule", "Настроить правило очереди", "configuration", "admin-ui", [align("contact-center", "interaction-routing", "routing-rules", mapping_gap=gap("function", "configure-queue-routing-rule", "Industry Taxonomy фиксирует routing-rules, но не содержит leaf-функцию настройки правила."))], CC_ROUTING),
+        ],
+    },
+    {
+        "id": "cc-outbound-campaign-service",
+        "product": "mango-contact-center",
+        "cluster": "contact-center-core",
+        "name": "Исходящие кампании КЦ",
+        "description": "Сервис кампаний исходящего обзвона, карточек кампаний и запуска задач.",
+        "module": ("cc-outbound-campaign-module", "Кампании исходящего обзвона"),
+        "evidence": [CC_CAMPAIGNS, CC_ADD_CAMPAIGN],
+        "alignments": [align("contact-center", "outbound-calling", "campaign-management")],
+        "functions": [
+            ("start-outbound-campaign", "Запустить исходящую кампанию", "business", "operator-ui", [align("contact-center", "outbound-calling", "campaign-management", "start-campaign", facets=channel("voice", "sync", "outbound"))], CC_CAMPAIGNS),
+            ("configure-outbound-campaign", "Настроить исходящую кампанию", "configuration", "admin-ui", [align("contact-center", "outbound-calling", "campaign-management", mapping_gap=gap("function", "configure-outbound-campaign", "Industry Taxonomy содержит start-campaign, но не содержит отдельную функцию конфигурации кампании."))], CC_ADD_CAMPAIGN),
+        ],
+    },
+    {
+        "id": "cc-supervisor-wfm-service",
+        "product": "mango-contact-center",
+        "cluster": "contact-center-core",
+        "name": "Супервизорский контроль и WFM",
+        "description": "Сервис супервизорских панелей, графиков и планирования нагрузки.",
+        "module": ("cc-supervisor-wfm-module", "Планирование и супервизорский мониторинг"),
+        "evidence": [CC_DASHBOARD, CC_WFM, CC_WIDGET],
+        "alignments": [align("contact-center", "workforce-management"), align("contact-center", "supervisor-workspace", alignment_type="secondary")],
+        "functions": [
+            ("monitor-agent-workload", "Просмотреть нагрузку операторов", "ui-action", "operator-ui", [align("contact-center", "supervisor-workspace", mapping_gap=gap("function", "monitor-agent-workload", "Industry Taxonomy не содержит UI leaf-функцию просмотра нагрузки операторов."))], CC_DASHBOARD),
+            ("configure-workforce-schedule", "Настроить график входящих обращений", "configuration", "admin-ui", [align("contact-center", "workforce-management", mapping_gap=gap("function", "configure-workforce-schedule", "Industry Taxonomy не содержит leaf-функцию настройки графика WFM."))], CC_WFM),
+        ],
+    },
+    {
+        "id": "digital-channel-group-service",
+        "product": "mango-digital-communications",
+        "cluster": "digital-channels",
+        "name": "Группы текстовых каналов",
+        "description": "Сервис объединения цифровых каналов, расписаний и правил обработки диалогов.",
+        "module": ("digital-channel-group-module", "Группы каналов коммуникации"),
+        "evidence": [LK_TEXT, LK_WHATSAPP, LK_TELEGRAM],
+        "alignments": [align("digital-channels", "omnichannel-messaging", facets=channel("text", "async", "inbound"))],
+        "functions": [
+            ("send-channel-message", "Отправить сообщение в цифровом канале", "business", "operator-ui", [align("digital-channels", "omnichannel-messaging", "messenger-integration", "send-message", facets=channel("text", "async", "outbound"))], LK_TEXT),
+            ("configure-channel-group", "Настроить группу каналов", "configuration", "admin-ui", [align("digital-channels", "omnichannel-messaging", facets=channel("text", "async", "inbound"), mapping_gap=gap("function", "configure-channel-group", "Industry Taxonomy не содержит leaf-функцию настройки группы каналов."))], LK_TEXT),
+        ],
+    },
+    {
+        "id": "website-chat-service",
+        "product": "mango-digital-communications",
+        "cluster": "digital-channels",
+        "name": "Чат на сайте",
+        "description": "Сервис виджета сайта, кода установки и обработки входящих чат-диалогов.",
+        "module": ("website-chat-widget-module", "Виджет чата на сайте"),
+        "evidence": [LK_CHAT],
+        "alignments": [align("digital-channels", "website-chat", facets=channel("text", "async", "inbound"))],
+        "functions": [
+            ("receive-website-chat", "Принять обращение из чата сайта", "business", "operator-ui", [align("digital-channels", "website-chat", facets=channel("text", "async", "inbound"), mapping_gap=gap("function", "receive-website-chat", "Industry Taxonomy не содержит leaf-функцию приёма обращения из сайта."))], LK_CHAT),
+            ("install-website-chat-widget", "Установить код виджета чата", "configuration", "admin-ui", [align("digital-channels", "website-chat", mapping_gap=gap("function", "install-website-chat-widget", "Industry Taxonomy не содержит leaf-функцию установки виджета сайта."))], LK_CHAT),
+        ],
+    },
+    {
+        "id": "messenger-channel-service",
+        "product": "mango-digital-communications",
+        "cluster": "digital-channels",
+        "name": "Мессенджер-каналы",
+        "description": "Сервис подключения Telegram, WhatsApp и других мессенджеров к группам каналов.",
+        "module": ("messenger-channel-connector-module", "Подключение мессенджеров"),
+        "evidence": [LK_WHATSAPP, LK_TELEGRAM],
+        "alignments": [align("digital-channels", "omnichannel-messaging", "messenger-integration", facets=channel("text", "async", "inbound"))],
+        "functions": [
+            ("connect-telegram-channel", "Подключить Telegram-канал", "configuration", "admin-ui", [align("digital-channels", "omnichannel-messaging", "messenger-integration", facets=channel("text", "async", "inbound"), mapping_gap=gap("function", "connect-telegram-channel", "Industry Taxonomy не содержит leaf-функцию подключения конкретного мессенджера."))], LK_TELEGRAM),
+            ("reply-to-messenger-dialog", "Ответить в диалоге мессенджера", "business", "operator-ui", [align("digital-channels", "omnichannel-messaging", "messenger-integration", "send-message", facets=channel("text", "async", "outbound"))], LK_WHATSAPP),
+        ],
+    },
+    {
+        "id": "dialog-api-messaging-service",
+        "product": "mango-digital-communications",
+        "cluster": "digital-channels",
+        "name": "Dialog API",
+        "description": "Сервис программного обмена сообщениями и событиями цифровых диалогов.",
+        "module": ("dialog-api-message-module", "API сообщений Dialogi"),
+        "evidence": [MDIALOGI_API_INDEX, VPBX_API_DIALOG_SEND, VPBX_API_DIALOG_EVENT],
+        "alignments": [align("platform", "communications-apis"), align("digital-channels", "omnichannel-messaging", alignment_type="secondary", facets=channel("text", "async", "outbound"))],
+        "functions": [
+            ("send-dialog-api-message", "Отправить сообщение через Dialog API", "business", "api", [align("digital-channels", "omnichannel-messaging", "messenger-integration", "send-message", facets=channel("text", "async", "outbound")), align("platform", "communications-apis", alignment_type="supporting")], VPBX_API_DIALOG_SEND),
+            ("receive-dialog-api-event", "Получить событие Dialog API", "business", "webhook", [align("platform", "open-api", "webhook-management", "configure-webhook-endpoint", facets=channel("text", "async", "inbound")), align("digital-channels", "omnichannel-messaging", alignment_type="secondary")], VPBX_API_DIALOG_EVENT),
+        ],
+    },
+    {
+        "id": "talker-softphone-service",
+        "product": "mango-talker",
+        "cluster": "mango-talker",
+        "name": "Софтфон Mango Talker",
+        "description": "Сервис звонков в приложении Mango Talker.",
+        "module": ("talker-softphone-module", "Звонки в Talker"),
+        "evidence": [TALKER_CALL, TALKER_ANSWER],
+        "alignments": [align("voice-ucaas", "unified-communications", facets=channel("voice", "sync", "outbound"))],
+        "functions": [
+            ("call-colleague-in-talker", "Позвонить сотруднику из Talker", "business", "end-user-ui", [align("voice-ucaas", "voice-channel", "outbound-voice-call", facets=channel("voice", "sync", "outbound"))], TALKER_CALL),
+            ("answer-talker-call", "Ответить на входящий звонок в Talker", "business", "end-user-ui", [align("voice-ucaas", "voice-channel", "inbound-voice-call", "receive-inbound-call", facets=channel("voice", "sync", "inbound"))], TALKER_ANSWER),
+        ],
+    },
+    {
+        "id": "talker-team-chat-service",
+        "product": "mango-talker",
+        "cluster": "mango-talker",
+        "name": "Командные чаты Mango Talker",
+        "description": "Сервис личных и групповых чатов, каналов и сообщений в Talker.",
+        "module": ("talker-team-chat-module", "Чаты и каналы Talker"),
+        "evidence": [TALKER_CHAT, TALKER_CHANNEL],
+        "alignments": [align("digital-channels", "team-messaging", facets=channel("text", "async", "outbound"))],
+        "functions": [
+            ("send-talker-chat-message", "Отправить сообщение в Talker", "business", "end-user-ui", [align("digital-channels", "team-messaging", facets=channel("text", "async", "outbound"), mapping_gap=gap("function", "send-team-chat-message", "Industry Taxonomy не содержит leaf-функцию отправки командного сообщения."))], TALKER_CHAT),
+            ("create-talker-chat-channel", "Создать чат или канал Talker", "configuration", "end-user-ui", [align("digital-channels", "team-messaging", mapping_gap=gap("function", "create-team-chat-channel", "Industry Taxonomy не содержит leaf-функцию создания командного канала."))], TALKER_CHANNEL),
+        ],
+    },
+    {
+        "id": "talker-video-meeting-service",
+        "product": "mango-talker",
+        "cluster": "mango-talker",
+        "name": "Видео и конференции Talker",
+        "description": "Сервис видеозвонков, аудиоконференций и конференц-комнат.",
+        "module": ("talker-video-meeting-module", "Видео и конференции"),
+        "evidence": [TALKER_VIDEO, TALKER_CONFERENCE],
+        "alignments": [align("voice-ucaas", "unified-communications", facets=channel("video", "sync", "outbound"))],
+        "functions": [
+            ("start-talker-video-call", "Начать групповой видеозвонок", "business", "end-user-ui", [align("voice-ucaas", "unified-communications", facets=channel("video", "sync", "outbound"), mapping_gap=gap("function", "start-video-call", "Industry Taxonomy не содержит leaf-функцию старта видеозвонка внутри UCaaS."))], TALKER_VIDEO),
+            ("join-talker-conference-room", "Присоединиться к конференции Talker", "business", "end-user-ui", [align("voice-ucaas", "unified-communications", facets=channel("video", "sync", "inbound"), mapping_gap=gap("function", "join-conference-room", "Industry Taxonomy не содержит leaf-функцию входа в конференц-комнату."))], TALKER_CONFERENCE),
+        ],
+    },
+    {
+        "id": "talker-contact-history-service",
+        "product": "mango-talker",
+        "cluster": "mango-talker",
+        "name": "Контакты и история Talker",
+        "description": "Сервис карточек контактов, истории вызовов и быстрых действий из журнала.",
+        "module": ("talker-contact-history-module", "Контакты и журнал Talker"),
+        "evidence": [TALKER_CONTACT, TALKER_HISTORY],
+        "alignments": [align("voice-ucaas", "unified-communications")],
+        "functions": [
+            ("open-talker-contact-card", "Открыть карточку контакта Talker", "ui-action", "end-user-ui", [align("voice-ucaas", "unified-communications", mapping_gap=gap("function", "open-contact-card", "Industry Taxonomy не содержит UI leaf-функцию открытия карточки контакта."))], TALKER_CONTACT),
+            ("call-contact-from-history", "Позвонить контакту из истории", "business", "end-user-ui", [align("voice-ucaas", "voice-channel", "outbound-voice-call", facets=channel("voice", "sync", "outbound"))], TALKER_HISTORY),
+        ],
+    },
+    {
+        "id": "speech-analytics-service",
+        "product": "mango-ai-speech-quality",
+        "cluster": "ai-speech-quality",
+        "name": "Речевая аналитика",
+        "description": "Сервис распознавания речи, тематик, тегов и аналитики разговоров.",
+        "module": ("speech-analytics-topic-module", "Тематики речевой аналитики"),
+        "evidence": [SPEECH_INDEX, CC_SPEECH],
+        "alignments": [align("ai-automation", "speech-analytics", facets={"ai_assisted": True})],
+        "functions": [
+            ("recognize-recorded-call-speech", "Распознать речь в записи разговора", "business", "background-job", [align("ai-automation", "speech-analytics", facets={"ai_assisted": True, **channel("voice", "sync", "inbound")}, mapping_gap=gap("function", "recognize-call-speech", "Industry Taxonomy не содержит leaf-функцию распознавания записи разговора."))], SPEECH_INDEX),
+            ("configure-speech-topic", "Настроить тематику речевой аналитики", "configuration", "admin-ui", [align("ai-automation", "speech-analytics", facets={"ai_assisted": True}, mapping_gap=gap("function", "configure-speech-topic", "Industry Taxonomy не содержит leaf-функцию настройки тематик речи."))], CC_SPEECH),
+        ],
+    },
+    {
+        "id": "conversation-summary-service",
+        "product": "mango-ai-speech-quality",
+        "cluster": "ai-speech-quality",
+        "name": "AI-конспекты разговоров",
+        "description": "Сервис генерации и просмотра конспектов разговоров по данным звонков.",
+        "module": ("conversation-summary-module", "Конспекты разговоров"),
+        "evidence": [VPBX_API_INDEX, VPBX_API_STATS],
+        "alignments": [align("ai-automation", "conversation-summaries", "ai-summary", "generate-summary", facets={"ai_assisted": True})],
+        "functions": [
+            ("generate-call-summary", "Сформировать конспект разговора", "business", "background-job", [align("ai-automation", "conversation-summaries", "ai-summary", "generate-summary", facets={"ai_assisted": True})], VPBX_API_INDEX),
+            ("view-call-summary", "Открыть конспект разговора", "ui-action", "admin-ui", [align("ai-automation", "conversation-summaries", "ai-summary", facets={"ai_assisted": True}, mapping_gap=gap("function", "view-call-summary", "Industry Taxonomy содержит generate-summary, но не содержит UI-функцию просмотра конспекта."))], VPBX_API_INDEX),
+        ],
+    },
+    {
+        "id": "quality-checklist-service",
+        "product": "mango-ai-speech-quality",
+        "cluster": "ai-speech-quality",
+        "name": "Контроль качества и чек-листы",
+        "description": "Сервис чек-листов, оценок операторов и контроля качества разговоров.",
+        "module": ("quality-checklist-module", "Чек-листы качества"),
+        "evidence": [QUALITY_INDEX, CC_CHECKLIST],
+        "alignments": [align("contact-center", "quality-management")],
+        "functions": [
+            ("evaluate-call-by-checklist", "Оценить разговор по чек-листу", "business", "admin-ui", [align("contact-center", "quality-management", mapping_gap=gap("function", "evaluate-call-by-checklist", "Industry Taxonomy не содержит leaf-функцию оценки разговора по чек-листу."))], QUALITY_INDEX),
+            ("configure-quality-checklist", "Настроить чек-лист качества", "configuration", "admin-ui", [align("contact-center", "quality-management", mapping_gap=gap("function", "configure-quality-checklist", "Industry Taxonomy не содержит leaf-функцию настройки чек-листа."))], CC_CHECKLIST),
+        ],
+    },
+    {
+        "id": "voice-robot-service",
+        "product": "mango-ai-speech-quality",
+        "cluster": "ai-speech-quality",
+        "name": "Голосовой робот",
+        "description": "Сервис автоматических голосовых диалогов и сценариев робота.",
+        "module": ("voice-robot-scenario-module", "Сценарии голосового робота"),
+        "evidence": [ROBOT_URL, PRODUCTS_URL],
+        "alignments": [align("ai-automation", "voice-bot", facets={"ai_assisted": True, **channel("voice", "sync", "outbound")})],
+        "functions": [
+            ("run-voice-robot-dialog", "Запустить голосовой диалог робота", "business", "system-rule", [align("ai-automation", "voice-bot", facets={"ai_assisted": True, **channel("voice", "sync", "outbound")}, mapping_gap=gap("function", "run-voice-robot-dialog", "Industry Taxonomy не содержит leaf-функцию исполнения сценария голосового робота."))], ROBOT_URL),
+            ("configure-voice-robot-scenario", "Настроить сценарий голосового робота", "configuration", "admin-ui", [align("ai-automation", "voice-bot", facets={"ai_assisted": True}, mapping_gap=gap("function", "configure-voice-robot-scenario", "Industry Taxonomy не содержит leaf-функцию настройки сценария голосового робота."))], ROBOT_URL),
+        ],
+    },
+    {
+        "id": "calltracking-attribution-service",
+        "product": "mango-marketing-analytics",
+        "cluster": "analytics-marketing",
+        "name": "Атрибуция коллтрекинга",
+        "description": "Сервис определения рекламного источника звонка и подстановки номеров.",
+        "module": ("calltracking-attribution-module", "Атрибуция рекламных источников"),
+        "evidence": [CALLTRACKING_URL, LK_ANALYTICS],
+        "alignments": [align("analytics", "call-tracking")],
+        "functions": [
+            ("attribute-call-to-ad-source", "Привязать звонок к рекламному источнику", "business", "background-job", [align("analytics", "call-tracking", mapping_gap=gap("function", "attribute-call-to-ad-source", "Industry Taxonomy не содержит leaf-функцию атрибуции звонка к рекламе."))], LK_ANALYTICS),
+            ("configure-calltracking-number", "Настроить номер коллтрекинга", "configuration", "admin-ui", [align("analytics", "call-tracking", mapping_gap=gap("function", "configure-calltracking-number", "Industry Taxonomy не содержит leaf-функцию настройки номера коллтрекинга."))], CALLTRACKING_URL),
+        ],
+    },
+    {
+        "id": "end-to-end-analytics-service",
+        "product": "mango-marketing-analytics",
+        "cluster": "analytics-marketing",
+        "name": "Сквозная аналитика",
+        "description": "Сервис связывания коммуникаций, сделок и маркетинговой воронки.",
+        "module": ("end-to-end-analytics-module", "Сквозные отчёты"),
+        "evidence": [CALLTRACKING_URL, VPBX_API_STATS],
+        "alignments": [align("analytics", "end-to-end-analytics")],
+        "functions": [
+            ("join-call-and-sales-funnel", "Связать звонок с воронкой продаж", "business", "background-job", [align("analytics", "end-to-end-analytics", mapping_gap=gap("function", "join-call-and-sales-funnel", "Industry Taxonomy не содержит leaf-функцию связывания звонка с продажами."))], VPBX_API_STATS),
+            ("open-end-to-end-analytics-report", "Открыть отчёт сквозной аналитики", "ui-action", "admin-ui", [align("analytics", "end-to-end-analytics", mapping_gap=gap("function", "open-end-to-end-analytics-report", "Industry Taxonomy не содержит UI leaf-функцию открытия отчёта сквозной аналитики."))], CALLTRACKING_URL),
+        ],
+    },
+    {
+        "id": "reporting-dashboard-service",
+        "product": "mango-marketing-analytics",
+        "cluster": "analytics-marketing",
+        "name": "Отчёты и дашборды",
+        "description": "Сервис отчётов, фильтров, графиков и табличной аналитики.",
+        "module": ("reporting-dashboard-module", "Конструктор и просмотр отчётов"),
+        "evidence": [CC_DASHBOARD, CC_WIDGET, LK_ANALYTICS],
+        "alignments": [align("analytics", "multichannel-analytics")],
+        "functions": [
+            ("build-analytics-report", "Сформировать аналитический отчёт", "business", "background-job", [align("analytics", "multichannel-analytics", mapping_gap=gap("function", "build-analytics-report", "Industry Taxonomy не содержит leaf-функцию формирования отчёта."))], LK_ANALYTICS),
+            ("select-dashboard-widget", "Выбрать виджет дашборда", "ui-action", "admin-ui", [align("analytics", "real-time-reporting", "dashboard-view", "select-dashboard-widget")], CC_WIDGET),
+        ],
+    },
+    {
+        "id": "wallboard-monitoring-service",
+        "product": "mango-marketing-analytics",
+        "cluster": "analytics-marketing",
+        "name": "Wallboard-мониторинг",
+        "description": "Сервис real-time экранов, групповых показателей и виджетов Wallboard.",
+        "module": ("wallboard-monitoring-module", "Wallboard-виджеты"),
+        "evidence": [WALLBOARD_INDEX, LK_WALLBOARD],
+        "alignments": [align("analytics", "real-time-reporting")],
+        "functions": [
+            ("display-wallboard-widget", "Показать виджет Wallboard", "business", "end-user-ui", [align("analytics", "real-time-reporting", "dashboard-view", "select-dashboard-widget")], WALLBOARD_INDEX),
+            ("configure-wallboard-widget", "Настроить виджет Wallboard", "configuration", "admin-ui", [align("analytics", "real-time-reporting", mapping_gap=gap("function", "configure-wallboard-widget", "Industry Taxonomy не содержит leaf-функцию настройки Wallboard-виджета."))], LK_WALLBOARD),
+        ],
+    },
+    {
+        "id": "vpbx-open-api-service",
+        "product": "mango-platform-integrations",
+        "cluster": "platform-integrations",
+        "name": "ВАТС Open API",
+        "description": "Сервис API-команд Виртуальной АТС, realtime-событий и программного управления вызовами.",
+        "module": ("vpbx-open-api-module", "API Виртуальной АТС"),
+        "evidence": [VPBX_API_INDEX, VPBX_API_CALL, VPBX_API_WEBHOOK],
+        "alignments": [align("platform", "open-api")],
+        "functions": [
+            ("initiate-vpbx-api-call", "Инициировать звонок через API ВАТС", "business", "api", [align("voice-ucaas", "voice-channel", "outbound-voice-call", facets=channel("voice", "sync", "outbound")), align("platform", "open-api", alignment_type="supporting")], VPBX_API_CALL),
+            ("configure-vpbx-webhook", "Настроить webhook ВАТС", "configuration", "api", [align("platform", "open-api", "webhook-management", "configure-webhook-endpoint")], VPBX_API_WEBHOOK),
+        ],
+    },
+    {
+        "id": "contact-center-api-service",
+        "product": "mango-platform-integrations",
+        "cluster": "platform-integrations",
+        "name": "Contact Center API",
+        "description": "Сервис API задач, событий и сущностей Контакт-центра.",
+        "module": ("contact-center-api-module", "API Контакт-центра"),
+        "evidence": [VPBX_API_INDEX, VPBX_API_CC_TASK, VPBX_API_CC_EVENT],
+        "alignments": [align("platform", "open-api"), align("contact-center", "conversation-orchestration", alignment_type="secondary")],
+        "functions": [
+            ("create-contact-center-task-api", "Создать задачу Контакт-центра через API", "business", "api", [align("platform", "open-api", mapping_gap=gap("function", "create-contact-center-task", "Industry Taxonomy не содержит leaf-функцию создания задачи КЦ через API.")), align("contact-center", "conversation-orchestration", alignment_type="secondary")], VPBX_API_CC_TASK),
+            ("receive-contact-center-event-webhook", "Получить событие Контакт-центра через webhook", "business", "webhook", [align("platform", "open-api", "webhook-management", "configure-webhook-endpoint"), align("contact-center", "conversation-orchestration", alignment_type="secondary")], VPBX_API_CC_EVENT),
+        ],
+    },
+    {
+        "id": "crm-erp-integration-service",
+        "product": "mango-platform-integrations",
+        "cluster": "platform-integrations",
+        "name": "CRM и ERP-интеграции",
+        "description": "Сервис интеграций с Bitrix24, 1C, amoCRM и внешними бизнес-системами.",
+        "module": ("crm-erp-integration-module", "Коннекторы CRM и ERP"),
+        "evidence": [BITRIX_INDEX, ONE_C_INDEX, AMOCRM_INDEX],
+        "alignments": [align("platform", "platform-integration")],
+        "functions": [
+            ("sync-crm-call-card", "Синхронизировать карточку звонка с CRM", "business", "background-job", [align("platform", "platform-integration", mapping_gap=gap("function", "sync-crm-call-card", "Industry Taxonomy не содержит leaf-функцию синхронизации карточки звонка."))], BITRIX_INDEX),
+            ("configure-crm-integration", "Настроить CRM-интеграцию", "configuration", "admin-ui", [align("platform", "platform-integration", mapping_gap=gap("function", "configure-crm-integration", "Industry Taxonomy не содержит leaf-функцию настройки CRM-коннектора."))], AMOCRM_INDEX),
+        ],
+    },
+    {
+        "id": "webhook-event-service",
+        "product": "mango-platform-integrations",
+        "cluster": "platform-integrations",
+        "name": "Webhook-события",
+        "description": "Сервис исходящих уведомлений, статусов и событий для внешних систем.",
+        "module": ("webhook-event-module", "Webhook endpoints"),
+        "evidence": [VPBX_API_WEBHOOK, VPBX_API_INDEX],
+        "alignments": [align("platform", "open-api", "webhook-management", "configure-webhook-endpoint")],
+        "functions": [
+            ("send-call-event-webhook", "Передать событие звонка во внешний webhook", "business", "webhook", [align("platform", "open-api", "webhook-management", "configure-webhook-endpoint"), align("voice-ucaas", "voice-channel", "inbound-voice-call", alignment_type="secondary", facets=channel("voice", "sync", "inbound"))], VPBX_API_WEBHOOK),
+            ("configure-webhook-endpoint", "Настроить endpoint webhook", "configuration", "admin-ui", [align("platform", "open-api", "webhook-management", "configure-webhook-endpoint")], VPBX_API_WEBHOOK),
+        ],
+    },
+    {
+        "id": "role-access-management-service",
+        "product": "mango-security-access",
+        "cluster": "security-access",
+        "name": "Ролевое управление доступом",
+        "description": "Сервис ролей, прав и ограничений доступа к разделам ЛК и Контакт-центра.",
+        "module": ("role-access-management-module", "Роли и права доступа"),
+        "evidence": [ROLE_MODEL_INDEX, LK_ROLES, CC_ROLES],
+        "alignments": [align("security", "access-control", "role-management", "assign-role")],
+        "functions": [
+            ("assign-user-role", "Назначить роль пользователю", "configuration", "admin-ui", [align("security", "access-control", "role-management", "assign-role")], LK_ROLES),
+            ("view-role-permissions", "Просмотреть права роли", "ui-action", "admin-ui", [align("security", "access-control", "role-management", mapping_gap=gap("function", "view-role-permissions", "Industry Taxonomy содержит assign-role, но не содержит UI-функцию просмотра прав роли."))], ROLE_MODEL_INDEX),
+        ],
+    },
+    {
+        "id": "sso-identity-service",
+        "product": "mango-security-access",
+        "cluster": "security-access",
+        "name": "SSO и идентификация",
+        "description": "Сервис единого входа и federated authentication для ЛК ВАТС.",
+        "module": ("sso-identity-module", "SSO-подключение"),
+        "evidence": [SSO_INDEX],
+        "alignments": [align("security", "access-control")],
+        "functions": [
+            ("authenticate-user-with-sso", "Аутентифицировать пользователя через SSO", "business", "end-user-ui", [align("security", "access-control", mapping_gap=gap("function", "authenticate-user-with-sso", "Industry Taxonomy не содержит leaf-функцию SSO-аутентификации."))], SSO_INDEX),
+            ("configure-sso-connection", "Настроить SSO-подключение", "configuration", "admin-ui", [align("security", "access-control", mapping_gap=gap("function", "configure-sso-connection", "Industry Taxonomy не содержит leaf-функцию настройки SSO."))], SSO_INDEX),
+        ],
+    },
+    {
+        "id": "recording-access-security-service",
+        "product": "mango-security-access",
+        "cluster": "security-access",
+        "name": "Безопасность доступа к записям",
+        "description": "Сервис ограничений, доступа и контроля операций с записями разговоров.",
+        "module": ("recording-access-security-module", "Ограничения доступа к записям"),
+        "evidence": [LK_RECORDING, LK_SECURITY],
+        "alignments": [align("security", "information-security")],
+        "functions": [
+            ("restrict-recording-access", "Ограничить доступ к записям разговоров", "configuration", "admin-ui", [align("security", "information-security", mapping_gap=gap("function", "restrict-recording-access", "Industry Taxonomy не содержит leaf-функцию ограничения доступа к записям."))], LK_SECURITY),
+            ("audit-recording-download", "Проверить доступ к скачиванию записи", "ui-action", "admin-ui", [align("security", "information-security", mapping_gap=gap("function", "audit-recording-download", "Industry Taxonomy не содержит UI leaf-функцию проверки доступа к скачиванию записи."))], LK_RECORDING),
+        ],
+    },
+    {
+        "id": "security-audit-settings-service",
+        "product": "mango-security-access",
+        "cluster": "security-access",
+        "name": "Аудит и настройки безопасности",
+        "description": "Сервис журнала действий, security-настроек и cross-product ограничений.",
+        "module": ("security-audit-settings-module", "Журнал действий и политики безопасности"),
+        "evidence": [LK_SECURITY, LK_INDEX],
+        "alignments": [align("security", "information-security")],
+        "functions": [
+            ("view-security-audit-log", "Просмотреть журнал действий", "ui-action", "admin-ui", [align("security", "information-security", mapping_gap=gap("function", "view-security-audit-log", "Industry Taxonomy не содержит UI leaf-функцию просмотра журнала безопасности."))], LK_SECURITY),
+            ("configure-security-policy", "Настроить политику безопасности", "configuration", "admin-ui", [align("security", "information-security", mapping_gap=gap("function", "configure-security-policy", "Industry Taxonomy не содержит leaf-функцию настройки политики безопасности."))], LK_SECURITY),
+        ],
+    },
+]
+
+
+def build_internal() -> dict[str, Any]:
+    products = [
+        entity(
+            spec["id"],
+            "product",
+            spec["name"],
+            spec["description"],
+            spec["evidence"],
+            spec["alignments"],
+            **{
+                key: spec[key]
+                for key in ("official_refs", "internal_only_reason")
+                if key in spec
+            },
+            services=spec["services"],
+        )
+        for spec in product_specs
+    ]
+
+    services = []
+    modules = []
+    functions = []
+    for spec in service_specs:
+        module_id, module_name = spec["module"]
+        function_ids = [function[0] for function in spec["functions"]]
+        services.append(
+            entity(
+                spec["id"],
+                "service",
+                spec["name"],
+                spec["description"],
+                spec["evidence"],
+                spec["alignments"],
+                cluster=spec["cluster"],
+                parent_products=[spec["product"]],
+                modules=[module_id],
+            )
+        )
+        modules.append(
+            entity(
+                module_id,
+                "module",
+                module_name,
+                f"Модуль сервиса «{spec['name']}» в Mango Taxonomy.",
+                spec["evidence"],
+                spec["alignments"],
+                cluster=spec["cluster"],
+                parent_services=[spec["id"]],
+                functions=function_ids,
+            )
+        )
+        for function_id, name, function_type, surface, alignments, evidence in spec["functions"]:
+            functions.append(
+                entity(
+                    function_id,
+                    "function",
+                    name,
+                    f"Атомарная функция модуля «{module_name}».",
+                    [evidence],
+                    alignments,
+                    parent_module=module_id,
+                    function_type=function_type,
+                    interaction_surface=surface,
+                )
+            )
+
+    return {
+        "taxonomy": {
+            "version": 1,
+            "scope": "mango-internal-registry",
+            "products": products,
+            "internal_services": services,
+            "modules": modules,
+            "functions": functions,
+        }
+    }
+
+
+def build_mapping(official: dict[str, Any], internal: dict[str, Any]) -> dict[str, Any]:
+    entities = []
+    collections = [
+        official["taxonomy"]["official_products"],
+        internal["taxonomy"]["products"],
+        internal["taxonomy"]["internal_services"],
+        internal["taxonomy"]["modules"],
+        internal["taxonomy"]["functions"],
+    ]
+    for collection in collections:
+        for item in collection:
+            entities.append(
+                {
+                    "source_id": item["id"],
+                    "source_level": item["level"],
+                    "industry_alignment": item["maps_to"]["industry_alignment"],
+                }
+            )
+    return {
+        "taxonomy_mapping": {
+            "version": 1,
+            "mapping_scope": "mango-to-industry",
+            "source_taxonomy": "mango-taxonomy",
+            "target_taxonomy": "industry-taxonomy",
+            "entities": entities,
+        }
+    }
+
+
+def dump(path: Path, data: dict[str, Any]) -> None:
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    missing = [
+        ref
+        for ref in {
+            ref
+            for product in official_products
+            for ref in product["evidence_refs"]
+            if not ref.startswith("http")
+        }
+        if not (ROOT / ref).exists()
+    ]
+    internal = build_internal()
+    for collection in (
+        internal["taxonomy"]["products"],
+        internal["taxonomy"]["internal_services"],
+        internal["taxonomy"]["modules"],
+        internal["taxonomy"]["functions"],
+    ):
+        for item in collection:
+            for ref in item["evidence_refs"]:
+                if not ref.startswith("http") and not (ROOT / ref).exists():
+                    missing.append(ref)
+    if missing:
+        raise SystemExit("Missing evidence refs:\n" + "\n".join(sorted(set(missing))))
+
+    official = {
+        "taxonomy": {
+            "version": 1,
+            "scope": "mango-official-products",
+            "official_products": official_products,
+        }
+    }
+    mapping = build_mapping(official, internal)
+
+    OUT.mkdir(parents=True, exist_ok=True)
+    dump(OUT / "official-products.yaml", official)
+    dump(OUT / "internal-registry.yaml", internal)
+    dump(OUT / "product-mapping.yaml", mapping)
+
+
+if __name__ == "__main__":
+    main()

--- a/kb/README.md
+++ b/kb/README.md
@@ -10,12 +10,14 @@ related_artifacts:
   - "docs/adr/007-kb-standard.md"
   - "kb/mango-product-docs/README.md"
   - "kb/industry/README.md"
+  - "kb/mango/README.md"
   - "docs/audit/issue-144-kb-structure.md"
 related_issues:
   - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/97"
   - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/111"
   - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/144"
   - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/156"
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/160"
 ---
 
 # База знаний (KB)
@@ -39,7 +41,7 @@ KB регулируется [kb-standard.md](../standards/kb-standard.md) и
 | [`kb/fragments/`](fragments/README.md) | Задел под атомарные фрагменты будущего векторного RAG; сейчас product-docs чанки живут в `kb/mango-product-docs/processed/`. | Оставить в `kb/`, не переносить в product-docs |
 | [`kb/practices/`](practices/README.md) | Ручные практики и методики анализа, не привязанные к конкретному продукту Mango Office. | Оставить в `kb/`, не переносить в product-docs |
 | [`kb/industry/`](industry/README.md) | Industry Taxonomy: machine-readable реестр отраслевой классификации `Domain -> Capability -> Feature -> Function`. | Рабочий industry namespace |
-| `kb/mango/ (будущий)` | Mango Taxonomy: корпоративная классификация продуктов и mapping к taxonomy. | Планируемый namespace |
+| [`kb/mango/`](mango/README.md) | Mango Taxonomy Registry: Official Layer, Internal Layer и mapping к Industry Taxonomy. Историческая метка `kb/mango/ (будущий)` сохранена для совместимости с issue #144. | Рабочий taxonomy namespace |
 
 ## Как использовать?
 
@@ -47,6 +49,16 @@ KB регулируется [kb-standard.md](../standards/kb-standard.md) и
 [`kb/mango-product-docs/README.md`](mango-product-docs/README.md): там описаны
 `sources/`, `processed/`, [`USAGE.md`](mango-product-docs/USAGE.md) и
 [`UPLOAD-GUIDE.md`](mango-product-docs/UPLOAD-GUIDE.md).
+
+Для классификации продуктов Mango Office используйте
+[`kb/mango/README.md`](mango/README.md): там описаны публичный Official Layer,
+внутренний Internal Layer `Product -> Service -> Module -> Function` и mapping к
+Industry Taxonomy.
+
+Для отраслевой классификации используйте
+[`kb/industry/README.md`](industry/README.md): там описан machine-readable
+реестр `Domain -> Capability -> Feature -> Function`, на который ссылается
+Mango mapping.
 
 Для ручных практик используйте `kb/practices/` и цитируйте запись стабильным
 адресом вида:
@@ -115,6 +127,8 @@ RAG, `practices/` — ручные практики. Их не нужно пер
   как добавлять и обновлять документы.
 - [`kb/industry/README.md`](industry/README.md) — machine-readable Industry
   Taxonomy registry.
+- [`kb/mango/README.md`](mango/README.md) — machine-readable Mango Taxonomy
+  Registry и crosswalk к Industry Taxonomy.
 - [`docs/audit/issue-144-kb-structure.md`](../docs/audit/issue-144-kb-structure.md) —
   проверка истории `fragments/` и `practices/`.
 - [`docs/kb-experiment-report.md`](../docs/kb-experiment-report.md) —

--- a/kb/mango/README.md
+++ b/kb/mango/README.md
@@ -1,0 +1,93 @@
+---
+status: draft
+version: 0.1
+updated: 2026-06-21
+ai-generated: true
+type: kb-registry
+scope: mango-taxonomy
+related_artifacts:
+  - "../../standards/mango-taxonomy-standard.md"
+  - "../../standards/decisions/ADR-012-mango-taxonomy.md"
+  - "../../standards/industry-taxonomy-standard.md"
+  - "official-products.yaml"
+  - "internal-registry.yaml"
+  - "product-mapping.yaml"
+related_issues:
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/160"
+---
+
+# Mango Taxonomy Registry
+
+`kb/mango/` хранит machine-readable реестр Mango Taxonomy по стандарту
+[`standards/mango-taxonomy-standard.md`](../../standards/mango-taxonomy-standard.md)
+и ADR
+[`standards/decisions/ADR-012-mango-taxonomy.md`](../../standards/decisions/ADR-012-mango-taxonomy.md).
+Файлы сериализованы как JSON-compatible YAML: это валидный YAML, который можно
+проверять без внешних Python-зависимостей.
+
+## Official Layer
+
+[`official-products.yaml`](official-products.yaml) фиксирует публичные продукты
+Mango Office: Виртуальная АТС, Контакт-центр, Текстовые коммуникации, Mango
+Talker, Коллтрекинг, Речевая аналитика, Роботы, Интеграции и связанные
+телефонные/инфраструктурные предложения. Для каждого продукта указаны
+официальные URL, evidence refs, поддерживающие внутренние сервисы и mapping к
+Industry Taxonomy.
+
+## Internal Layer
+
+[`internal-registry.yaml`](internal-registry.yaml) нормализует внутреннюю модель
+в иерархию `Product -> Service -> Module -> Function`. Реестр покрывает все
+кластеры Mango Taxonomy:
+
+| Cluster | Назначение |
+| --- | --- |
+| `vats-core` | Входящая маршрутизация, IVR, номера и записи ВАТС. |
+| `contact-center-core` | Операторское рабочее место, очереди, кампании и WFM. |
+| `digital-channels` | Текстовые каналы, чат сайта, мессенджеры и Dialog API. |
+| `mango-talker` | Софтфон, командные чаты, видео и контакты Mango Talker. |
+| `ai-speech-quality` | Речевая аналитика, AI-конспекты, качество и роботы. |
+| `analytics-marketing` | Коллтрекинг, сквозная аналитика, отчёты и Wallboard. |
+| `platform-integrations` | Open API, webhooks и CRM/ERP-интеграции. |
+| `security-access` | Роли, SSO, безопасность записей и аудит. |
+
+Function-level записи используют `function_type` (`business`, `configuration`,
+`ui-action`) и `interaction_surface`, чтобы AI-agent мог отличать бизнесовое
+действие, настройку и пользовательскую UI-операцию.
+
+## Industry Taxonomy
+
+[`product-mapping.yaml`](product-mapping.yaml) дублирует
+`maps_to.industry_alignment` из каждой Mango-сущности в отдельном crosswalk
+файле. Mapping выравнивается на
+[`standards/industry-taxonomy-standard.md`](../../standards/industry-taxonomy-standard.md)
+и использует только канонические `industry_ref`. Если Industry Taxonomy не
+содержит нужный Feature или Function, запись содержит `mapping_gap` с
+предлагаемым slug и причиной.
+
+## AI-agent Contract
+
+AI-agent должен:
+
+- читать `official-products.yaml`, когда нужен публичный продуктовый слой Mango;
+- читать `internal-registry.yaml`, когда нужна внутренняя декомпозиция
+  `Product -> Service -> Module -> Function`;
+- читать `product-mapping.yaml`, когда нужен полный crosswalk Mango Taxonomy к
+  Industry Taxonomy;
+- цитировать `evidence_refs` из записей, а не выводить продуктовые факты из
+  названий сущностей;
+- сохранять `maps_to.industry_alignment` и mapping file синхронными.
+
+## Validation
+
+Лёгкая проверка без внешних зависимостей:
+
+```bash
+python3 scripts/validate_issue_160_mango_registry.py
+```
+
+Полный KB-контур:
+
+```bash
+make kb-validate
+```

--- a/kb/mango/internal-registry.yaml
+++ b/kb/mango/internal-registry.yaml
@@ -1,0 +1,4989 @@
+{
+  "taxonomy": {
+    "version": 1,
+    "scope": "mango-internal-registry",
+    "products": [
+      {
+        "id": "mango-virtual-pbx",
+        "level": "product",
+        "name_ru": "Mango Virtual PBX",
+        "description": "Внутренний продуктовый кластер Виртуальной АТС: входящие сценарии, IVR, номера и записи разговоров.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/virtualnaya_ats/",
+          "kb/mango-product-docs/processed/mango-lk-manual/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "cloud-pbx"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/virtualnaya_ats/",
+                "kb/mango-product-docs/processed/mango-lk-manual/index.md"
+              ]
+            }
+          ]
+        },
+        "official_refs": [
+          "mango-virtual-pbx-official",
+          "mango-sip-trunk-official",
+          "mango-numbers-equipment-official"
+        ],
+        "services": [
+          "vats-inbound-routing-service",
+          "vats-ivr-service",
+          "vats-number-management-service",
+          "vats-recording-history-service"
+        ]
+      },
+      {
+        "id": "mango-contact-center",
+        "level": "product",
+        "name_ru": "Mango Contact Center",
+        "description": "Внутренний продуктовый кластер Контакт-центра: операторские рабочие места, очереди, кампании и WFM.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/contact-center/",
+          "kb/mango-product-docs/processed/mango-cc-manual/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "omnichannel-contact-center"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/contact-center/",
+                "kb/mango-product-docs/processed/mango-cc-manual/index.md"
+              ]
+            }
+          ]
+        },
+        "official_refs": [
+          "mango-contact-center-official"
+        ],
+        "services": [
+          "cc-agent-workspace-service",
+          "cc-interaction-routing-service",
+          "cc-outbound-campaign-service",
+          "cc-supervisor-wfm-service"
+        ]
+      },
+      {
+        "id": "mango-digital-communications",
+        "level": "product",
+        "name_ru": "Mango Digital Communications",
+        "description": "Внутренний продуктовый кластер текстовых каналов, чата на сайте, мессенджеров и Dialog API.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/179-tekstovye-kommunikacii.md",
+          "kb/mango-product-docs/processed/mdialogi-api/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "omnichannel-messaging"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/179-tekstovye-kommunikacii.md",
+                "kb/mango-product-docs/processed/mdialogi-api/index.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "inbound"
+                }
+              }
+            }
+          ]
+        },
+        "official_refs": [
+          "mango-text-communications-official"
+        ],
+        "services": [
+          "digital-channel-group-service",
+          "website-chat-service",
+          "messenger-channel-service",
+          "dialog-api-messaging-service"
+        ]
+      },
+      {
+        "id": "mango-talker",
+        "level": "product",
+        "name_ru": "Mango Talker",
+        "description": "Внутренний продуктовый кластер приложения Mango Talker: софтфон, командные чаты, видео и контакты.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/mango-talker/",
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "unified-communications"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/mango-talker/",
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/index.md"
+              ]
+            }
+          ]
+        },
+        "official_refs": [
+          "mango-talker-official"
+        ],
+        "services": [
+          "talker-softphone-service",
+          "talker-team-chat-service",
+          "talker-video-meeting-service",
+          "talker-contact-history-service"
+        ]
+      },
+      {
+        "id": "mango-ai-speech-quality",
+        "level": "product",
+        "name_ru": "Mango AI Speech and Quality",
+        "description": "Внутренний продуктовый кластер AI, речевой аналитики, конспектов, чек-листов качества и голосовых роботов.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/virtualnaya_ats/vozmozhnosti/speech-analytics/",
+          "kb/mango-product-docs/processed/speech-analytics/index.md",
+          "kb/mango-product-docs/processed/quality-managment/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "ai-automation",
+                "capability": "speech-analytics"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/virtualnaya_ats/vozmozhnosti/speech-analytics/",
+                "kb/mango-product-docs/processed/speech-analytics/index.md",
+                "kb/mango-product-docs/processed/quality-managment/index.md"
+              ],
+              "facets": {
+                "ai_assisted": true
+              }
+            }
+          ]
+        },
+        "official_refs": [
+          "mango-speech-analytics-official",
+          "mango-robots-official"
+        ],
+        "services": [
+          "speech-analytics-service",
+          "conversation-summary-service",
+          "quality-checklist-service",
+          "voice-robot-service"
+        ]
+      },
+      {
+        "id": "mango-marketing-analytics",
+        "level": "product",
+        "name_ru": "Mango Marketing Analytics",
+        "description": "Внутренний продуктовый кластер коллтрекинга, сквозной аналитики, отчётов и real-time панелей.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/calltracking/",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md",
+          "kb/mango-product-docs/processed/wallboard/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "analytics",
+                "capability": "call-tracking"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/calltracking/",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md",
+                "kb/mango-product-docs/processed/wallboard/index.md"
+              ]
+            }
+          ]
+        },
+        "official_refs": [
+          "mango-calltracking-official"
+        ],
+        "services": [
+          "calltracking-attribution-service",
+          "end-to-end-analytics-service",
+          "reporting-dashboard-service",
+          "wallboard-monitoring-service"
+        ]
+      },
+      {
+        "id": "mango-platform-integrations",
+        "level": "product",
+        "name_ru": "Mango Platform Integrations",
+        "description": "Внутренний продуктовый кластер API, webhooks и CRM/ERP-интеграций.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/integraciya/",
+          "kb/mango-product-docs/processed/vpbx-api/index.md",
+          "kb/mango-product-docs/processed/integration-bitrix24/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "open-api"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/integraciya/",
+                "kb/mango-product-docs/processed/vpbx-api/index.md",
+                "kb/mango-product-docs/processed/integration-bitrix24/index.md"
+              ]
+            }
+          ]
+        },
+        "official_refs": [
+          "mango-integrations-official"
+        ],
+        "services": [
+          "vpbx-open-api-service",
+          "contact-center-api-service",
+          "crm-erp-integration-service",
+          "webhook-event-service"
+        ]
+      },
+      {
+        "id": "mango-security-access",
+        "level": "product",
+        "name_ru": "Mango Security and Access",
+        "description": "Внутренний cross-product кластер ролей, SSO, доступа к записям и аудита безопасности.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/Rolevaya-model-vats/index.md",
+          "kb/mango-product-docs/processed/lk-vats-sso/index.md",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "security",
+                "capability": "access-control"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/Rolevaya-model-vats/index.md",
+                "kb/mango-product-docs/processed/lk-vats-sso/index.md",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md"
+              ]
+            }
+          ]
+        },
+        "internal_only_reason": "Кластер выделен как внутренний слой поверх публичных продуктов, потому что права доступа и безопасность обслуживают несколько продуктовых линий.",
+        "services": [
+          "role-access-management-service",
+          "sso-identity-service",
+          "recording-access-security-service",
+          "security-audit-settings-service"
+        ]
+      }
+    ],
+    "internal_services": [
+      {
+        "id": "vats-inbound-routing-service",
+        "level": "service",
+        "name_ru": "Входящая маршрутизация ВАТС",
+        "description": "Сервис входящих схем, правил и распределения голосовых вызовов.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/105-nastroyki-dlya-vhodyaschih-liniy.md",
+          "kb/mango-product-docs/processed/vpbx-api/sections/42-marshrutizaciya-vyzova.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "call-routing"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/105-nastroyki-dlya-vhodyaschih-liniy.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/42-marshrutizaciya-vyzova.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "inbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "vats-core",
+        "parent_products": [
+          "mango-virtual-pbx"
+        ],
+        "modules": [
+          "vats-inbound-scenarios-module"
+        ]
+      },
+      {
+        "id": "vats-ivr-service",
+        "level": "service",
+        "name_ru": "Голосовое меню ВАТС",
+        "description": "Сервис IVR-меню, приветствий и ветвления входящих звонков.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "ivr-voice-menu"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "inbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "vats-core",
+        "parent_products": [
+          "mango-virtual-pbx"
+        ],
+        "modules": [
+          "vats-ivr-menu-module"
+        ]
+      },
+      {
+        "id": "vats-number-management-service",
+        "level": "service",
+        "name_ru": "Управление номерами ВАТС",
+        "description": "Сервис подключённых номеров, входящих линий и SIP-инфраструктуры.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/100-nomera-podklyuchennye-k-ats.md",
+          "kb/mango-product-docs/processed/sip-trunk/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "number-management"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/100-nomera-podklyuchennye-k-ats.md",
+                "kb/mango-product-docs/processed/sip-trunk/index.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "vats-core",
+        "parent_products": [
+          "mango-virtual-pbx"
+        ],
+        "modules": [
+          "vats-connected-numbers-module"
+        ]
+      },
+      {
+        "id": "vats-recording-history-service",
+        "level": "service",
+        "name_ru": "Записи и история звонков ВАТС",
+        "description": "Сервис записи разговоров, журнала вызовов и доступа к сохранённым разговорам.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/134-zapis-razgovorov.md",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/135-zapisannye-razgovory.md",
+          "kb/mango-product-docs/processed/vpbx-api/sections/40-vklyuchenie-zapisi-razgovora.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "call-recording"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/134-zapis-razgovorov.md",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/135-zapisannye-razgovory.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/40-vklyuchenie-zapisi-razgovora.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "inbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "vats-core",
+        "parent_products": [
+          "mango-virtual-pbx"
+        ],
+        "modules": [
+          "vats-call-recording-module"
+        ]
+      },
+      {
+        "id": "cc-agent-workspace-service",
+        "level": "service",
+        "name_ru": "Рабочее место оператора КЦ",
+        "description": "Сервис операторского интерфейса для звонков, статусов и обработки обращений.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/05-upravlenie-statusom.md",
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/07-ochered-obrascheniy.md",
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/46-sovershenie-ishodyaschih-vyzovov.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "agent-workspace"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/05-upravlenie-statusom.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/07-ochered-obrascheniy.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/46-sovershenie-ishodyaschih-vyzovov.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "contact-center-core",
+        "parent_products": [
+          "mango-contact-center"
+        ],
+        "modules": [
+          "cc-agent-call-handling-module"
+        ]
+      },
+      {
+        "id": "cc-interaction-routing-service",
+        "level": "service",
+        "name_ru": "Маршрутизация обращений КЦ",
+        "description": "Сервис очередей, автоматического распределения и правил маршрутизации обращений.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/07-ochered-obrascheniy.md",
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/64-avtomaticheskoe-raspredelenie-obrascheni.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "interaction-routing",
+                "feature": "queue-routing"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/07-ochered-obrascheniy.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/64-avtomaticheskoe-raspredelenie-obrascheni.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "contact-center-core",
+        "parent_products": [
+          "mango-contact-center"
+        ],
+        "modules": [
+          "cc-queue-routing-module"
+        ]
+      },
+      {
+        "id": "cc-outbound-campaign-service",
+        "level": "service",
+        "name_ru": "Исходящие кампании КЦ",
+        "description": "Сервис кампаний исходящего обзвона, карточек кампаний и запуска задач.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/123-ishodyaschiy-obzvon.md",
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/127-dobavlenie-kampanii.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "outbound-calling",
+                "feature": "campaign-management"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/123-ishodyaschiy-obzvon.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/127-dobavlenie-kampanii.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "contact-center-core",
+        "parent_products": [
+          "mango-contact-center"
+        ],
+        "modules": [
+          "cc-outbound-campaign-module"
+        ]
+      },
+      {
+        "id": "cc-supervisor-wfm-service",
+        "level": "service",
+        "name_ru": "Супервизорский контроль и WFM",
+        "description": "Сервис супервизорских панелей, графиков и планирования нагрузки.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/57-dashboard.md",
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/100-planirovanie-vhodyaschih.md",
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/58-sozdanie-i-nastroyka-vidzheta.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "workforce-management"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/57-dashboard.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/100-planirovanie-vhodyaschih.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/58-sozdanie-i-nastroyka-vidzheta.md"
+              ]
+            },
+            {
+              "alignment_type": "secondary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "supervisor-workspace"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/57-dashboard.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/100-planirovanie-vhodyaschih.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/58-sozdanie-i-nastroyka-vidzheta.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "contact-center-core",
+        "parent_products": [
+          "mango-contact-center"
+        ],
+        "modules": [
+          "cc-supervisor-wfm-module"
+        ]
+      },
+      {
+        "id": "digital-channel-group-service",
+        "level": "service",
+        "name_ru": "Группы текстовых каналов",
+        "description": "Сервис объединения цифровых каналов, расписаний и правил обработки диалогов.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/179-tekstovye-kommunikacii.md",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/191-whatsapp.md",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/192-telegram.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "omnichannel-messaging"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/179-tekstovye-kommunikacii.md",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/191-whatsapp.md",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/192-telegram.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "inbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "digital-channels",
+        "parent_products": [
+          "mango-digital-communications"
+        ],
+        "modules": [
+          "digital-channel-group-module"
+        ]
+      },
+      {
+        "id": "website-chat-service",
+        "level": "service",
+        "name_ru": "Чат на сайте",
+        "description": "Сервис виджета сайта, кода установки и обработки входящих чат-диалогов.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/189-chat-na-sayte.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "website-chat"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/189-chat-na-sayte.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "inbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "digital-channels",
+        "parent_products": [
+          "mango-digital-communications"
+        ],
+        "modules": [
+          "website-chat-widget-module"
+        ]
+      },
+      {
+        "id": "messenger-channel-service",
+        "level": "service",
+        "name_ru": "Мессенджер-каналы",
+        "description": "Сервис подключения Telegram, WhatsApp и других мессенджеров к группам каналов.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/191-whatsapp.md",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/192-telegram.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "omnichannel-messaging",
+                "feature": "messenger-integration"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/191-whatsapp.md",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/192-telegram.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "inbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "digital-channels",
+        "parent_products": [
+          "mango-digital-communications"
+        ],
+        "modules": [
+          "messenger-channel-connector-module"
+        ]
+      },
+      {
+        "id": "dialog-api-messaging-service",
+        "level": "service",
+        "name_ru": "Dialog API",
+        "description": "Сервис программного обмена сообщениями и событиями цифровых диалогов.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mdialogi-api/index.md",
+          "kb/mango-product-docs/processed/vpbx-api/sections/238-otpravka-soobscheniya.md",
+          "kb/mango-product-docs/processed/vpbx-api/sections/239-opoveschenie-o-tom-chto-polzovatel-nabir.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "communications-apis"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mdialogi-api/index.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/238-otpravka-soobscheniya.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/239-opoveschenie-o-tom-chto-polzovatel-nabir.md"
+              ]
+            },
+            {
+              "alignment_type": "secondary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "omnichannel-messaging"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mdialogi-api/index.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/238-otpravka-soobscheniya.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/239-opoveschenie-o-tom-chto-polzovatel-nabir.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "outbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "digital-channels",
+        "parent_products": [
+          "mango-digital-communications"
+        ],
+        "modules": [
+          "dialog-api-message-module"
+        ]
+      },
+      {
+        "id": "talker-softphone-service",
+        "level": "service",
+        "name_ru": "Софтфон Mango Talker",
+        "description": "Сервис звонков в приложении Mango Talker.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/11-zvonok-sotrudniku.md",
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/15-kak-prinyat-vhodyaschiy-zvonok.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "unified-communications"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/11-zvonok-sotrudniku.md",
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/15-kak-prinyat-vhodyaschiy-zvonok.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "outbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "mango-talker",
+        "parent_products": [
+          "mango-talker"
+        ],
+        "modules": [
+          "talker-softphone-module"
+        ]
+      },
+      {
+        "id": "talker-team-chat-service",
+        "level": "service",
+        "name_ru": "Командные чаты Mango Talker",
+        "description": "Сервис личных и групповых чатов, каналов и сообщений в Talker.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/17-otpravka-soobscheniya-v-chat.md",
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/47-sozdanie-novogo-chata-ili-kanala.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "team-messaging"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/17-otpravka-soobscheniya-v-chat.md",
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/47-sozdanie-novogo-chata-ili-kanala.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "outbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "mango-talker",
+        "parent_products": [
+          "mango-talker"
+        ],
+        "modules": [
+          "talker-team-chat-module"
+        ]
+      },
+      {
+        "id": "talker-video-meeting-service",
+        "level": "service",
+        "name_ru": "Видео и конференции Talker",
+        "description": "Сервис видеозвонков, аудиоконференций и конференц-комнат.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/14-kak-nachat-gruppovoy-videozvonok.md",
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/42-kak-prisoedinitsya-k-konferencii-po-ssyl.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "unified-communications"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/14-kak-nachat-gruppovoy-videozvonok.md",
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/42-kak-prisoedinitsya-k-konferencii-po-ssyl.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "video",
+                  "synchronicity": "sync",
+                  "direction": "outbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "mango-talker",
+        "parent_products": [
+          "mango-talker"
+        ],
+        "modules": [
+          "talker-video-meeting-module"
+        ]
+      },
+      {
+        "id": "talker-contact-history-service",
+        "level": "service",
+        "name_ru": "Контакты и история Talker",
+        "description": "Сервис карточек контактов, истории вызовов и быстрых действий из журнала.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/97-opisanie-kartochki-kontakta.md",
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/78-opisanie-zhurnala-vyzovov.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "unified-communications"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/97-opisanie-kartochki-kontakta.md",
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/78-opisanie-zhurnala-vyzovov.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "mango-talker",
+        "parent_products": [
+          "mango-talker"
+        ],
+        "modules": [
+          "talker-contact-history-module"
+        ]
+      },
+      {
+        "id": "speech-analytics-service",
+        "level": "service",
+        "name_ru": "Речевая аналитика",
+        "description": "Сервис распознавания речи, тематик, тегов и аналитики разговоров.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/speech-analytics/index.md",
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/178-rechevaya-analitika.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "ai-automation",
+                "capability": "speech-analytics"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/speech-analytics/index.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/178-rechevaya-analitika.md"
+              ],
+              "facets": {
+                "ai_assisted": true
+              }
+            }
+          ]
+        },
+        "cluster": "ai-speech-quality",
+        "parent_products": [
+          "mango-ai-speech-quality"
+        ],
+        "modules": [
+          "speech-analytics-topic-module"
+        ]
+      },
+      {
+        "id": "conversation-summary-service",
+        "level": "service",
+        "name_ru": "AI-конспекты разговоров",
+        "description": "Сервис генерации и просмотра конспектов разговоров по данным звонков.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/vpbx-api/index.md",
+          "kb/mango-product-docs/processed/vpbx-api/sections/58-poluchenie-statistiki-vyzovov.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "ai-automation",
+                "capability": "conversation-summaries",
+                "feature": "ai-summary",
+                "function": "generate-summary"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/index.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/58-poluchenie-statistiki-vyzovov.md"
+              ],
+              "facets": {
+                "ai_assisted": true
+              }
+            }
+          ]
+        },
+        "cluster": "ai-speech-quality",
+        "parent_products": [
+          "mango-ai-speech-quality"
+        ],
+        "modules": [
+          "conversation-summary-module"
+        ]
+      },
+      {
+        "id": "quality-checklist-service",
+        "level": "service",
+        "name_ru": "Контроль качества и чек-листы",
+        "description": "Сервис чек-листов, оценок операторов и контроля качества разговоров.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/quality-managment/index.md",
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/184-konstruktor-chek-listov.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "quality-management"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/quality-managment/index.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/184-konstruktor-chek-listov.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "ai-speech-quality",
+        "parent_products": [
+          "mango-ai-speech-quality"
+        ],
+        "modules": [
+          "quality-checklist-module"
+        ]
+      },
+      {
+        "id": "voice-robot-service",
+        "level": "service",
+        "name_ru": "Голосовой робот",
+        "description": "Сервис автоматических голосовых диалогов и сценариев робота.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/contact-center/ai/voice-robot/",
+          "https://www.mango-office.ru/products/"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "ai-automation",
+                "capability": "voice-bot"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/contact-center/ai/voice-robot/",
+                "https://www.mango-office.ru/products/"
+              ],
+              "facets": {
+                "ai_assisted": true,
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "outbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "ai-speech-quality",
+        "parent_products": [
+          "mango-ai-speech-quality"
+        ],
+        "modules": [
+          "voice-robot-scenario-module"
+        ]
+      },
+      {
+        "id": "calltracking-attribution-service",
+        "level": "service",
+        "name_ru": "Атрибуция коллтрекинга",
+        "description": "Сервис определения рекламного источника звонка и подстановки номеров.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/calltracking/",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "analytics",
+                "capability": "call-tracking"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/calltracking/",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "analytics-marketing",
+        "parent_products": [
+          "mango-marketing-analytics"
+        ],
+        "modules": [
+          "calltracking-attribution-module"
+        ]
+      },
+      {
+        "id": "end-to-end-analytics-service",
+        "level": "service",
+        "name_ru": "Сквозная аналитика",
+        "description": "Сервис связывания коммуникаций, сделок и маркетинговой воронки.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/calltracking/",
+          "kb/mango-product-docs/processed/vpbx-api/sections/58-poluchenie-statistiki-vyzovov.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "analytics",
+                "capability": "end-to-end-analytics"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/calltracking/",
+                "kb/mango-product-docs/processed/vpbx-api/sections/58-poluchenie-statistiki-vyzovov.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "analytics-marketing",
+        "parent_products": [
+          "mango-marketing-analytics"
+        ],
+        "modules": [
+          "end-to-end-analytics-module"
+        ]
+      },
+      {
+        "id": "reporting-dashboard-service",
+        "level": "service",
+        "name_ru": "Отчёты и дашборды",
+        "description": "Сервис отчётов, фильтров, графиков и табличной аналитики.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/57-dashboard.md",
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/58-sozdanie-i-nastroyka-vidzheta.md",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "analytics",
+                "capability": "multichannel-analytics"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/57-dashboard.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/58-sozdanie-i-nastroyka-vidzheta.md",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "analytics-marketing",
+        "parent_products": [
+          "mango-marketing-analytics"
+        ],
+        "modules": [
+          "reporting-dashboard-module"
+        ]
+      },
+      {
+        "id": "wallboard-monitoring-service",
+        "level": "service",
+        "name_ru": "Wallboard-мониторинг",
+        "description": "Сервис real-time экранов, групповых показателей и виджетов Wallboard.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/wallboard/index.md",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/234-wallboard.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "analytics",
+                "capability": "real-time-reporting"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/wallboard/index.md",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/234-wallboard.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "analytics-marketing",
+        "parent_products": [
+          "mango-marketing-analytics"
+        ],
+        "modules": [
+          "wallboard-monitoring-module"
+        ]
+      },
+      {
+        "id": "vpbx-open-api-service",
+        "level": "service",
+        "name_ru": "ВАТС Open API",
+        "description": "Сервис API-команд Виртуальной АТС, realtime-событий и программного управления вызовами.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/vpbx-api/index.md",
+          "kb/mango-product-docs/processed/vpbx-api/sections/246-iniciirovanie-ishodyaschego-vyzova.md",
+          "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "open-api"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/index.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/246-iniciirovanie-ishodyaschego-vyzova.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "platform-integrations",
+        "parent_products": [
+          "mango-platform-integrations"
+        ],
+        "modules": [
+          "vpbx-open-api-module"
+        ]
+      },
+      {
+        "id": "contact-center-api-service",
+        "level": "service",
+        "name_ru": "Contact Center API",
+        "description": "Сервис API задач, событий и сущностей Контакт-центра.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/vpbx-api/index.md",
+          "kb/mango-product-docs/processed/vpbx-api/sections/157-sozdanie-zadachi-na-avtoperezvon.md",
+          "kb/mango-product-docs/processed/vpbx-api/sections/215-sobytiya.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "open-api"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/index.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/157-sozdanie-zadachi-na-avtoperezvon.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/215-sobytiya.md"
+              ]
+            },
+            {
+              "alignment_type": "secondary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "conversation-orchestration"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/index.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/157-sozdanie-zadachi-na-avtoperezvon.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/215-sobytiya.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "platform-integrations",
+        "parent_products": [
+          "mango-platform-integrations"
+        ],
+        "modules": [
+          "contact-center-api-module"
+        ]
+      },
+      {
+        "id": "crm-erp-integration-service",
+        "level": "service",
+        "name_ru": "CRM и ERP-интеграции",
+        "description": "Сервис интеграций с Bitrix24, 1C, amoCRM и внешними бизнес-системами.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/integration-bitrix24/index.md",
+          "kb/mango-product-docs/processed/integration_1c/index.md",
+          "kb/mango-product-docs/processed/integration_amocrm/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "platform-integration"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/integration-bitrix24/index.md",
+                "kb/mango-product-docs/processed/integration_1c/index.md",
+                "kb/mango-product-docs/processed/integration_amocrm/index.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "platform-integrations",
+        "parent_products": [
+          "mango-platform-integrations"
+        ],
+        "modules": [
+          "crm-erp-integration-module"
+        ]
+      },
+      {
+        "id": "webhook-event-service",
+        "level": "service",
+        "name_ru": "Webhook-события",
+        "description": "Сервис исходящих уведомлений, статусов и событий для внешних систем.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md",
+          "kb/mango-product-docs/processed/vpbx-api/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "open-api",
+                "feature": "webhook-management",
+                "function": "configure-webhook-endpoint"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md",
+                "kb/mango-product-docs/processed/vpbx-api/index.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "platform-integrations",
+        "parent_products": [
+          "mango-platform-integrations"
+        ],
+        "modules": [
+          "webhook-event-module"
+        ]
+      },
+      {
+        "id": "role-access-management-service",
+        "level": "service",
+        "name_ru": "Ролевое управление доступом",
+        "description": "Сервис ролей, прав и ограничений доступа к разделам ЛК и Контакт-центра.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/Rolevaya-model-vats/index.md",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/286-nastroyka-prav-dostupa-roli.md",
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/217-prilozhenie-1-upravlenie-pravami-dostupa.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "security",
+                "capability": "access-control",
+                "feature": "role-management",
+                "function": "assign-role"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/Rolevaya-model-vats/index.md",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/286-nastroyka-prav-dostupa-roli.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/217-prilozhenie-1-upravlenie-pravami-dostupa.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "security-access",
+        "parent_products": [
+          "mango-security-access"
+        ],
+        "modules": [
+          "role-access-management-module"
+        ]
+      },
+      {
+        "id": "sso-identity-service",
+        "level": "service",
+        "name_ru": "SSO и идентификация",
+        "description": "Сервис единого входа и federated authentication для ЛК ВАТС.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/lk-vats-sso/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "security",
+                "capability": "access-control"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/lk-vats-sso/index.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "security-access",
+        "parent_products": [
+          "mango-security-access"
+        ],
+        "modules": [
+          "sso-identity-module"
+        ]
+      },
+      {
+        "id": "recording-access-security-service",
+        "level": "service",
+        "name_ru": "Безопасность доступа к записям",
+        "description": "Сервис ограничений, доступа и контроля операций с записями разговоров.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/134-zapis-razgovorov.md",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "security",
+                "capability": "information-security"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/134-zapis-razgovorov.md",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "security-access",
+        "parent_products": [
+          "mango-security-access"
+        ],
+        "modules": [
+          "recording-access-security-module"
+        ]
+      },
+      {
+        "id": "security-audit-settings-service",
+        "level": "service",
+        "name_ru": "Аудит и настройки безопасности",
+        "description": "Сервис журнала действий, security-настроек и cross-product ограничений.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md",
+          "kb/mango-product-docs/processed/mango-lk-manual/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "security",
+                "capability": "information-security"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md",
+                "kb/mango-product-docs/processed/mango-lk-manual/index.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "security-access",
+        "parent_products": [
+          "mango-security-access"
+        ],
+        "modules": [
+          "security-audit-settings-module"
+        ]
+      }
+    ],
+    "modules": [
+      {
+        "id": "vats-inbound-scenarios-module",
+        "level": "module",
+        "name_ru": "Сценарии входящих звонков",
+        "description": "Модуль сервиса «Входящая маршрутизация ВАТС» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/105-nastroyki-dlya-vhodyaschih-liniy.md",
+          "kb/mango-product-docs/processed/vpbx-api/sections/42-marshrutizaciya-vyzova.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "call-routing"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/105-nastroyki-dlya-vhodyaschih-liniy.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/42-marshrutizaciya-vyzova.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "inbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "vats-core",
+        "parent_services": [
+          "vats-inbound-routing-service"
+        ],
+        "functions": [
+          "receive-inbound-call-through-scenario",
+          "configure-inbound-call-scenario"
+        ]
+      },
+      {
+        "id": "vats-ivr-menu-module",
+        "level": "module",
+        "name_ru": "Голосовое меню",
+        "description": "Модуль сервиса «Голосовое меню ВАТС» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "ivr-voice-menu"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "inbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "vats-core",
+        "parent_services": [
+          "vats-ivr-service"
+        ],
+        "functions": [
+          "play-ivr-menu-to-caller",
+          "edit-ivr-menu-branch"
+        ]
+      },
+      {
+        "id": "vats-connected-numbers-module",
+        "level": "module",
+        "name_ru": "Подключённые номера",
+        "description": "Модуль сервиса «Управление номерами ВАТС» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/100-nomera-podklyuchennye-k-ats.md",
+          "kb/mango-product-docs/processed/sip-trunk/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "number-management"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/100-nomera-podklyuchennye-k-ats.md",
+                "kb/mango-product-docs/processed/sip-trunk/index.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "vats-core",
+        "parent_services": [
+          "vats-number-management-service"
+        ],
+        "functions": [
+          "assign-connected-number-route",
+          "view-connected-number-list"
+        ]
+      },
+      {
+        "id": "vats-call-recording-module",
+        "level": "module",
+        "name_ru": "Запись разговоров",
+        "description": "Модуль сервиса «Записи и история звонков ВАТС» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/134-zapis-razgovorov.md",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/135-zapisannye-razgovory.md",
+          "kb/mango-product-docs/processed/vpbx-api/sections/40-vklyuchenie-zapisi-razgovora.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "call-recording"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/134-zapis-razgovorov.md",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/135-zapisannye-razgovory.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/40-vklyuchenie-zapisi-razgovora.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "inbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "vats-core",
+        "parent_services": [
+          "vats-recording-history-service"
+        ],
+        "functions": [
+          "enable-call-recording-rule",
+          "play-call-recording"
+        ]
+      },
+      {
+        "id": "cc-agent-call-handling-module",
+        "level": "module",
+        "name_ru": "Обработка обращений оператором",
+        "description": "Модуль сервиса «Рабочее место оператора КЦ» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/05-upravlenie-statusom.md",
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/07-ochered-obrascheniy.md",
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/46-sovershenie-ishodyaschih-vyzovov.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "agent-workspace"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/05-upravlenie-statusom.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/07-ochered-obrascheniy.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/46-sovershenie-ishodyaschih-vyzovov.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "contact-center-core",
+        "parent_services": [
+          "cc-agent-workspace-service"
+        ],
+        "functions": [
+          "accept-queue-interaction",
+          "set-agent-status"
+        ]
+      },
+      {
+        "id": "cc-queue-routing-module",
+        "level": "module",
+        "name_ru": "Очереди и правила распределения",
+        "description": "Модуль сервиса «Маршрутизация обращений КЦ» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/07-ochered-obrascheniy.md",
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/64-avtomaticheskoe-raspredelenie-obrascheni.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "interaction-routing",
+                "feature": "queue-routing"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/07-ochered-obrascheniy.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/64-avtomaticheskoe-raspredelenie-obrascheni.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "contact-center-core",
+        "parent_services": [
+          "cc-interaction-routing-service"
+        ],
+        "functions": [
+          "route-interaction-to-queue",
+          "configure-queue-routing-rule"
+        ]
+      },
+      {
+        "id": "cc-outbound-campaign-module",
+        "level": "module",
+        "name_ru": "Кампании исходящего обзвона",
+        "description": "Модуль сервиса «Исходящие кампании КЦ» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/123-ishodyaschiy-obzvon.md",
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/127-dobavlenie-kampanii.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "outbound-calling",
+                "feature": "campaign-management"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/123-ishodyaschiy-obzvon.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/127-dobavlenie-kampanii.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "contact-center-core",
+        "parent_services": [
+          "cc-outbound-campaign-service"
+        ],
+        "functions": [
+          "start-outbound-campaign",
+          "configure-outbound-campaign"
+        ]
+      },
+      {
+        "id": "cc-supervisor-wfm-module",
+        "level": "module",
+        "name_ru": "Планирование и супервизорский мониторинг",
+        "description": "Модуль сервиса «Супервизорский контроль и WFM» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/57-dashboard.md",
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/100-planirovanie-vhodyaschih.md",
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/58-sozdanie-i-nastroyka-vidzheta.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "workforce-management"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/57-dashboard.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/100-planirovanie-vhodyaschih.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/58-sozdanie-i-nastroyka-vidzheta.md"
+              ]
+            },
+            {
+              "alignment_type": "secondary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "supervisor-workspace"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/57-dashboard.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/100-planirovanie-vhodyaschih.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/58-sozdanie-i-nastroyka-vidzheta.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "contact-center-core",
+        "parent_services": [
+          "cc-supervisor-wfm-service"
+        ],
+        "functions": [
+          "monitor-agent-workload",
+          "configure-workforce-schedule"
+        ]
+      },
+      {
+        "id": "digital-channel-group-module",
+        "level": "module",
+        "name_ru": "Группы каналов коммуникации",
+        "description": "Модуль сервиса «Группы текстовых каналов» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/179-tekstovye-kommunikacii.md",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/191-whatsapp.md",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/192-telegram.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "omnichannel-messaging"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/179-tekstovye-kommunikacii.md",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/191-whatsapp.md",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/192-telegram.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "inbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "digital-channels",
+        "parent_services": [
+          "digital-channel-group-service"
+        ],
+        "functions": [
+          "send-channel-message",
+          "configure-channel-group"
+        ]
+      },
+      {
+        "id": "website-chat-widget-module",
+        "level": "module",
+        "name_ru": "Виджет чата на сайте",
+        "description": "Модуль сервиса «Чат на сайте» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/189-chat-na-sayte.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "website-chat"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/189-chat-na-sayte.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "inbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "digital-channels",
+        "parent_services": [
+          "website-chat-service"
+        ],
+        "functions": [
+          "receive-website-chat",
+          "install-website-chat-widget"
+        ]
+      },
+      {
+        "id": "messenger-channel-connector-module",
+        "level": "module",
+        "name_ru": "Подключение мессенджеров",
+        "description": "Модуль сервиса «Мессенджер-каналы» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/191-whatsapp.md",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/192-telegram.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "omnichannel-messaging",
+                "feature": "messenger-integration"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/191-whatsapp.md",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/192-telegram.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "inbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "digital-channels",
+        "parent_services": [
+          "messenger-channel-service"
+        ],
+        "functions": [
+          "connect-telegram-channel",
+          "reply-to-messenger-dialog"
+        ]
+      },
+      {
+        "id": "dialog-api-message-module",
+        "level": "module",
+        "name_ru": "API сообщений Dialogi",
+        "description": "Модуль сервиса «Dialog API» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mdialogi-api/index.md",
+          "kb/mango-product-docs/processed/vpbx-api/sections/238-otpravka-soobscheniya.md",
+          "kb/mango-product-docs/processed/vpbx-api/sections/239-opoveschenie-o-tom-chto-polzovatel-nabir.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "communications-apis"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mdialogi-api/index.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/238-otpravka-soobscheniya.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/239-opoveschenie-o-tom-chto-polzovatel-nabir.md"
+              ]
+            },
+            {
+              "alignment_type": "secondary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "omnichannel-messaging"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mdialogi-api/index.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/238-otpravka-soobscheniya.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/239-opoveschenie-o-tom-chto-polzovatel-nabir.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "outbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "digital-channels",
+        "parent_services": [
+          "dialog-api-messaging-service"
+        ],
+        "functions": [
+          "send-dialog-api-message",
+          "receive-dialog-api-event"
+        ]
+      },
+      {
+        "id": "talker-softphone-module",
+        "level": "module",
+        "name_ru": "Звонки в Talker",
+        "description": "Модуль сервиса «Софтфон Mango Talker» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/11-zvonok-sotrudniku.md",
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/15-kak-prinyat-vhodyaschiy-zvonok.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "unified-communications"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/11-zvonok-sotrudniku.md",
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/15-kak-prinyat-vhodyaschiy-zvonok.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "outbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "mango-talker",
+        "parent_services": [
+          "talker-softphone-service"
+        ],
+        "functions": [
+          "call-colleague-in-talker",
+          "answer-talker-call"
+        ]
+      },
+      {
+        "id": "talker-team-chat-module",
+        "level": "module",
+        "name_ru": "Чаты и каналы Talker",
+        "description": "Модуль сервиса «Командные чаты Mango Talker» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/17-otpravka-soobscheniya-v-chat.md",
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/47-sozdanie-novogo-chata-ili-kanala.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "team-messaging"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/17-otpravka-soobscheniya-v-chat.md",
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/47-sozdanie-novogo-chata-ili-kanala.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "outbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "mango-talker",
+        "parent_services": [
+          "talker-team-chat-service"
+        ],
+        "functions": [
+          "send-talker-chat-message",
+          "create-talker-chat-channel"
+        ]
+      },
+      {
+        "id": "talker-video-meeting-module",
+        "level": "module",
+        "name_ru": "Видео и конференции",
+        "description": "Модуль сервиса «Видео и конференции Talker» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/14-kak-nachat-gruppovoy-videozvonok.md",
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/42-kak-prisoedinitsya-k-konferencii-po-ssyl.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "unified-communications"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/14-kak-nachat-gruppovoy-videozvonok.md",
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/42-kak-prisoedinitsya-k-konferencii-po-ssyl.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "video",
+                  "synchronicity": "sync",
+                  "direction": "outbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "mango-talker",
+        "parent_services": [
+          "talker-video-meeting-service"
+        ],
+        "functions": [
+          "start-talker-video-call",
+          "join-talker-conference-room"
+        ]
+      },
+      {
+        "id": "talker-contact-history-module",
+        "level": "module",
+        "name_ru": "Контакты и журнал Talker",
+        "description": "Модуль сервиса «Контакты и история Talker» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/97-opisanie-kartochki-kontakta.md",
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/78-opisanie-zhurnala-vyzovov.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "unified-communications"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/97-opisanie-kartochki-kontakta.md",
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/78-opisanie-zhurnala-vyzovov.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "mango-talker",
+        "parent_services": [
+          "talker-contact-history-service"
+        ],
+        "functions": [
+          "open-talker-contact-card",
+          "call-contact-from-history"
+        ]
+      },
+      {
+        "id": "speech-analytics-topic-module",
+        "level": "module",
+        "name_ru": "Тематики речевой аналитики",
+        "description": "Модуль сервиса «Речевая аналитика» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/speech-analytics/index.md",
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/178-rechevaya-analitika.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "ai-automation",
+                "capability": "speech-analytics"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/speech-analytics/index.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/178-rechevaya-analitika.md"
+              ],
+              "facets": {
+                "ai_assisted": true
+              }
+            }
+          ]
+        },
+        "cluster": "ai-speech-quality",
+        "parent_services": [
+          "speech-analytics-service"
+        ],
+        "functions": [
+          "recognize-recorded-call-speech",
+          "configure-speech-topic"
+        ]
+      },
+      {
+        "id": "conversation-summary-module",
+        "level": "module",
+        "name_ru": "Конспекты разговоров",
+        "description": "Модуль сервиса «AI-конспекты разговоров» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/vpbx-api/index.md",
+          "kb/mango-product-docs/processed/vpbx-api/sections/58-poluchenie-statistiki-vyzovov.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "ai-automation",
+                "capability": "conversation-summaries",
+                "feature": "ai-summary",
+                "function": "generate-summary"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/index.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/58-poluchenie-statistiki-vyzovov.md"
+              ],
+              "facets": {
+                "ai_assisted": true
+              }
+            }
+          ]
+        },
+        "cluster": "ai-speech-quality",
+        "parent_services": [
+          "conversation-summary-service"
+        ],
+        "functions": [
+          "generate-call-summary",
+          "view-call-summary"
+        ]
+      },
+      {
+        "id": "quality-checklist-module",
+        "level": "module",
+        "name_ru": "Чек-листы качества",
+        "description": "Модуль сервиса «Контроль качества и чек-листы» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/quality-managment/index.md",
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/184-konstruktor-chek-listov.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "quality-management"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/quality-managment/index.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/184-konstruktor-chek-listov.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "ai-speech-quality",
+        "parent_services": [
+          "quality-checklist-service"
+        ],
+        "functions": [
+          "evaluate-call-by-checklist",
+          "configure-quality-checklist"
+        ]
+      },
+      {
+        "id": "voice-robot-scenario-module",
+        "level": "module",
+        "name_ru": "Сценарии голосового робота",
+        "description": "Модуль сервиса «Голосовой робот» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/contact-center/ai/voice-robot/",
+          "https://www.mango-office.ru/products/"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "ai-automation",
+                "capability": "voice-bot"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/contact-center/ai/voice-robot/",
+                "https://www.mango-office.ru/products/"
+              ],
+              "facets": {
+                "ai_assisted": true,
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "outbound"
+                }
+              }
+            }
+          ]
+        },
+        "cluster": "ai-speech-quality",
+        "parent_services": [
+          "voice-robot-service"
+        ],
+        "functions": [
+          "run-voice-robot-dialog",
+          "configure-voice-robot-scenario"
+        ]
+      },
+      {
+        "id": "calltracking-attribution-module",
+        "level": "module",
+        "name_ru": "Атрибуция рекламных источников",
+        "description": "Модуль сервиса «Атрибуция коллтрекинга» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/calltracking/",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "analytics",
+                "capability": "call-tracking"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/calltracking/",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "analytics-marketing",
+        "parent_services": [
+          "calltracking-attribution-service"
+        ],
+        "functions": [
+          "attribute-call-to-ad-source",
+          "configure-calltracking-number"
+        ]
+      },
+      {
+        "id": "end-to-end-analytics-module",
+        "level": "module",
+        "name_ru": "Сквозные отчёты",
+        "description": "Модуль сервиса «Сквозная аналитика» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/calltracking/",
+          "kb/mango-product-docs/processed/vpbx-api/sections/58-poluchenie-statistiki-vyzovov.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "analytics",
+                "capability": "end-to-end-analytics"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/calltracking/",
+                "kb/mango-product-docs/processed/vpbx-api/sections/58-poluchenie-statistiki-vyzovov.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "analytics-marketing",
+        "parent_services": [
+          "end-to-end-analytics-service"
+        ],
+        "functions": [
+          "join-call-and-sales-funnel",
+          "open-end-to-end-analytics-report"
+        ]
+      },
+      {
+        "id": "reporting-dashboard-module",
+        "level": "module",
+        "name_ru": "Конструктор и просмотр отчётов",
+        "description": "Модуль сервиса «Отчёты и дашборды» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/57-dashboard.md",
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/58-sozdanie-i-nastroyka-vidzheta.md",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "analytics",
+                "capability": "multichannel-analytics"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/57-dashboard.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/58-sozdanie-i-nastroyka-vidzheta.md",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "analytics-marketing",
+        "parent_services": [
+          "reporting-dashboard-service"
+        ],
+        "functions": [
+          "build-analytics-report",
+          "select-dashboard-widget"
+        ]
+      },
+      {
+        "id": "wallboard-monitoring-module",
+        "level": "module",
+        "name_ru": "Wallboard-виджеты",
+        "description": "Модуль сервиса «Wallboard-мониторинг» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/wallboard/index.md",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/234-wallboard.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "analytics",
+                "capability": "real-time-reporting"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/wallboard/index.md",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/234-wallboard.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "analytics-marketing",
+        "parent_services": [
+          "wallboard-monitoring-service"
+        ],
+        "functions": [
+          "display-wallboard-widget",
+          "configure-wallboard-widget"
+        ]
+      },
+      {
+        "id": "vpbx-open-api-module",
+        "level": "module",
+        "name_ru": "API Виртуальной АТС",
+        "description": "Модуль сервиса «ВАТС Open API» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/vpbx-api/index.md",
+          "kb/mango-product-docs/processed/vpbx-api/sections/246-iniciirovanie-ishodyaschego-vyzova.md",
+          "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "open-api"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/index.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/246-iniciirovanie-ishodyaschego-vyzova.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "platform-integrations",
+        "parent_services": [
+          "vpbx-open-api-service"
+        ],
+        "functions": [
+          "initiate-vpbx-api-call",
+          "configure-vpbx-webhook"
+        ]
+      },
+      {
+        "id": "contact-center-api-module",
+        "level": "module",
+        "name_ru": "API Контакт-центра",
+        "description": "Модуль сервиса «Contact Center API» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/vpbx-api/index.md",
+          "kb/mango-product-docs/processed/vpbx-api/sections/157-sozdanie-zadachi-na-avtoperezvon.md",
+          "kb/mango-product-docs/processed/vpbx-api/sections/215-sobytiya.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "open-api"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/index.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/157-sozdanie-zadachi-na-avtoperezvon.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/215-sobytiya.md"
+              ]
+            },
+            {
+              "alignment_type": "secondary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "conversation-orchestration"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/index.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/157-sozdanie-zadachi-na-avtoperezvon.md",
+                "kb/mango-product-docs/processed/vpbx-api/sections/215-sobytiya.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "platform-integrations",
+        "parent_services": [
+          "contact-center-api-service"
+        ],
+        "functions": [
+          "create-contact-center-task-api",
+          "receive-contact-center-event-webhook"
+        ]
+      },
+      {
+        "id": "crm-erp-integration-module",
+        "level": "module",
+        "name_ru": "Коннекторы CRM и ERP",
+        "description": "Модуль сервиса «CRM и ERP-интеграции» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/integration-bitrix24/index.md",
+          "kb/mango-product-docs/processed/integration_1c/index.md",
+          "kb/mango-product-docs/processed/integration_amocrm/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "platform-integration"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/integration-bitrix24/index.md",
+                "kb/mango-product-docs/processed/integration_1c/index.md",
+                "kb/mango-product-docs/processed/integration_amocrm/index.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "platform-integrations",
+        "parent_services": [
+          "crm-erp-integration-service"
+        ],
+        "functions": [
+          "sync-crm-call-card",
+          "configure-crm-integration"
+        ]
+      },
+      {
+        "id": "webhook-event-module",
+        "level": "module",
+        "name_ru": "Webhook endpoints",
+        "description": "Модуль сервиса «Webhook-события» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md",
+          "kb/mango-product-docs/processed/vpbx-api/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "open-api",
+                "feature": "webhook-management",
+                "function": "configure-webhook-endpoint"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md",
+                "kb/mango-product-docs/processed/vpbx-api/index.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "platform-integrations",
+        "parent_services": [
+          "webhook-event-service"
+        ],
+        "functions": [
+          "send-call-event-webhook",
+          "configure-webhook-endpoint"
+        ]
+      },
+      {
+        "id": "role-access-management-module",
+        "level": "module",
+        "name_ru": "Роли и права доступа",
+        "description": "Модуль сервиса «Ролевое управление доступом» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/Rolevaya-model-vats/index.md",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/286-nastroyka-prav-dostupa-roli.md",
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/217-prilozhenie-1-upravlenie-pravami-dostupa.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "security",
+                "capability": "access-control",
+                "feature": "role-management",
+                "function": "assign-role"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/Rolevaya-model-vats/index.md",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/286-nastroyka-prav-dostupa-roli.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/217-prilozhenie-1-upravlenie-pravami-dostupa.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "security-access",
+        "parent_services": [
+          "role-access-management-service"
+        ],
+        "functions": [
+          "assign-user-role",
+          "view-role-permissions"
+        ]
+      },
+      {
+        "id": "sso-identity-module",
+        "level": "module",
+        "name_ru": "SSO-подключение",
+        "description": "Модуль сервиса «SSO и идентификация» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/lk-vats-sso/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "security",
+                "capability": "access-control"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/lk-vats-sso/index.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "security-access",
+        "parent_services": [
+          "sso-identity-service"
+        ],
+        "functions": [
+          "authenticate-user-with-sso",
+          "configure-sso-connection"
+        ]
+      },
+      {
+        "id": "recording-access-security-module",
+        "level": "module",
+        "name_ru": "Ограничения доступа к записям",
+        "description": "Модуль сервиса «Безопасность доступа к записям» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/134-zapis-razgovorov.md",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "security",
+                "capability": "information-security"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/134-zapis-razgovorov.md",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "security-access",
+        "parent_services": [
+          "recording-access-security-service"
+        ],
+        "functions": [
+          "restrict-recording-access",
+          "audit-recording-download"
+        ]
+      },
+      {
+        "id": "security-audit-settings-module",
+        "level": "module",
+        "name_ru": "Журнал действий и политики безопасности",
+        "description": "Модуль сервиса «Аудит и настройки безопасности» в Mango Taxonomy.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md",
+          "kb/mango-product-docs/processed/mango-lk-manual/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "security",
+                "capability": "information-security"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md",
+                "kb/mango-product-docs/processed/mango-lk-manual/index.md"
+              ]
+            }
+          ]
+        },
+        "cluster": "security-access",
+        "parent_services": [
+          "security-audit-settings-service"
+        ],
+        "functions": [
+          "view-security-audit-log",
+          "configure-security-policy"
+        ]
+      }
+    ],
+    "functions": [
+      {
+        "id": "receive-inbound-call-through-scenario",
+        "level": "function",
+        "name_ru": "Принять входящий звонок по сценарию",
+        "description": "Атомарная функция модуля «Сценарии входящих звонков».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/105-nastroyki-dlya-vhodyaschih-liniy.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "voice-channel",
+                "feature": "inbound-voice-call",
+                "function": "receive-inbound-call"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/105-nastroyki-dlya-vhodyaschih-liniy.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "inbound"
+                }
+              }
+            }
+          ]
+        },
+        "parent_module": "vats-inbound-scenarios-module",
+        "function_type": "business",
+        "interaction_surface": "system-rule"
+      },
+      {
+        "id": "configure-inbound-call-scenario",
+        "level": "function",
+        "name_ru": "Настроить сценарий входящего звонка",
+        "description": "Атомарная функция модуля «Сценарии входящих звонков».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "call-routing"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "inbound"
+                }
+              },
+              "mapping_gap": {
+                "missing_level": "feature",
+                "proposed_id": "inbound-call-scenario",
+                "reason": "Industry Taxonomy фиксирует capability call-routing, но не выделяет сценарии ВАТС как feature."
+              }
+            }
+          ]
+        },
+        "parent_module": "vats-inbound-scenarios-module",
+        "function_type": "configuration",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "play-ivr-menu-to-caller",
+        "level": "function",
+        "name_ru": "Проиграть голосовое меню звонящему",
+        "description": "Атомарная функция модуля «Голосовое меню».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "ivr-voice-menu"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "inbound"
+                }
+              },
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "play-ivr-menu",
+                "reason": "Industry Taxonomy не содержит leaf-функцию проигрывания IVR."
+              }
+            }
+          ]
+        },
+        "parent_module": "vats-ivr-menu-module",
+        "function_type": "business",
+        "interaction_surface": "system-rule"
+      },
+      {
+        "id": "edit-ivr-menu-branch",
+        "level": "function",
+        "name_ru": "Изменить ветку голосового меню",
+        "description": "Атомарная функция модуля «Голосовое меню».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "ivr-voice-menu"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "inbound"
+                }
+              },
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "edit-ivr-branch",
+                "reason": "Industry Taxonomy не содержит leaf-функцию редактирования веток IVR."
+              }
+            }
+          ]
+        },
+        "parent_module": "vats-ivr-menu-module",
+        "function_type": "configuration",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "assign-connected-number-route",
+        "level": "function",
+        "name_ru": "Назначить маршрут подключённому номеру",
+        "description": "Атомарная функция модуля «Подключённые номера».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/100-nomera-podklyuchennye-k-ats.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "number-management"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/100-nomera-podklyuchennye-k-ats.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "assign-number-route",
+                "reason": "Industry Taxonomy не содержит leaf-функцию назначения маршрута номеру."
+              }
+            }
+          ]
+        },
+        "parent_module": "vats-connected-numbers-module",
+        "function_type": "configuration",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "view-connected-number-list",
+        "level": "function",
+        "name_ru": "Открыть список подключённых номеров",
+        "description": "Атомарная функция модуля «Подключённые номера».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/100-nomera-podklyuchennye-k-ats.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "number-management"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/100-nomera-podklyuchennye-k-ats.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "view-number-list",
+                "reason": "Industry Taxonomy не содержит UI leaf-функцию просмотра списка номеров."
+              }
+            }
+          ]
+        },
+        "parent_module": "vats-connected-numbers-module",
+        "function_type": "ui-action",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "enable-call-recording-rule",
+        "level": "function",
+        "name_ru": "Включить правило записи разговора",
+        "description": "Атомарная функция модуля «Запись разговоров».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/134-zapis-razgovorov.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "call-recording"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/134-zapis-razgovorov.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "inbound"
+                }
+              },
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "enable-call-recording-rule",
+                "reason": "Industry Taxonomy не содержит leaf-функцию включения правила записи."
+              }
+            }
+          ]
+        },
+        "parent_module": "vats-call-recording-module",
+        "function_type": "configuration",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "play-call-recording",
+        "level": "function",
+        "name_ru": "Прослушать запись разговора",
+        "description": "Атомарная функция модуля «Запись разговоров».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/135-zapisannye-razgovory.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "call-recording"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/135-zapisannye-razgovory.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "inbound"
+                }
+              },
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "play-call-recording",
+                "reason": "Industry Taxonomy не содержит UI leaf-функцию прослушивания записи."
+              }
+            }
+          ]
+        },
+        "parent_module": "vats-call-recording-module",
+        "function_type": "ui-action",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "accept-queue-interaction",
+        "level": "function",
+        "name_ru": "Принять обращение из очереди",
+        "description": "Атомарная функция модуля «Обработка обращений оператором».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/07-ochered-obrascheniy.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "agent-workspace"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/07-ochered-obrascheniy.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "accept-queue-interaction",
+                "reason": "Industry Taxonomy не содержит leaf-функцию принятия обращения оператором."
+              }
+            }
+          ]
+        },
+        "parent_module": "cc-agent-call-handling-module",
+        "function_type": "business",
+        "interaction_surface": "operator-ui"
+      },
+      {
+        "id": "set-agent-status",
+        "level": "function",
+        "name_ru": "Изменить статус оператора",
+        "description": "Атомарная функция модуля «Обработка обращений оператором».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/05-upravlenie-statusom.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "agent-workspace"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/05-upravlenie-statusom.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "set-agent-status",
+                "reason": "Industry Taxonomy не содержит UI leaf-функцию смены статуса оператора."
+              }
+            }
+          ]
+        },
+        "parent_module": "cc-agent-call-handling-module",
+        "function_type": "ui-action",
+        "interaction_surface": "operator-ui"
+      },
+      {
+        "id": "route-interaction-to-queue",
+        "level": "function",
+        "name_ru": "Распределить обращение в очередь",
+        "description": "Атомарная функция модуля «Очереди и правила распределения».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/64-avtomaticheskoe-raspredelenie-obrascheni.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "interaction-routing",
+                "feature": "queue-routing"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/64-avtomaticheskoe-raspredelenie-obrascheni.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "route-interaction-to-queue",
+                "reason": "Industry Taxonomy фиксирует queue-routing, но не содержит leaf-функцию распределения обращения."
+              }
+            }
+          ]
+        },
+        "parent_module": "cc-queue-routing-module",
+        "function_type": "business",
+        "interaction_surface": "system-rule"
+      },
+      {
+        "id": "configure-queue-routing-rule",
+        "level": "function",
+        "name_ru": "Настроить правило очереди",
+        "description": "Атомарная функция модуля «Очереди и правила распределения».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/64-avtomaticheskoe-raspredelenie-obrascheni.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "interaction-routing",
+                "feature": "routing-rules"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/64-avtomaticheskoe-raspredelenie-obrascheni.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "configure-queue-routing-rule",
+                "reason": "Industry Taxonomy фиксирует routing-rules, но не содержит leaf-функцию настройки правила."
+              }
+            }
+          ]
+        },
+        "parent_module": "cc-queue-routing-module",
+        "function_type": "configuration",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "start-outbound-campaign",
+        "level": "function",
+        "name_ru": "Запустить исходящую кампанию",
+        "description": "Атомарная функция модуля «Кампании исходящего обзвона».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/123-ishodyaschiy-obzvon.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "outbound-calling",
+                "feature": "campaign-management",
+                "function": "start-campaign"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/123-ishodyaschiy-obzvon.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "outbound"
+                }
+              }
+            }
+          ]
+        },
+        "parent_module": "cc-outbound-campaign-module",
+        "function_type": "business",
+        "interaction_surface": "operator-ui"
+      },
+      {
+        "id": "configure-outbound-campaign",
+        "level": "function",
+        "name_ru": "Настроить исходящую кампанию",
+        "description": "Атомарная функция модуля «Кампании исходящего обзвона».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/127-dobavlenie-kampanii.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "outbound-calling",
+                "feature": "campaign-management"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/127-dobavlenie-kampanii.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "configure-outbound-campaign",
+                "reason": "Industry Taxonomy содержит start-campaign, но не содержит отдельную функцию конфигурации кампании."
+              }
+            }
+          ]
+        },
+        "parent_module": "cc-outbound-campaign-module",
+        "function_type": "configuration",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "monitor-agent-workload",
+        "level": "function",
+        "name_ru": "Просмотреть нагрузку операторов",
+        "description": "Атомарная функция модуля «Планирование и супервизорский мониторинг».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/57-dashboard.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "supervisor-workspace"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/57-dashboard.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "monitor-agent-workload",
+                "reason": "Industry Taxonomy не содержит UI leaf-функцию просмотра нагрузки операторов."
+              }
+            }
+          ]
+        },
+        "parent_module": "cc-supervisor-wfm-module",
+        "function_type": "ui-action",
+        "interaction_surface": "operator-ui"
+      },
+      {
+        "id": "configure-workforce-schedule",
+        "level": "function",
+        "name_ru": "Настроить график входящих обращений",
+        "description": "Атомарная функция модуля «Планирование и супервизорский мониторинг».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/100-planirovanie-vhodyaschih.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "workforce-management"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/100-planirovanie-vhodyaschih.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "configure-workforce-schedule",
+                "reason": "Industry Taxonomy не содержит leaf-функцию настройки графика WFM."
+              }
+            }
+          ]
+        },
+        "parent_module": "cc-supervisor-wfm-module",
+        "function_type": "configuration",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "send-channel-message",
+        "level": "function",
+        "name_ru": "Отправить сообщение в цифровом канале",
+        "description": "Атомарная функция модуля «Группы каналов коммуникации».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/179-tekstovye-kommunikacii.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "omnichannel-messaging",
+                "feature": "messenger-integration",
+                "function": "send-message"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/179-tekstovye-kommunikacii.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "outbound"
+                }
+              }
+            }
+          ]
+        },
+        "parent_module": "digital-channel-group-module",
+        "function_type": "business",
+        "interaction_surface": "operator-ui"
+      },
+      {
+        "id": "configure-channel-group",
+        "level": "function",
+        "name_ru": "Настроить группу каналов",
+        "description": "Атомарная функция модуля «Группы каналов коммуникации».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/179-tekstovye-kommunikacii.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "omnichannel-messaging"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/179-tekstovye-kommunikacii.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "inbound"
+                }
+              },
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "configure-channel-group",
+                "reason": "Industry Taxonomy не содержит leaf-функцию настройки группы каналов."
+              }
+            }
+          ]
+        },
+        "parent_module": "digital-channel-group-module",
+        "function_type": "configuration",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "receive-website-chat",
+        "level": "function",
+        "name_ru": "Принять обращение из чата сайта",
+        "description": "Атомарная функция модуля «Виджет чата на сайте».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/189-chat-na-sayte.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "website-chat"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/189-chat-na-sayte.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "inbound"
+                }
+              },
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "receive-website-chat",
+                "reason": "Industry Taxonomy не содержит leaf-функцию приёма обращения из сайта."
+              }
+            }
+          ]
+        },
+        "parent_module": "website-chat-widget-module",
+        "function_type": "business",
+        "interaction_surface": "operator-ui"
+      },
+      {
+        "id": "install-website-chat-widget",
+        "level": "function",
+        "name_ru": "Установить код виджета чата",
+        "description": "Атомарная функция модуля «Виджет чата на сайте».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/189-chat-na-sayte.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "website-chat"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/189-chat-na-sayte.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "install-website-chat-widget",
+                "reason": "Industry Taxonomy не содержит leaf-функцию установки виджета сайта."
+              }
+            }
+          ]
+        },
+        "parent_module": "website-chat-widget-module",
+        "function_type": "configuration",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "connect-telegram-channel",
+        "level": "function",
+        "name_ru": "Подключить Telegram-канал",
+        "description": "Атомарная функция модуля «Подключение мессенджеров».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/192-telegram.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "omnichannel-messaging",
+                "feature": "messenger-integration"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/192-telegram.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "inbound"
+                }
+              },
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "connect-telegram-channel",
+                "reason": "Industry Taxonomy не содержит leaf-функцию подключения конкретного мессенджера."
+              }
+            }
+          ]
+        },
+        "parent_module": "messenger-channel-connector-module",
+        "function_type": "configuration",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "reply-to-messenger-dialog",
+        "level": "function",
+        "name_ru": "Ответить в диалоге мессенджера",
+        "description": "Атомарная функция модуля «Подключение мессенджеров».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/191-whatsapp.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "omnichannel-messaging",
+                "feature": "messenger-integration",
+                "function": "send-message"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/191-whatsapp.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "outbound"
+                }
+              }
+            }
+          ]
+        },
+        "parent_module": "messenger-channel-connector-module",
+        "function_type": "business",
+        "interaction_surface": "operator-ui"
+      },
+      {
+        "id": "send-dialog-api-message",
+        "level": "function",
+        "name_ru": "Отправить сообщение через Dialog API",
+        "description": "Атомарная функция модуля «API сообщений Dialogi».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/vpbx-api/sections/238-otpravka-soobscheniya.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "omnichannel-messaging",
+                "feature": "messenger-integration",
+                "function": "send-message"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/sections/238-otpravka-soobscheniya.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "outbound"
+                }
+              }
+            },
+            {
+              "alignment_type": "supporting",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "communications-apis"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/sections/238-otpravka-soobscheniya.md"
+              ]
+            }
+          ]
+        },
+        "parent_module": "dialog-api-message-module",
+        "function_type": "business",
+        "interaction_surface": "api"
+      },
+      {
+        "id": "receive-dialog-api-event",
+        "level": "function",
+        "name_ru": "Получить событие Dialog API",
+        "description": "Атомарная функция модуля «API сообщений Dialogi».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/vpbx-api/sections/239-opoveschenie-o-tom-chto-polzovatel-nabir.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "open-api",
+                "feature": "webhook-management",
+                "function": "configure-webhook-endpoint"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/sections/239-opoveschenie-o-tom-chto-polzovatel-nabir.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "inbound"
+                }
+              }
+            },
+            {
+              "alignment_type": "secondary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "omnichannel-messaging"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/sections/239-opoveschenie-o-tom-chto-polzovatel-nabir.md"
+              ]
+            }
+          ]
+        },
+        "parent_module": "dialog-api-message-module",
+        "function_type": "business",
+        "interaction_surface": "webhook"
+      },
+      {
+        "id": "call-colleague-in-talker",
+        "level": "function",
+        "name_ru": "Позвонить сотруднику из Talker",
+        "description": "Атомарная функция модуля «Звонки в Talker».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/11-zvonok-sotrudniku.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "voice-channel",
+                "feature": "outbound-voice-call"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/11-zvonok-sotrudniku.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "outbound"
+                }
+              }
+            }
+          ]
+        },
+        "parent_module": "talker-softphone-module",
+        "function_type": "business",
+        "interaction_surface": "end-user-ui"
+      },
+      {
+        "id": "answer-talker-call",
+        "level": "function",
+        "name_ru": "Ответить на входящий звонок в Talker",
+        "description": "Атомарная функция модуля «Звонки в Talker».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/15-kak-prinyat-vhodyaschiy-zvonok.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "voice-channel",
+                "feature": "inbound-voice-call",
+                "function": "receive-inbound-call"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/15-kak-prinyat-vhodyaschiy-zvonok.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "inbound"
+                }
+              }
+            }
+          ]
+        },
+        "parent_module": "talker-softphone-module",
+        "function_type": "business",
+        "interaction_surface": "end-user-ui"
+      },
+      {
+        "id": "send-talker-chat-message",
+        "level": "function",
+        "name_ru": "Отправить сообщение в Talker",
+        "description": "Атомарная функция модуля «Чаты и каналы Talker».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/17-otpravka-soobscheniya-v-chat.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "team-messaging"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/17-otpravka-soobscheniya-v-chat.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "outbound"
+                }
+              },
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "send-team-chat-message",
+                "reason": "Industry Taxonomy не содержит leaf-функцию отправки командного сообщения."
+              }
+            }
+          ]
+        },
+        "parent_module": "talker-team-chat-module",
+        "function_type": "business",
+        "interaction_surface": "end-user-ui"
+      },
+      {
+        "id": "create-talker-chat-channel",
+        "level": "function",
+        "name_ru": "Создать чат или канал Talker",
+        "description": "Атомарная функция модуля «Чаты и каналы Talker».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/47-sozdanie-novogo-chata-ili-kanala.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "team-messaging"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/47-sozdanie-novogo-chata-ili-kanala.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "create-team-chat-channel",
+                "reason": "Industry Taxonomy не содержит leaf-функцию создания командного канала."
+              }
+            }
+          ]
+        },
+        "parent_module": "talker-team-chat-module",
+        "function_type": "configuration",
+        "interaction_surface": "end-user-ui"
+      },
+      {
+        "id": "start-talker-video-call",
+        "level": "function",
+        "name_ru": "Начать групповой видеозвонок",
+        "description": "Атомарная функция модуля «Видео и конференции».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/14-kak-nachat-gruppovoy-videozvonok.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "unified-communications"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/14-kak-nachat-gruppovoy-videozvonok.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "video",
+                  "synchronicity": "sync",
+                  "direction": "outbound"
+                }
+              },
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "start-video-call",
+                "reason": "Industry Taxonomy не содержит leaf-функцию старта видеозвонка внутри UCaaS."
+              }
+            }
+          ]
+        },
+        "parent_module": "talker-video-meeting-module",
+        "function_type": "business",
+        "interaction_surface": "end-user-ui"
+      },
+      {
+        "id": "join-talker-conference-room",
+        "level": "function",
+        "name_ru": "Присоединиться к конференции Talker",
+        "description": "Атомарная функция модуля «Видео и конференции».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/42-kak-prisoedinitsya-k-konferencii-po-ssyl.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "unified-communications"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/42-kak-prisoedinitsya-k-konferencii-po-ssyl.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "video",
+                  "synchronicity": "sync",
+                  "direction": "inbound"
+                }
+              },
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "join-conference-room",
+                "reason": "Industry Taxonomy не содержит leaf-функцию входа в конференц-комнату."
+              }
+            }
+          ]
+        },
+        "parent_module": "talker-video-meeting-module",
+        "function_type": "business",
+        "interaction_surface": "end-user-ui"
+      },
+      {
+        "id": "open-talker-contact-card",
+        "level": "function",
+        "name_ru": "Открыть карточку контакта Talker",
+        "description": "Атомарная функция модуля «Контакты и журнал Talker».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/97-opisanie-kartochki-kontakta.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "unified-communications"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/97-opisanie-kartochki-kontakta.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "open-contact-card",
+                "reason": "Industry Taxonomy не содержит UI leaf-функцию открытия карточки контакта."
+              }
+            }
+          ]
+        },
+        "parent_module": "talker-contact-history-module",
+        "function_type": "ui-action",
+        "interaction_surface": "end-user-ui"
+      },
+      {
+        "id": "call-contact-from-history",
+        "level": "function",
+        "name_ru": "Позвонить контакту из истории",
+        "description": "Атомарная функция модуля «Контакты и журнал Talker».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/78-opisanie-zhurnala-vyzovov.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "voice-channel",
+                "feature": "outbound-voice-call"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/78-opisanie-zhurnala-vyzovov.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "outbound"
+                }
+              }
+            }
+          ]
+        },
+        "parent_module": "talker-contact-history-module",
+        "function_type": "business",
+        "interaction_surface": "end-user-ui"
+      },
+      {
+        "id": "recognize-recorded-call-speech",
+        "level": "function",
+        "name_ru": "Распознать речь в записи разговора",
+        "description": "Атомарная функция модуля «Тематики речевой аналитики».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/speech-analytics/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "ai-automation",
+                "capability": "speech-analytics"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/speech-analytics/index.md"
+              ],
+              "facets": {
+                "ai_assisted": true,
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "inbound"
+                }
+              },
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "recognize-call-speech",
+                "reason": "Industry Taxonomy не содержит leaf-функцию распознавания записи разговора."
+              }
+            }
+          ]
+        },
+        "parent_module": "speech-analytics-topic-module",
+        "function_type": "business",
+        "interaction_surface": "background-job"
+      },
+      {
+        "id": "configure-speech-topic",
+        "level": "function",
+        "name_ru": "Настроить тематику речевой аналитики",
+        "description": "Атомарная функция модуля «Тематики речевой аналитики».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/178-rechevaya-analitika.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "ai-automation",
+                "capability": "speech-analytics"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/178-rechevaya-analitika.md"
+              ],
+              "facets": {
+                "ai_assisted": true
+              },
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "configure-speech-topic",
+                "reason": "Industry Taxonomy не содержит leaf-функцию настройки тематик речи."
+              }
+            }
+          ]
+        },
+        "parent_module": "speech-analytics-topic-module",
+        "function_type": "configuration",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "generate-call-summary",
+        "level": "function",
+        "name_ru": "Сформировать конспект разговора",
+        "description": "Атомарная функция модуля «Конспекты разговоров».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/vpbx-api/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "ai-automation",
+                "capability": "conversation-summaries",
+                "feature": "ai-summary",
+                "function": "generate-summary"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/index.md"
+              ],
+              "facets": {
+                "ai_assisted": true
+              }
+            }
+          ]
+        },
+        "parent_module": "conversation-summary-module",
+        "function_type": "business",
+        "interaction_surface": "background-job"
+      },
+      {
+        "id": "view-call-summary",
+        "level": "function",
+        "name_ru": "Открыть конспект разговора",
+        "description": "Атомарная функция модуля «Конспекты разговоров».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/vpbx-api/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "ai-automation",
+                "capability": "conversation-summaries",
+                "feature": "ai-summary"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/index.md"
+              ],
+              "facets": {
+                "ai_assisted": true
+              },
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "view-call-summary",
+                "reason": "Industry Taxonomy содержит generate-summary, но не содержит UI-функцию просмотра конспекта."
+              }
+            }
+          ]
+        },
+        "parent_module": "conversation-summary-module",
+        "function_type": "ui-action",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "evaluate-call-by-checklist",
+        "level": "function",
+        "name_ru": "Оценить разговор по чек-листу",
+        "description": "Атомарная функция модуля «Чек-листы качества».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/quality-managment/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "quality-management"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/quality-managment/index.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "evaluate-call-by-checklist",
+                "reason": "Industry Taxonomy не содержит leaf-функцию оценки разговора по чек-листу."
+              }
+            }
+          ]
+        },
+        "parent_module": "quality-checklist-module",
+        "function_type": "business",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "configure-quality-checklist",
+        "level": "function",
+        "name_ru": "Настроить чек-лист качества",
+        "description": "Атомарная функция модуля «Чек-листы качества».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/184-konstruktor-chek-listov.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "quality-management"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/184-konstruktor-chek-listov.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "configure-quality-checklist",
+                "reason": "Industry Taxonomy не содержит leaf-функцию настройки чек-листа."
+              }
+            }
+          ]
+        },
+        "parent_module": "quality-checklist-module",
+        "function_type": "configuration",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "run-voice-robot-dialog",
+        "level": "function",
+        "name_ru": "Запустить голосовой диалог робота",
+        "description": "Атомарная функция модуля «Сценарии голосового робота».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/contact-center/ai/voice-robot/"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "ai-automation",
+                "capability": "voice-bot"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/contact-center/ai/voice-robot/"
+              ],
+              "facets": {
+                "ai_assisted": true,
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "outbound"
+                }
+              },
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "run-voice-robot-dialog",
+                "reason": "Industry Taxonomy не содержит leaf-функцию исполнения сценария голосового робота."
+              }
+            }
+          ]
+        },
+        "parent_module": "voice-robot-scenario-module",
+        "function_type": "business",
+        "interaction_surface": "system-rule"
+      },
+      {
+        "id": "configure-voice-robot-scenario",
+        "level": "function",
+        "name_ru": "Настроить сценарий голосового робота",
+        "description": "Атомарная функция модуля «Сценарии голосового робота».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/contact-center/ai/voice-robot/"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "ai-automation",
+                "capability": "voice-bot"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/contact-center/ai/voice-robot/"
+              ],
+              "facets": {
+                "ai_assisted": true
+              },
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "configure-voice-robot-scenario",
+                "reason": "Industry Taxonomy не содержит leaf-функцию настройки сценария голосового робота."
+              }
+            }
+          ]
+        },
+        "parent_module": "voice-robot-scenario-module",
+        "function_type": "configuration",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "attribute-call-to-ad-source",
+        "level": "function",
+        "name_ru": "Привязать звонок к рекламному источнику",
+        "description": "Атомарная функция модуля «Атрибуция рекламных источников».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "analytics",
+                "capability": "call-tracking"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "attribute-call-to-ad-source",
+                "reason": "Industry Taxonomy не содержит leaf-функцию атрибуции звонка к рекламе."
+              }
+            }
+          ]
+        },
+        "parent_module": "calltracking-attribution-module",
+        "function_type": "business",
+        "interaction_surface": "background-job"
+      },
+      {
+        "id": "configure-calltracking-number",
+        "level": "function",
+        "name_ru": "Настроить номер коллтрекинга",
+        "description": "Атомарная функция модуля «Атрибуция рекламных источников».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/calltracking/"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "analytics",
+                "capability": "call-tracking"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/calltracking/"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "configure-calltracking-number",
+                "reason": "Industry Taxonomy не содержит leaf-функцию настройки номера коллтрекинга."
+              }
+            }
+          ]
+        },
+        "parent_module": "calltracking-attribution-module",
+        "function_type": "configuration",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "join-call-and-sales-funnel",
+        "level": "function",
+        "name_ru": "Связать звонок с воронкой продаж",
+        "description": "Атомарная функция модуля «Сквозные отчёты».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/vpbx-api/sections/58-poluchenie-statistiki-vyzovov.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "analytics",
+                "capability": "end-to-end-analytics"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/sections/58-poluchenie-statistiki-vyzovov.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "join-call-and-sales-funnel",
+                "reason": "Industry Taxonomy не содержит leaf-функцию связывания звонка с продажами."
+              }
+            }
+          ]
+        },
+        "parent_module": "end-to-end-analytics-module",
+        "function_type": "business",
+        "interaction_surface": "background-job"
+      },
+      {
+        "id": "open-end-to-end-analytics-report",
+        "level": "function",
+        "name_ru": "Открыть отчёт сквозной аналитики",
+        "description": "Атомарная функция модуля «Сквозные отчёты».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/calltracking/"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "analytics",
+                "capability": "end-to-end-analytics"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/calltracking/"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "open-end-to-end-analytics-report",
+                "reason": "Industry Taxonomy не содержит UI leaf-функцию открытия отчёта сквозной аналитики."
+              }
+            }
+          ]
+        },
+        "parent_module": "end-to-end-analytics-module",
+        "function_type": "ui-action",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "build-analytics-report",
+        "level": "function",
+        "name_ru": "Сформировать аналитический отчёт",
+        "description": "Атомарная функция модуля «Конструктор и просмотр отчётов».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "analytics",
+                "capability": "multichannel-analytics"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "build-analytics-report",
+                "reason": "Industry Taxonomy не содержит leaf-функцию формирования отчёта."
+              }
+            }
+          ]
+        },
+        "parent_module": "reporting-dashboard-module",
+        "function_type": "business",
+        "interaction_surface": "background-job"
+      },
+      {
+        "id": "select-dashboard-widget",
+        "level": "function",
+        "name_ru": "Выбрать виджет дашборда",
+        "description": "Атомарная функция модуля «Конструктор и просмотр отчётов».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/58-sozdanie-i-nastroyka-vidzheta.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "analytics",
+                "capability": "real-time-reporting",
+                "feature": "dashboard-view",
+                "function": "select-dashboard-widget"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/58-sozdanie-i-nastroyka-vidzheta.md"
+              ]
+            }
+          ]
+        },
+        "parent_module": "reporting-dashboard-module",
+        "function_type": "ui-action",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "display-wallboard-widget",
+        "level": "function",
+        "name_ru": "Показать виджет Wallboard",
+        "description": "Атомарная функция модуля «Wallboard-виджеты».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/wallboard/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "analytics",
+                "capability": "real-time-reporting",
+                "feature": "dashboard-view",
+                "function": "select-dashboard-widget"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/wallboard/index.md"
+              ]
+            }
+          ]
+        },
+        "parent_module": "wallboard-monitoring-module",
+        "function_type": "business",
+        "interaction_surface": "end-user-ui"
+      },
+      {
+        "id": "configure-wallboard-widget",
+        "level": "function",
+        "name_ru": "Настроить виджет Wallboard",
+        "description": "Атомарная функция модуля «Wallboard-виджеты».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/234-wallboard.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "analytics",
+                "capability": "real-time-reporting"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/234-wallboard.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "configure-wallboard-widget",
+                "reason": "Industry Taxonomy не содержит leaf-функцию настройки Wallboard-виджета."
+              }
+            }
+          ]
+        },
+        "parent_module": "wallboard-monitoring-module",
+        "function_type": "configuration",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "initiate-vpbx-api-call",
+        "level": "function",
+        "name_ru": "Инициировать звонок через API ВАТС",
+        "description": "Атомарная функция модуля «API Виртуальной АТС».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/vpbx-api/sections/246-iniciirovanie-ishodyaschego-vyzova.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "voice-channel",
+                "feature": "outbound-voice-call"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/sections/246-iniciirovanie-ishodyaschego-vyzova.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "outbound"
+                }
+              }
+            },
+            {
+              "alignment_type": "supporting",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "open-api"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/sections/246-iniciirovanie-ishodyaschego-vyzova.md"
+              ]
+            }
+          ]
+        },
+        "parent_module": "vpbx-open-api-module",
+        "function_type": "business",
+        "interaction_surface": "api"
+      },
+      {
+        "id": "configure-vpbx-webhook",
+        "level": "function",
+        "name_ru": "Настроить webhook ВАТС",
+        "description": "Атомарная функция модуля «API Виртуальной АТС».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "open-api",
+                "feature": "webhook-management",
+                "function": "configure-webhook-endpoint"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md"
+              ]
+            }
+          ]
+        },
+        "parent_module": "vpbx-open-api-module",
+        "function_type": "configuration",
+        "interaction_surface": "api"
+      },
+      {
+        "id": "create-contact-center-task-api",
+        "level": "function",
+        "name_ru": "Создать задачу Контакт-центра через API",
+        "description": "Атомарная функция модуля «API Контакт-центра».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/vpbx-api/sections/157-sozdanie-zadachi-na-avtoperezvon.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "open-api"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/sections/157-sozdanie-zadachi-na-avtoperezvon.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "create-contact-center-task",
+                "reason": "Industry Taxonomy не содержит leaf-функцию создания задачи КЦ через API."
+              }
+            },
+            {
+              "alignment_type": "secondary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "conversation-orchestration"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/sections/157-sozdanie-zadachi-na-avtoperezvon.md"
+              ]
+            }
+          ]
+        },
+        "parent_module": "contact-center-api-module",
+        "function_type": "business",
+        "interaction_surface": "api"
+      },
+      {
+        "id": "receive-contact-center-event-webhook",
+        "level": "function",
+        "name_ru": "Получить событие Контакт-центра через webhook",
+        "description": "Атомарная функция модуля «API Контакт-центра».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/vpbx-api/sections/215-sobytiya.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "open-api",
+                "feature": "webhook-management",
+                "function": "configure-webhook-endpoint"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/sections/215-sobytiya.md"
+              ]
+            },
+            {
+              "alignment_type": "secondary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "conversation-orchestration"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/sections/215-sobytiya.md"
+              ]
+            }
+          ]
+        },
+        "parent_module": "contact-center-api-module",
+        "function_type": "business",
+        "interaction_surface": "webhook"
+      },
+      {
+        "id": "sync-crm-call-card",
+        "level": "function",
+        "name_ru": "Синхронизировать карточку звонка с CRM",
+        "description": "Атомарная функция модуля «Коннекторы CRM и ERP».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/integration-bitrix24/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "platform-integration"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/integration-bitrix24/index.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "sync-crm-call-card",
+                "reason": "Industry Taxonomy не содержит leaf-функцию синхронизации карточки звонка."
+              }
+            }
+          ]
+        },
+        "parent_module": "crm-erp-integration-module",
+        "function_type": "business",
+        "interaction_surface": "background-job"
+      },
+      {
+        "id": "configure-crm-integration",
+        "level": "function",
+        "name_ru": "Настроить CRM-интеграцию",
+        "description": "Атомарная функция модуля «Коннекторы CRM и ERP».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/integration_amocrm/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "platform-integration"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/integration_amocrm/index.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "configure-crm-integration",
+                "reason": "Industry Taxonomy не содержит leaf-функцию настройки CRM-коннектора."
+              }
+            }
+          ]
+        },
+        "parent_module": "crm-erp-integration-module",
+        "function_type": "configuration",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "send-call-event-webhook",
+        "level": "function",
+        "name_ru": "Передать событие звонка во внешний webhook",
+        "description": "Атомарная функция модуля «Webhook endpoints».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "open-api",
+                "feature": "webhook-management",
+                "function": "configure-webhook-endpoint"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md"
+              ]
+            },
+            {
+              "alignment_type": "secondary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "voice-channel",
+                "feature": "inbound-voice-call"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "inbound"
+                }
+              }
+            }
+          ]
+        },
+        "parent_module": "webhook-event-module",
+        "function_type": "business",
+        "interaction_surface": "webhook"
+      },
+      {
+        "id": "configure-webhook-endpoint",
+        "level": "function",
+        "name_ru": "Настроить endpoint webhook",
+        "description": "Атомарная функция модуля «Webhook endpoints».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "open-api",
+                "feature": "webhook-management",
+                "function": "configure-webhook-endpoint"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md"
+              ]
+            }
+          ]
+        },
+        "parent_module": "webhook-event-module",
+        "function_type": "configuration",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "assign-user-role",
+        "level": "function",
+        "name_ru": "Назначить роль пользователю",
+        "description": "Атомарная функция модуля «Роли и права доступа».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/286-nastroyka-prav-dostupa-roli.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "security",
+                "capability": "access-control",
+                "feature": "role-management",
+                "function": "assign-role"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/286-nastroyka-prav-dostupa-roli.md"
+              ]
+            }
+          ]
+        },
+        "parent_module": "role-access-management-module",
+        "function_type": "configuration",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "view-role-permissions",
+        "level": "function",
+        "name_ru": "Просмотреть права роли",
+        "description": "Атомарная функция модуля «Роли и права доступа».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/Rolevaya-model-vats/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "security",
+                "capability": "access-control",
+                "feature": "role-management"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/Rolevaya-model-vats/index.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "view-role-permissions",
+                "reason": "Industry Taxonomy содержит assign-role, но не содержит UI-функцию просмотра прав роли."
+              }
+            }
+          ]
+        },
+        "parent_module": "role-access-management-module",
+        "function_type": "ui-action",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "authenticate-user-with-sso",
+        "level": "function",
+        "name_ru": "Аутентифицировать пользователя через SSO",
+        "description": "Атомарная функция модуля «SSO-подключение».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/lk-vats-sso/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "security",
+                "capability": "access-control"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/lk-vats-sso/index.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "authenticate-user-with-sso",
+                "reason": "Industry Taxonomy не содержит leaf-функцию SSO-аутентификации."
+              }
+            }
+          ]
+        },
+        "parent_module": "sso-identity-module",
+        "function_type": "business",
+        "interaction_surface": "end-user-ui"
+      },
+      {
+        "id": "configure-sso-connection",
+        "level": "function",
+        "name_ru": "Настроить SSO-подключение",
+        "description": "Атомарная функция модуля «SSO-подключение».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/lk-vats-sso/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "security",
+                "capability": "access-control"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/lk-vats-sso/index.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "configure-sso-connection",
+                "reason": "Industry Taxonomy не содержит leaf-функцию настройки SSO."
+              }
+            }
+          ]
+        },
+        "parent_module": "sso-identity-module",
+        "function_type": "configuration",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "restrict-recording-access",
+        "level": "function",
+        "name_ru": "Ограничить доступ к записям разговоров",
+        "description": "Атомарная функция модуля «Ограничения доступа к записям».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "security",
+                "capability": "information-security"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "restrict-recording-access",
+                "reason": "Industry Taxonomy не содержит leaf-функцию ограничения доступа к записям."
+              }
+            }
+          ]
+        },
+        "parent_module": "recording-access-security-module",
+        "function_type": "configuration",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "audit-recording-download",
+        "level": "function",
+        "name_ru": "Проверить доступ к скачиванию записи",
+        "description": "Атомарная функция модуля «Ограничения доступа к записям».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/134-zapis-razgovorov.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "security",
+                "capability": "information-security"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/134-zapis-razgovorov.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "audit-recording-download",
+                "reason": "Industry Taxonomy не содержит UI leaf-функцию проверки доступа к скачиванию записи."
+              }
+            }
+          ]
+        },
+        "parent_module": "recording-access-security-module",
+        "function_type": "ui-action",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "view-security-audit-log",
+        "level": "function",
+        "name_ru": "Просмотреть журнал действий",
+        "description": "Атомарная функция модуля «Журнал действий и политики безопасности».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "security",
+                "capability": "information-security"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "view-security-audit-log",
+                "reason": "Industry Taxonomy не содержит UI leaf-функцию просмотра журнала безопасности."
+              }
+            }
+          ]
+        },
+        "parent_module": "security-audit-settings-module",
+        "function_type": "ui-action",
+        "interaction_surface": "admin-ui"
+      },
+      {
+        "id": "configure-security-policy",
+        "level": "function",
+        "name_ru": "Настроить политику безопасности",
+        "description": "Атомарная функция модуля «Журнал действий и политики безопасности».",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "security",
+                "capability": "information-security"
+              },
+              "evidence_refs": [
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md"
+              ],
+              "mapping_gap": {
+                "missing_level": "function",
+                "proposed_id": "configure-security-policy",
+                "reason": "Industry Taxonomy не содержит leaf-функцию настройки политики безопасности."
+              }
+            }
+          ]
+        },
+        "parent_module": "security-audit-settings-module",
+        "function_type": "configuration",
+        "interaction_surface": "admin-ui"
+      }
+    ]
+  }
+}

--- a/kb/mango/official-products.yaml
+++ b/kb/mango/official-products.yaml
@@ -1,0 +1,427 @@
+{
+  "taxonomy": {
+    "version": 1,
+    "scope": "mango-official-products",
+    "official_products": [
+      {
+        "id": "mango-virtual-pbx-official",
+        "level": "official-product",
+        "name_ru": "Виртуальная АТС",
+        "description": "Публичный продукт Mango Office для облачной офисной телефонии, маршрутизации звонков и управления номерами.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/virtualnaya_ats/",
+          "kb/mango-product-docs/processed/mango-lk-manual/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "cloud-pbx"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/virtualnaya_ats/",
+                "kb/mango-product-docs/processed/mango-lk-manual/index.md"
+              ]
+            }
+          ]
+        },
+        "aliases": [
+          "ВАТС",
+          "Virtual PBX",
+          "Облачная АТС"
+        ],
+        "owner": "Mango Office",
+        "official_urls": [
+          "https://www.mango-office.ru/products/virtualnaya_ats/"
+        ],
+        "supported_by_services": [
+          "vats-inbound-routing-service",
+          "vats-ivr-service",
+          "vats-number-management-service",
+          "vats-recording-history-service"
+        ]
+      },
+      {
+        "id": "mango-sip-trunk-official",
+        "level": "official-product",
+        "name_ru": "SIP Trunk и гибридная телефония",
+        "description": "Публичный набор возможностей подключения внешней телефонии и SIP-инфраструктуры к Виртуальной АТС.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/",
+          "kb/mango-product-docs/processed/sip-trunk/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "sip-connectivity"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/",
+                "kb/mango-product-docs/processed/sip-trunk/index.md"
+              ]
+            }
+          ]
+        },
+        "aliases": [
+          "SIP Trunk",
+          "Гибридная АТС"
+        ],
+        "owner": "Mango Office",
+        "official_urls": [
+          "https://www.mango-office.ru/products/"
+        ],
+        "supported_by_services": [
+          "vats-number-management-service",
+          "vpbx-open-api-service"
+        ]
+      },
+      {
+        "id": "mango-contact-center-official",
+        "level": "official-product",
+        "name_ru": "Контакт-центр",
+        "description": "Публичный продукт для обработки обращений, рабочих мест операторов, очередей и супервизорского контроля.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/contact-center/",
+          "kb/mango-product-docs/processed/mango-cc-manual/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "contact-center",
+                "capability": "omnichannel-contact-center"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/contact-center/",
+                "kb/mango-product-docs/processed/mango-cc-manual/index.md"
+              ]
+            }
+          ]
+        },
+        "aliases": [
+          "КЦ",
+          "Contact Center"
+        ],
+        "owner": "Mango Office",
+        "official_urls": [
+          "https://www.mango-office.ru/products/contact-center/",
+          "https://www.mango-office.ru/products/contact-center/vozmozhnosti/"
+        ],
+        "supported_by_services": [
+          "cc-agent-workspace-service",
+          "cc-interaction-routing-service",
+          "cc-outbound-campaign-service",
+          "cc-supervisor-wfm-service",
+          "quality-checklist-service"
+        ]
+      },
+      {
+        "id": "mango-text-communications-official",
+        "level": "official-product",
+        "name_ru": "Текстовые коммуникации",
+        "description": "Публичный продуктовый слой для сайта, мессенджеров, шаблонов и цифровых диалогов.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/179-tekstovye-kommunikacii.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "digital-channels",
+                "capability": "omnichannel-messaging"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/179-tekstovye-kommunikacii.md"
+              ],
+              "facets": {
+                "channel": {
+                  "channel_kind": "text",
+                  "synchronicity": "async",
+                  "direction": "inbound"
+                }
+              }
+            }
+          ]
+        },
+        "aliases": [
+          "Текстовые коммуникации",
+          "Digital channels"
+        ],
+        "owner": "Mango Office",
+        "official_urls": [
+          "https://www.mango-office.ru/products/"
+        ],
+        "supported_by_services": [
+          "digital-channel-group-service",
+          "website-chat-service",
+          "messenger-channel-service",
+          "dialog-api-messaging-service"
+        ]
+      },
+      {
+        "id": "mango-calltracking-official",
+        "level": "official-product",
+        "name_ru": "Коллтрекинг и маркетинговая аналитика",
+        "description": "Публичный продукт для привязки звонков к рекламным источникам и оценки эффективности маркетинга.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/calltracking/",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "analytics",
+                "capability": "call-tracking"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/calltracking/",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+              ]
+            }
+          ]
+        },
+        "aliases": [
+          "Calltracking",
+          "Коллтрекинг",
+          "Сквозная аналитика"
+        ],
+        "owner": "Mango Office",
+        "official_urls": [
+          "https://www.mango-office.ru/products/calltracking/"
+        ],
+        "supported_by_services": [
+          "calltracking-attribution-service",
+          "end-to-end-analytics-service",
+          "reporting-dashboard-service"
+        ]
+      },
+      {
+        "id": "mango-speech-analytics-official",
+        "level": "official-product",
+        "name_ru": "Речевая аналитика",
+        "description": "Публичный AI-продукт для распознавания и анализа разговоров.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/virtualnaya_ats/vozmozhnosti/speech-analytics/",
+          "kb/mango-product-docs/processed/speech-analytics/index.md",
+          "kb/mango-product-docs/processed/mango-cc-manual/sections/178-rechevaya-analitika.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "ai-automation",
+                "capability": "speech-analytics"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/virtualnaya_ats/vozmozhnosti/speech-analytics/",
+                "kb/mango-product-docs/processed/speech-analytics/index.md",
+                "kb/mango-product-docs/processed/mango-cc-manual/sections/178-rechevaya-analitika.md"
+              ],
+              "facets": {
+                "ai_assisted": true
+              }
+            }
+          ]
+        },
+        "aliases": [
+          "Speech Analytics",
+          "Речевая аналитика"
+        ],
+        "owner": "Mango Office",
+        "official_urls": [
+          "https://www.mango-office.ru/products/virtualnaya_ats/vozmozhnosti/speech-analytics/"
+        ],
+        "supported_by_services": [
+          "speech-analytics-service",
+          "conversation-summary-service",
+          "quality-checklist-service"
+        ]
+      },
+      {
+        "id": "mango-robots-official",
+        "level": "official-product",
+        "name_ru": "Роботы",
+        "description": "Публичный AI-продукт для автоматизированных голосовых сценариев и диалогов.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/contact-center/ai/voice-robot/",
+          "https://www.mango-office.ru/products/"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "ai-automation",
+                "capability": "voice-bot"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/contact-center/ai/voice-robot/",
+                "https://www.mango-office.ru/products/"
+              ],
+              "facets": {
+                "ai_assisted": true,
+                "channel": {
+                  "channel_kind": "voice",
+                  "synchronicity": "sync",
+                  "direction": "outbound"
+                }
+              }
+            }
+          ]
+        },
+        "aliases": [
+          "Голосовые роботы",
+          "Voice Robot"
+        ],
+        "owner": "Mango Office",
+        "official_urls": [
+          "https://www.mango-office.ru/products/contact-center/ai/voice-robot/"
+        ],
+        "supported_by_services": [
+          "voice-robot-service"
+        ]
+      },
+      {
+        "id": "mango-talker-official",
+        "level": "official-product",
+        "name_ru": "Mango Talker",
+        "description": "Публичный продукт корпоративных звонков, чатов, видеозвонков и контактной истории.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/mango-talker/",
+          "kb/mango-product-docs/processed/mtalker/android-user-guide/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "voice-ucaas",
+                "capability": "unified-communications"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/mango-talker/",
+                "kb/mango-product-docs/processed/mtalker/android-user-guide/index.md"
+              ]
+            }
+          ]
+        },
+        "aliases": [
+          "Mango Talker",
+          "MTalker"
+        ],
+        "owner": "Mango Office",
+        "official_urls": [
+          "https://www.mango-office.ru/products/mango-talker/"
+        ],
+        "supported_by_services": [
+          "talker-softphone-service",
+          "talker-team-chat-service",
+          "talker-video-meeting-service",
+          "talker-contact-history-service"
+        ]
+      },
+      {
+        "id": "mango-integrations-official",
+        "level": "official-product",
+        "name_ru": "Интеграции",
+        "description": "Публичный продуктовый слой интеграций Mango Office с CRM, ERP, API и webhooks.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/products/integraciya/",
+          "kb/mango-product-docs/processed/integration-bitrix24/index.md",
+          "kb/mango-product-docs/processed/integration_1c/index.md",
+          "kb/mango-product-docs/processed/integration_amocrm/index.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "platform",
+                "capability": "platform-integration"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/products/integraciya/",
+                "kb/mango-product-docs/processed/integration-bitrix24/index.md",
+                "kb/mango-product-docs/processed/integration_1c/index.md",
+                "kb/mango-product-docs/processed/integration_amocrm/index.md"
+              ]
+            }
+          ]
+        },
+        "aliases": [
+          "Интеграции",
+          "CRM integrations"
+        ],
+        "owner": "Mango Office",
+        "official_urls": [
+          "https://www.mango-office.ru/products/integraciya/"
+        ],
+        "supported_by_services": [
+          "vpbx-open-api-service",
+          "contact-center-api-service",
+          "crm-erp-integration-service",
+          "webhook-event-service"
+        ]
+      },
+      {
+        "id": "mango-numbers-equipment-official",
+        "level": "official-product",
+        "name_ru": "Номера и оборудование",
+        "description": "Публичный продуктовый слой подключения номеров, устройств и телефонной инфраструктуры.",
+        "lifecycle_status": "active",
+        "evidence_refs": [
+          "https://www.mango-office.ru/shop/devices/",
+          "kb/mango-product-docs/processed/mango-lk-manual/sections/100-nomera-podklyuchennye-k-ats.md"
+        ],
+        "maps_to": {
+          "industry_alignment": [
+            {
+              "alignment_type": "primary",
+              "industry_ref": {
+                "domain": "hardware",
+                "capability": "device-management"
+              },
+              "evidence_refs": [
+                "https://www.mango-office.ru/shop/devices/",
+                "kb/mango-product-docs/processed/mango-lk-manual/sections/100-nomera-podklyuchennye-k-ats.md"
+              ]
+            }
+          ]
+        },
+        "aliases": [
+          "Оборудование",
+          "Номера",
+          "Devices"
+        ],
+        "owner": "Mango Office",
+        "official_urls": [
+          "https://www.mango-office.ru/shop/devices/"
+        ],
+        "supported_by_services": [
+          "vats-number-management-service"
+        ]
+      }
+    ]
+  }
+}

--- a/kb/mango/product-mapping.yaml
+++ b/kb/mango/product-mapping.yaml
@@ -1,0 +1,3250 @@
+{
+  "taxonomy_mapping": {
+    "version": 1,
+    "mapping_scope": "mango-to-industry",
+    "source_taxonomy": "mango-taxonomy",
+    "target_taxonomy": "industry-taxonomy",
+    "entities": [
+      {
+        "source_id": "mango-virtual-pbx-official",
+        "source_level": "official-product",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "cloud-pbx"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/virtualnaya_ats/",
+              "kb/mango-product-docs/processed/mango-lk-manual/index.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "mango-sip-trunk-official",
+        "source_level": "official-product",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "sip-connectivity"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/",
+              "kb/mango-product-docs/processed/sip-trunk/index.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "mango-contact-center-official",
+        "source_level": "official-product",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "omnichannel-contact-center"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/contact-center/",
+              "kb/mango-product-docs/processed/mango-cc-manual/index.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "mango-text-communications-official",
+        "source_level": "official-product",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "omnichannel-messaging"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/179-tekstovye-kommunikacii.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "text",
+                "synchronicity": "async",
+                "direction": "inbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "mango-calltracking-official",
+        "source_level": "official-product",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "analytics",
+              "capability": "call-tracking"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/calltracking/",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "mango-speech-analytics-official",
+        "source_level": "official-product",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "ai-automation",
+              "capability": "speech-analytics"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/virtualnaya_ats/vozmozhnosti/speech-analytics/",
+              "kb/mango-product-docs/processed/speech-analytics/index.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/178-rechevaya-analitika.md"
+            ],
+            "facets": {
+              "ai_assisted": true
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "mango-robots-official",
+        "source_level": "official-product",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "ai-automation",
+              "capability": "voice-bot"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/contact-center/ai/voice-robot/",
+              "https://www.mango-office.ru/products/"
+            ],
+            "facets": {
+              "ai_assisted": true,
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "outbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "mango-talker-official",
+        "source_level": "official-product",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "unified-communications"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/mango-talker/",
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/index.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "mango-integrations-official",
+        "source_level": "official-product",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "platform-integration"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/integraciya/",
+              "kb/mango-product-docs/processed/integration-bitrix24/index.md",
+              "kb/mango-product-docs/processed/integration_1c/index.md",
+              "kb/mango-product-docs/processed/integration_amocrm/index.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "mango-numbers-equipment-official",
+        "source_level": "official-product",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "hardware",
+              "capability": "device-management"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/shop/devices/",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/100-nomera-podklyuchennye-k-ats.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "mango-virtual-pbx",
+        "source_level": "product",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "cloud-pbx"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/virtualnaya_ats/",
+              "kb/mango-product-docs/processed/mango-lk-manual/index.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "mango-contact-center",
+        "source_level": "product",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "omnichannel-contact-center"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/contact-center/",
+              "kb/mango-product-docs/processed/mango-cc-manual/index.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "mango-digital-communications",
+        "source_level": "product",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "omnichannel-messaging"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/179-tekstovye-kommunikacii.md",
+              "kb/mango-product-docs/processed/mdialogi-api/index.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "text",
+                "synchronicity": "async",
+                "direction": "inbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "mango-talker",
+        "source_level": "product",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "unified-communications"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/mango-talker/",
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/index.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "mango-ai-speech-quality",
+        "source_level": "product",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "ai-automation",
+              "capability": "speech-analytics"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/virtualnaya_ats/vozmozhnosti/speech-analytics/",
+              "kb/mango-product-docs/processed/speech-analytics/index.md",
+              "kb/mango-product-docs/processed/quality-managment/index.md"
+            ],
+            "facets": {
+              "ai_assisted": true
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "mango-marketing-analytics",
+        "source_level": "product",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "analytics",
+              "capability": "call-tracking"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/calltracking/",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md",
+              "kb/mango-product-docs/processed/wallboard/index.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "mango-platform-integrations",
+        "source_level": "product",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "open-api"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/integraciya/",
+              "kb/mango-product-docs/processed/vpbx-api/index.md",
+              "kb/mango-product-docs/processed/integration-bitrix24/index.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "mango-security-access",
+        "source_level": "product",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "security",
+              "capability": "access-control"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/Rolevaya-model-vats/index.md",
+              "kb/mango-product-docs/processed/lk-vats-sso/index.md",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "vats-inbound-routing-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "call-routing"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/105-nastroyki-dlya-vhodyaschih-liniy.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/42-marshrutizaciya-vyzova.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "inbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "vats-ivr-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "ivr-voice-menu"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "inbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "vats-number-management-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "number-management"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/100-nomera-podklyuchennye-k-ats.md",
+              "kb/mango-product-docs/processed/sip-trunk/index.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "vats-recording-history-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "call-recording"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/134-zapis-razgovorov.md",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/135-zapisannye-razgovory.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/40-vklyuchenie-zapisi-razgovora.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "inbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "cc-agent-workspace-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "agent-workspace"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/05-upravlenie-statusom.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/07-ochered-obrascheniy.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/46-sovershenie-ishodyaschih-vyzovov.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "cc-interaction-routing-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "interaction-routing",
+              "feature": "queue-routing"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/07-ochered-obrascheniy.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/64-avtomaticheskoe-raspredelenie-obrascheni.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "cc-outbound-campaign-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "outbound-calling",
+              "feature": "campaign-management"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/123-ishodyaschiy-obzvon.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/127-dobavlenie-kampanii.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "cc-supervisor-wfm-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "workforce-management"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/57-dashboard.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/100-planirovanie-vhodyaschih.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/58-sozdanie-i-nastroyka-vidzheta.md"
+            ]
+          },
+          {
+            "alignment_type": "secondary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "supervisor-workspace"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/57-dashboard.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/100-planirovanie-vhodyaschih.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/58-sozdanie-i-nastroyka-vidzheta.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "digital-channel-group-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "omnichannel-messaging"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/179-tekstovye-kommunikacii.md",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/191-whatsapp.md",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/192-telegram.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "text",
+                "synchronicity": "async",
+                "direction": "inbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "website-chat-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "website-chat"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/189-chat-na-sayte.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "text",
+                "synchronicity": "async",
+                "direction": "inbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "messenger-channel-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "omnichannel-messaging",
+              "feature": "messenger-integration"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/191-whatsapp.md",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/192-telegram.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "text",
+                "synchronicity": "async",
+                "direction": "inbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "dialog-api-messaging-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "communications-apis"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mdialogi-api/index.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/238-otpravka-soobscheniya.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/239-opoveschenie-o-tom-chto-polzovatel-nabir.md"
+            ]
+          },
+          {
+            "alignment_type": "secondary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "omnichannel-messaging"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mdialogi-api/index.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/238-otpravka-soobscheniya.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/239-opoveschenie-o-tom-chto-polzovatel-nabir.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "text",
+                "synchronicity": "async",
+                "direction": "outbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "talker-softphone-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "unified-communications"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/11-zvonok-sotrudniku.md",
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/15-kak-prinyat-vhodyaschiy-zvonok.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "outbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "talker-team-chat-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "team-messaging"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/17-otpravka-soobscheniya-v-chat.md",
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/47-sozdanie-novogo-chata-ili-kanala.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "text",
+                "synchronicity": "async",
+                "direction": "outbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "talker-video-meeting-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "unified-communications"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/14-kak-nachat-gruppovoy-videozvonok.md",
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/42-kak-prisoedinitsya-k-konferencii-po-ssyl.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "video",
+                "synchronicity": "sync",
+                "direction": "outbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "talker-contact-history-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "unified-communications"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/97-opisanie-kartochki-kontakta.md",
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/78-opisanie-zhurnala-vyzovov.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "speech-analytics-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "ai-automation",
+              "capability": "speech-analytics"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/speech-analytics/index.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/178-rechevaya-analitika.md"
+            ],
+            "facets": {
+              "ai_assisted": true
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "conversation-summary-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "ai-automation",
+              "capability": "conversation-summaries",
+              "feature": "ai-summary",
+              "function": "generate-summary"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/index.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/58-poluchenie-statistiki-vyzovov.md"
+            ],
+            "facets": {
+              "ai_assisted": true
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "quality-checklist-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "quality-management"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/quality-managment/index.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/184-konstruktor-chek-listov.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "voice-robot-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "ai-automation",
+              "capability": "voice-bot"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/contact-center/ai/voice-robot/",
+              "https://www.mango-office.ru/products/"
+            ],
+            "facets": {
+              "ai_assisted": true,
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "outbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "calltracking-attribution-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "analytics",
+              "capability": "call-tracking"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/calltracking/",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "end-to-end-analytics-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "analytics",
+              "capability": "end-to-end-analytics"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/calltracking/",
+              "kb/mango-product-docs/processed/vpbx-api/sections/58-poluchenie-statistiki-vyzovov.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "reporting-dashboard-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "analytics",
+              "capability": "multichannel-analytics"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/57-dashboard.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/58-sozdanie-i-nastroyka-vidzheta.md",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "wallboard-monitoring-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "analytics",
+              "capability": "real-time-reporting"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/wallboard/index.md",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/234-wallboard.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "vpbx-open-api-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "open-api"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/index.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/246-iniciirovanie-ishodyaschego-vyzova.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "contact-center-api-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "open-api"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/index.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/157-sozdanie-zadachi-na-avtoperezvon.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/215-sobytiya.md"
+            ]
+          },
+          {
+            "alignment_type": "secondary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "conversation-orchestration"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/index.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/157-sozdanie-zadachi-na-avtoperezvon.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/215-sobytiya.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "crm-erp-integration-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "platform-integration"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/integration-bitrix24/index.md",
+              "kb/mango-product-docs/processed/integration_1c/index.md",
+              "kb/mango-product-docs/processed/integration_amocrm/index.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "webhook-event-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "open-api",
+              "feature": "webhook-management",
+              "function": "configure-webhook-endpoint"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md",
+              "kb/mango-product-docs/processed/vpbx-api/index.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "role-access-management-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "security",
+              "capability": "access-control",
+              "feature": "role-management",
+              "function": "assign-role"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/Rolevaya-model-vats/index.md",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/286-nastroyka-prav-dostupa-roli.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/217-prilozhenie-1-upravlenie-pravami-dostupa.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "sso-identity-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "security",
+              "capability": "access-control"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/lk-vats-sso/index.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "recording-access-security-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "security",
+              "capability": "information-security"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/134-zapis-razgovorov.md",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "security-audit-settings-service",
+        "source_level": "service",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "security",
+              "capability": "information-security"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md",
+              "kb/mango-product-docs/processed/mango-lk-manual/index.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "vats-inbound-scenarios-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "call-routing"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/105-nastroyki-dlya-vhodyaschih-liniy.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/42-marshrutizaciya-vyzova.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "inbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "vats-ivr-menu-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "ivr-voice-menu"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "inbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "vats-connected-numbers-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "number-management"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/100-nomera-podklyuchennye-k-ats.md",
+              "kb/mango-product-docs/processed/sip-trunk/index.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "vats-call-recording-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "call-recording"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/134-zapis-razgovorov.md",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/135-zapisannye-razgovory.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/40-vklyuchenie-zapisi-razgovora.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "inbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "cc-agent-call-handling-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "agent-workspace"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/05-upravlenie-statusom.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/07-ochered-obrascheniy.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/46-sovershenie-ishodyaschih-vyzovov.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "cc-queue-routing-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "interaction-routing",
+              "feature": "queue-routing"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/07-ochered-obrascheniy.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/64-avtomaticheskoe-raspredelenie-obrascheni.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "cc-outbound-campaign-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "outbound-calling",
+              "feature": "campaign-management"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/123-ishodyaschiy-obzvon.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/127-dobavlenie-kampanii.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "cc-supervisor-wfm-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "workforce-management"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/57-dashboard.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/100-planirovanie-vhodyaschih.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/58-sozdanie-i-nastroyka-vidzheta.md"
+            ]
+          },
+          {
+            "alignment_type": "secondary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "supervisor-workspace"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/57-dashboard.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/100-planirovanie-vhodyaschih.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/58-sozdanie-i-nastroyka-vidzheta.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "digital-channel-group-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "omnichannel-messaging"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/179-tekstovye-kommunikacii.md",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/191-whatsapp.md",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/192-telegram.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "text",
+                "synchronicity": "async",
+                "direction": "inbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "website-chat-widget-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "website-chat"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/189-chat-na-sayte.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "text",
+                "synchronicity": "async",
+                "direction": "inbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "messenger-channel-connector-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "omnichannel-messaging",
+              "feature": "messenger-integration"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/191-whatsapp.md",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/192-telegram.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "text",
+                "synchronicity": "async",
+                "direction": "inbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "dialog-api-message-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "communications-apis"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mdialogi-api/index.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/238-otpravka-soobscheniya.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/239-opoveschenie-o-tom-chto-polzovatel-nabir.md"
+            ]
+          },
+          {
+            "alignment_type": "secondary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "omnichannel-messaging"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mdialogi-api/index.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/238-otpravka-soobscheniya.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/239-opoveschenie-o-tom-chto-polzovatel-nabir.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "text",
+                "synchronicity": "async",
+                "direction": "outbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "talker-softphone-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "unified-communications"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/11-zvonok-sotrudniku.md",
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/15-kak-prinyat-vhodyaschiy-zvonok.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "outbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "talker-team-chat-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "team-messaging"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/17-otpravka-soobscheniya-v-chat.md",
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/47-sozdanie-novogo-chata-ili-kanala.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "text",
+                "synchronicity": "async",
+                "direction": "outbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "talker-video-meeting-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "unified-communications"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/14-kak-nachat-gruppovoy-videozvonok.md",
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/42-kak-prisoedinitsya-k-konferencii-po-ssyl.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "video",
+                "synchronicity": "sync",
+                "direction": "outbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "talker-contact-history-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "unified-communications"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/97-opisanie-kartochki-kontakta.md",
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/78-opisanie-zhurnala-vyzovov.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "speech-analytics-topic-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "ai-automation",
+              "capability": "speech-analytics"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/speech-analytics/index.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/178-rechevaya-analitika.md"
+            ],
+            "facets": {
+              "ai_assisted": true
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "conversation-summary-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "ai-automation",
+              "capability": "conversation-summaries",
+              "feature": "ai-summary",
+              "function": "generate-summary"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/index.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/58-poluchenie-statistiki-vyzovov.md"
+            ],
+            "facets": {
+              "ai_assisted": true
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "quality-checklist-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "quality-management"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/quality-managment/index.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/184-konstruktor-chek-listov.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "voice-robot-scenario-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "ai-automation",
+              "capability": "voice-bot"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/contact-center/ai/voice-robot/",
+              "https://www.mango-office.ru/products/"
+            ],
+            "facets": {
+              "ai_assisted": true,
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "outbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "calltracking-attribution-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "analytics",
+              "capability": "call-tracking"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/calltracking/",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "end-to-end-analytics-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "analytics",
+              "capability": "end-to-end-analytics"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/calltracking/",
+              "kb/mango-product-docs/processed/vpbx-api/sections/58-poluchenie-statistiki-vyzovov.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "reporting-dashboard-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "analytics",
+              "capability": "multichannel-analytics"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/57-dashboard.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/58-sozdanie-i-nastroyka-vidzheta.md",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "wallboard-monitoring-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "analytics",
+              "capability": "real-time-reporting"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/wallboard/index.md",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/234-wallboard.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "vpbx-open-api-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "open-api"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/index.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/246-iniciirovanie-ishodyaschego-vyzova.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "contact-center-api-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "open-api"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/index.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/157-sozdanie-zadachi-na-avtoperezvon.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/215-sobytiya.md"
+            ]
+          },
+          {
+            "alignment_type": "secondary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "conversation-orchestration"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/index.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/157-sozdanie-zadachi-na-avtoperezvon.md",
+              "kb/mango-product-docs/processed/vpbx-api/sections/215-sobytiya.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "crm-erp-integration-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "platform-integration"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/integration-bitrix24/index.md",
+              "kb/mango-product-docs/processed/integration_1c/index.md",
+              "kb/mango-product-docs/processed/integration_amocrm/index.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "webhook-event-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "open-api",
+              "feature": "webhook-management",
+              "function": "configure-webhook-endpoint"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md",
+              "kb/mango-product-docs/processed/vpbx-api/index.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "role-access-management-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "security",
+              "capability": "access-control",
+              "feature": "role-management",
+              "function": "assign-role"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/Rolevaya-model-vats/index.md",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/286-nastroyka-prav-dostupa-roli.md",
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/217-prilozhenie-1-upravlenie-pravami-dostupa.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "sso-identity-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "security",
+              "capability": "access-control"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/lk-vats-sso/index.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "recording-access-security-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "security",
+              "capability": "information-security"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/134-zapis-razgovorov.md",
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "security-audit-settings-module",
+        "source_level": "module",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "security",
+              "capability": "information-security"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md",
+              "kb/mango-product-docs/processed/mango-lk-manual/index.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "receive-inbound-call-through-scenario",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "voice-channel",
+              "feature": "inbound-voice-call",
+              "function": "receive-inbound-call"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/105-nastroyki-dlya-vhodyaschih-liniy.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "inbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "configure-inbound-call-scenario",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "call-routing"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "inbound"
+              }
+            },
+            "mapping_gap": {
+              "missing_level": "feature",
+              "proposed_id": "inbound-call-scenario",
+              "reason": "Industry Taxonomy фиксирует capability call-routing, но не выделяет сценарии ВАТС как feature."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "play-ivr-menu-to-caller",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "ivr-voice-menu"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "inbound"
+              }
+            },
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "play-ivr-menu",
+              "reason": "Industry Taxonomy не содержит leaf-функцию проигрывания IVR."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "edit-ivr-menu-branch",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "ivr-voice-menu"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/104-golosovoe-menyu-i-raspredelenie-zvonkov.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "inbound"
+              }
+            },
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "edit-ivr-branch",
+              "reason": "Industry Taxonomy не содержит leaf-функцию редактирования веток IVR."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "assign-connected-number-route",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "number-management"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/100-nomera-podklyuchennye-k-ats.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "assign-number-route",
+              "reason": "Industry Taxonomy не содержит leaf-функцию назначения маршрута номеру."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "view-connected-number-list",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "number-management"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/100-nomera-podklyuchennye-k-ats.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "view-number-list",
+              "reason": "Industry Taxonomy не содержит UI leaf-функцию просмотра списка номеров."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "enable-call-recording-rule",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "call-recording"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/134-zapis-razgovorov.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "inbound"
+              }
+            },
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "enable-call-recording-rule",
+              "reason": "Industry Taxonomy не содержит leaf-функцию включения правила записи."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "play-call-recording",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "call-recording"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/135-zapisannye-razgovory.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "inbound"
+              }
+            },
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "play-call-recording",
+              "reason": "Industry Taxonomy не содержит UI leaf-функцию прослушивания записи."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "accept-queue-interaction",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "agent-workspace"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/07-ochered-obrascheniy.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "accept-queue-interaction",
+              "reason": "Industry Taxonomy не содержит leaf-функцию принятия обращения оператором."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "set-agent-status",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "agent-workspace"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/05-upravlenie-statusom.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "set-agent-status",
+              "reason": "Industry Taxonomy не содержит UI leaf-функцию смены статуса оператора."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "route-interaction-to-queue",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "interaction-routing",
+              "feature": "queue-routing"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/64-avtomaticheskoe-raspredelenie-obrascheni.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "route-interaction-to-queue",
+              "reason": "Industry Taxonomy фиксирует queue-routing, но не содержит leaf-функцию распределения обращения."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "configure-queue-routing-rule",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "interaction-routing",
+              "feature": "routing-rules"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/64-avtomaticheskoe-raspredelenie-obrascheni.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "configure-queue-routing-rule",
+              "reason": "Industry Taxonomy фиксирует routing-rules, но не содержит leaf-функцию настройки правила."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "start-outbound-campaign",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "outbound-calling",
+              "feature": "campaign-management",
+              "function": "start-campaign"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/123-ishodyaschiy-obzvon.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "outbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "configure-outbound-campaign",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "outbound-calling",
+              "feature": "campaign-management"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/127-dobavlenie-kampanii.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "configure-outbound-campaign",
+              "reason": "Industry Taxonomy содержит start-campaign, но не содержит отдельную функцию конфигурации кампании."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "monitor-agent-workload",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "supervisor-workspace"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/57-dashboard.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "monitor-agent-workload",
+              "reason": "Industry Taxonomy не содержит UI leaf-функцию просмотра нагрузки операторов."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "configure-workforce-schedule",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "workforce-management"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/100-planirovanie-vhodyaschih.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "configure-workforce-schedule",
+              "reason": "Industry Taxonomy не содержит leaf-функцию настройки графика WFM."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "send-channel-message",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "omnichannel-messaging",
+              "feature": "messenger-integration",
+              "function": "send-message"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/179-tekstovye-kommunikacii.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "text",
+                "synchronicity": "async",
+                "direction": "outbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "configure-channel-group",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "omnichannel-messaging"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/179-tekstovye-kommunikacii.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "text",
+                "synchronicity": "async",
+                "direction": "inbound"
+              }
+            },
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "configure-channel-group",
+              "reason": "Industry Taxonomy не содержит leaf-функцию настройки группы каналов."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "receive-website-chat",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "website-chat"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/189-chat-na-sayte.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "text",
+                "synchronicity": "async",
+                "direction": "inbound"
+              }
+            },
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "receive-website-chat",
+              "reason": "Industry Taxonomy не содержит leaf-функцию приёма обращения из сайта."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "install-website-chat-widget",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "website-chat"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/189-chat-na-sayte.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "install-website-chat-widget",
+              "reason": "Industry Taxonomy не содержит leaf-функцию установки виджета сайта."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "connect-telegram-channel",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "omnichannel-messaging",
+              "feature": "messenger-integration"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/192-telegram.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "text",
+                "synchronicity": "async",
+                "direction": "inbound"
+              }
+            },
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "connect-telegram-channel",
+              "reason": "Industry Taxonomy не содержит leaf-функцию подключения конкретного мессенджера."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "reply-to-messenger-dialog",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "omnichannel-messaging",
+              "feature": "messenger-integration",
+              "function": "send-message"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/191-whatsapp.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "text",
+                "synchronicity": "async",
+                "direction": "outbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "send-dialog-api-message",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "omnichannel-messaging",
+              "feature": "messenger-integration",
+              "function": "send-message"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/sections/238-otpravka-soobscheniya.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "text",
+                "synchronicity": "async",
+                "direction": "outbound"
+              }
+            }
+          },
+          {
+            "alignment_type": "supporting",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "communications-apis"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/sections/238-otpravka-soobscheniya.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "receive-dialog-api-event",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "open-api",
+              "feature": "webhook-management",
+              "function": "configure-webhook-endpoint"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/sections/239-opoveschenie-o-tom-chto-polzovatel-nabir.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "text",
+                "synchronicity": "async",
+                "direction": "inbound"
+              }
+            }
+          },
+          {
+            "alignment_type": "secondary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "omnichannel-messaging"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/sections/239-opoveschenie-o-tom-chto-polzovatel-nabir.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "call-colleague-in-talker",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "voice-channel",
+              "feature": "outbound-voice-call"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/11-zvonok-sotrudniku.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "outbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "answer-talker-call",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "voice-channel",
+              "feature": "inbound-voice-call",
+              "function": "receive-inbound-call"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/15-kak-prinyat-vhodyaschiy-zvonok.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "inbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "send-talker-chat-message",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "team-messaging"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/17-otpravka-soobscheniya-v-chat.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "text",
+                "synchronicity": "async",
+                "direction": "outbound"
+              }
+            },
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "send-team-chat-message",
+              "reason": "Industry Taxonomy не содержит leaf-функцию отправки командного сообщения."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "create-talker-chat-channel",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "digital-channels",
+              "capability": "team-messaging"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/47-sozdanie-novogo-chata-ili-kanala.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "create-team-chat-channel",
+              "reason": "Industry Taxonomy не содержит leaf-функцию создания командного канала."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "start-talker-video-call",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "unified-communications"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/14-kak-nachat-gruppovoy-videozvonok.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "video",
+                "synchronicity": "sync",
+                "direction": "outbound"
+              }
+            },
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "start-video-call",
+              "reason": "Industry Taxonomy не содержит leaf-функцию старта видеозвонка внутри UCaaS."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "join-talker-conference-room",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "unified-communications"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/42-kak-prisoedinitsya-k-konferencii-po-ssyl.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "video",
+                "synchronicity": "sync",
+                "direction": "inbound"
+              }
+            },
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "join-conference-room",
+              "reason": "Industry Taxonomy не содержит leaf-функцию входа в конференц-комнату."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "open-talker-contact-card",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "unified-communications"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/97-opisanie-kartochki-kontakta.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "open-contact-card",
+              "reason": "Industry Taxonomy не содержит UI leaf-функцию открытия карточки контакта."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "call-contact-from-history",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "voice-channel",
+              "feature": "outbound-voice-call"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mtalker/android-user-guide/sections/78-opisanie-zhurnala-vyzovov.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "outbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "recognize-recorded-call-speech",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "ai-automation",
+              "capability": "speech-analytics"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/speech-analytics/index.md"
+            ],
+            "facets": {
+              "ai_assisted": true,
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "inbound"
+              }
+            },
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "recognize-call-speech",
+              "reason": "Industry Taxonomy не содержит leaf-функцию распознавания записи разговора."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "configure-speech-topic",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "ai-automation",
+              "capability": "speech-analytics"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/178-rechevaya-analitika.md"
+            ],
+            "facets": {
+              "ai_assisted": true
+            },
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "configure-speech-topic",
+              "reason": "Industry Taxonomy не содержит leaf-функцию настройки тематик речи."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "generate-call-summary",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "ai-automation",
+              "capability": "conversation-summaries",
+              "feature": "ai-summary",
+              "function": "generate-summary"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/index.md"
+            ],
+            "facets": {
+              "ai_assisted": true
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "view-call-summary",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "ai-automation",
+              "capability": "conversation-summaries",
+              "feature": "ai-summary"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/index.md"
+            ],
+            "facets": {
+              "ai_assisted": true
+            },
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "view-call-summary",
+              "reason": "Industry Taxonomy содержит generate-summary, но не содержит UI-функцию просмотра конспекта."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "evaluate-call-by-checklist",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "quality-management"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/quality-managment/index.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "evaluate-call-by-checklist",
+              "reason": "Industry Taxonomy не содержит leaf-функцию оценки разговора по чек-листу."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "configure-quality-checklist",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "quality-management"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/184-konstruktor-chek-listov.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "configure-quality-checklist",
+              "reason": "Industry Taxonomy не содержит leaf-функцию настройки чек-листа."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "run-voice-robot-dialog",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "ai-automation",
+              "capability": "voice-bot"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/contact-center/ai/voice-robot/"
+            ],
+            "facets": {
+              "ai_assisted": true,
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "outbound"
+              }
+            },
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "run-voice-robot-dialog",
+              "reason": "Industry Taxonomy не содержит leaf-функцию исполнения сценария голосового робота."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "configure-voice-robot-scenario",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "ai-automation",
+              "capability": "voice-bot"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/contact-center/ai/voice-robot/"
+            ],
+            "facets": {
+              "ai_assisted": true
+            },
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "configure-voice-robot-scenario",
+              "reason": "Industry Taxonomy не содержит leaf-функцию настройки сценария голосового робота."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "attribute-call-to-ad-source",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "analytics",
+              "capability": "call-tracking"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "attribute-call-to-ad-source",
+              "reason": "Industry Taxonomy не содержит leaf-функцию атрибуции звонка к рекламе."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "configure-calltracking-number",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "analytics",
+              "capability": "call-tracking"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/calltracking/"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "configure-calltracking-number",
+              "reason": "Industry Taxonomy не содержит leaf-функцию настройки номера коллтрекинга."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "join-call-and-sales-funnel",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "analytics",
+              "capability": "end-to-end-analytics"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/sections/58-poluchenie-statistiki-vyzovov.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "join-call-and-sales-funnel",
+              "reason": "Industry Taxonomy не содержит leaf-функцию связывания звонка с продажами."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "open-end-to-end-analytics-report",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "analytics",
+              "capability": "end-to-end-analytics"
+            },
+            "evidence_refs": [
+              "https://www.mango-office.ru/products/calltracking/"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "open-end-to-end-analytics-report",
+              "reason": "Industry Taxonomy не содержит UI leaf-функцию открытия отчёта сквозной аналитики."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "build-analytics-report",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "analytics",
+              "capability": "multichannel-analytics"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/148-analitika.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "build-analytics-report",
+              "reason": "Industry Taxonomy не содержит leaf-функцию формирования отчёта."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "select-dashboard-widget",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "analytics",
+              "capability": "real-time-reporting",
+              "feature": "dashboard-view",
+              "function": "select-dashboard-widget"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-cc-manual/sections/58-sozdanie-i-nastroyka-vidzheta.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "display-wallboard-widget",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "analytics",
+              "capability": "real-time-reporting",
+              "feature": "dashboard-view",
+              "function": "select-dashboard-widget"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/wallboard/index.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "configure-wallboard-widget",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "analytics",
+              "capability": "real-time-reporting"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/234-wallboard.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "configure-wallboard-widget",
+              "reason": "Industry Taxonomy не содержит leaf-функцию настройки Wallboard-виджета."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "initiate-vpbx-api-call",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "voice-channel",
+              "feature": "outbound-voice-call"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/sections/246-iniciirovanie-ishodyaschego-vyzova.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "outbound"
+              }
+            }
+          },
+          {
+            "alignment_type": "supporting",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "open-api"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/sections/246-iniciirovanie-ishodyaschego-vyzova.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "configure-vpbx-webhook",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "open-api",
+              "feature": "webhook-management",
+              "function": "configure-webhook-endpoint"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "create-contact-center-task-api",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "open-api"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/sections/157-sozdanie-zadachi-na-avtoperezvon.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "create-contact-center-task",
+              "reason": "Industry Taxonomy не содержит leaf-функцию создания задачи КЦ через API."
+            }
+          },
+          {
+            "alignment_type": "secondary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "conversation-orchestration"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/sections/157-sozdanie-zadachi-na-avtoperezvon.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "receive-contact-center-event-webhook",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "open-api",
+              "feature": "webhook-management",
+              "function": "configure-webhook-endpoint"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/sections/215-sobytiya.md"
+            ]
+          },
+          {
+            "alignment_type": "secondary",
+            "industry_ref": {
+              "domain": "contact-center",
+              "capability": "conversation-orchestration"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/sections/215-sobytiya.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "sync-crm-call-card",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "platform-integration"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/integration-bitrix24/index.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "sync-crm-call-card",
+              "reason": "Industry Taxonomy не содержит leaf-функцию синхронизации карточки звонка."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "configure-crm-integration",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "platform-integration"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/integration_amocrm/index.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "configure-crm-integration",
+              "reason": "Industry Taxonomy не содержит leaf-функцию настройки CRM-коннектора."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "send-call-event-webhook",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "open-api",
+              "feature": "webhook-management",
+              "function": "configure-webhook-endpoint"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md"
+            ]
+          },
+          {
+            "alignment_type": "secondary",
+            "industry_ref": {
+              "domain": "voice-ucaas",
+              "capability": "voice-channel",
+              "feature": "inbound-voice-call"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md"
+            ],
+            "facets": {
+              "channel": {
+                "channel_kind": "voice",
+                "synchronicity": "sync",
+                "direction": "inbound"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "configure-webhook-endpoint",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "platform",
+              "capability": "open-api",
+              "feature": "webhook-management",
+              "function": "configure-webhook-endpoint"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/vpbx-api/sections/245-uvedomlenie-o-vyzove.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "assign-user-role",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "security",
+              "capability": "access-control",
+              "feature": "role-management",
+              "function": "assign-role"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/286-nastroyka-prav-dostupa-roli.md"
+            ]
+          }
+        ]
+      },
+      {
+        "source_id": "view-role-permissions",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "security",
+              "capability": "access-control",
+              "feature": "role-management"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/Rolevaya-model-vats/index.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "view-role-permissions",
+              "reason": "Industry Taxonomy содержит assign-role, но не содержит UI-функцию просмотра прав роли."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "authenticate-user-with-sso",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "security",
+              "capability": "access-control"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/lk-vats-sso/index.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "authenticate-user-with-sso",
+              "reason": "Industry Taxonomy не содержит leaf-функцию SSO-аутентификации."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "configure-sso-connection",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "security",
+              "capability": "access-control"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/lk-vats-sso/index.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "configure-sso-connection",
+              "reason": "Industry Taxonomy не содержит leaf-функцию настройки SSO."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "restrict-recording-access",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "security",
+              "capability": "information-security"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "restrict-recording-access",
+              "reason": "Industry Taxonomy не содержит leaf-функцию ограничения доступа к записям."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "audit-recording-download",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "security",
+              "capability": "information-security"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/134-zapis-razgovorov.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "audit-recording-download",
+              "reason": "Industry Taxonomy не содержит UI leaf-функцию проверки доступа к скачиванию записи."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "view-security-audit-log",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "security",
+              "capability": "information-security"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "view-security-audit-log",
+              "reason": "Industry Taxonomy не содержит UI leaf-функцию просмотра журнала безопасности."
+            }
+          }
+        ]
+      },
+      {
+        "source_id": "configure-security-policy",
+        "source_level": "function",
+        "industry_alignment": [
+          {
+            "alignment_type": "primary",
+            "industry_ref": {
+              "domain": "security",
+              "capability": "information-security"
+            },
+            "evidence_refs": [
+              "kb/mango-product-docs/processed/mango-lk-manual/sections/289-bezopasnost-pro.md"
+            ],
+            "mapping_gap": {
+              "missing_level": "function",
+              "proposed_id": "configure-security-policy",
+              "reason": "Industry Taxonomy не содержит leaf-функцию настройки политики безопасности."
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/validate_issue_160_mango_registry.py
+++ b/scripts/validate_issue_160_mango_registry.py
@@ -1,0 +1,570 @@
+#!/usr/bin/env python3
+"""Regression check for issue #160: machine-readable Mango registry.
+
+The registry is stored as YAML files serialized in a JSON-compatible subset so
+the CI check can stay stdlib-only. JSON is valid YAML, while ``json.loads`` gives
+us deterministic validation without adding PyYAML to the lightweight KB job.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+OFFICIAL = "kb/mango/official-products.yaml"
+INTERNAL = "kb/mango/internal-registry.yaml"
+MAPPING = "kb/mango/product-mapping.yaml"
+README = "kb/mango/README.md"
+CHANGELOG = "CHANGELOG.md"
+MAKEFILE = "Makefile"
+KB_WORKFLOW = ".github/workflows/kb.yml"
+VALIDATOR = "scripts/validate_issue_160_mango_registry.py"
+
+SLUG_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
+URL_RE = re.compile(r"^https?://")
+
+CLUSTERS = {
+    "vats-core",
+    "contact-center-core",
+    "digital-channels",
+    "mango-talker",
+    "ai-speech-quality",
+    "analytics-marketing",
+    "platform-integrations",
+    "security-access",
+}
+LEVELS = {"official-product", "product", "service", "module", "function"}
+LIFECYCLE = {"proposed", "active", "deprecated", "removed"}
+FUNCTION_TYPES = {"business", "configuration", "ui-action"}
+INTERACTION_SURFACES = {
+    "admin-ui",
+    "operator-ui",
+    "end-user-ui",
+    "api",
+    "webhook",
+    "background-job",
+    "system-rule",
+    "unknown",
+}
+ALIGNMENT_TYPES = {"primary", "secondary", "supporting"}
+CHANNEL_KIND = {"voice", "text", "video"}
+SYNCHRONICITY = {"sync", "async"}
+DIRECTION = {"inbound", "outbound", "broadcast"}
+
+INDUSTRY: dict[str, dict[str, dict[str, set[str]]]] = {
+    "voice-ucaas": {
+        "cloud-pbx": {},
+        "voice-channel": {
+            "inbound-voice-call": {"receive-inbound-call"},
+            "outbound-voice-call": set(),
+            "callback": {"request-callback"},
+        },
+        "call-routing": {},
+        "ivr-voice-menu": {},
+        "call-recording": {},
+        "number-management": {},
+        "sip-connectivity": {},
+        "unified-communications": {},
+    },
+    "contact-center": {
+        "omnichannel-contact-center": {},
+        "interaction-routing": {
+            "queue-routing": set(),
+            "routing-rules": set(),
+            "channel-based-routing": set(),
+        },
+        "agent-workspace": {},
+        "supervisor-workspace": {},
+        "outbound-calling": {"campaign-management": {"start-campaign"}},
+        "workforce-management": {},
+        "quality-management": {},
+        "conversation-orchestration": {},
+        "journey-orchestration": {},
+    },
+    "digital-channels": {
+        "omnichannel-messaging": {"messenger-integration": {"send-message"}},
+        "website-chat": {},
+        "sms-messaging": {},
+        "team-messaging": {},
+    },
+    "ai-automation": {
+        "speech-analytics": {},
+        "conversation-summaries": {"ai-summary": {"generate-summary"}},
+        "voice-bot": {},
+        "chatbot": {},
+        "process-robot": {},
+        "agent-assist": {},
+    },
+    "analytics": {
+        "conversation-analytics": {},
+        "real-time-reporting": {"dashboard-view": {"select-dashboard-widget"}},
+        "call-tracking": {},
+        "end-to-end-analytics": {},
+        "multichannel-analytics": {},
+        "email-tracking": {},
+        "competitor-analysis": {},
+        "product-analytics": {},
+    },
+    "hardware": {
+        "device-management": {},
+    },
+    "security": {
+        "access-control": {"role-management": {"assign-role"}},
+        "information-security": {},
+    },
+    "platform": {
+        "open-api": {"webhook-management": {"configure-webhook-endpoint"}},
+        "cpaas": {},
+        "platform-integration": {},
+        "communications-apis": {},
+        "service-desk": {},
+        "vendor-support-services": {},
+    },
+}
+
+
+def read_text(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def require_path(path: str) -> list[str]:
+    return [] if (ROOT / path).exists() else [f"{path}: missing"]
+
+
+def require_text(path: str, *needles: str) -> list[str]:
+    errors = require_path(path)
+    if errors:
+        return errors
+    text = read_text(path)
+    return [f"{path}: missing {needle!r}" for needle in needles if needle not in text]
+
+
+def load_json_yaml(path: str) -> tuple[dict[str, Any] | None, list[str]]:
+    errors = require_path(path)
+    if errors:
+        return None, errors
+    try:
+        data = json.loads(read_text(path))
+    except json.JSONDecodeError as exc:
+        return None, [f"{path}: must be JSON-compatible YAML: {exc}"]
+    if not isinstance(data, dict):
+        return None, [f"{path}: root must be object"]
+    return data, []
+
+
+def is_slug(value: Any) -> bool:
+    return isinstance(value, str) and bool(SLUG_RE.fullmatch(value))
+
+
+def check_slug(path: str, field: str, value: Any) -> list[str]:
+    return [] if is_slug(value) else [f"{path}: invalid slug in {field}: {value!r}"]
+
+
+def check_nonempty_list(path: str, field: str, value: Any) -> list[str]:
+    if not isinstance(value, list) or not value:
+        return [f"{path}: {field} must be a non-empty array"]
+    return []
+
+
+def check_string(path: str, field: str, value: Any) -> list[str]:
+    if not isinstance(value, str) or not value.strip():
+        return [f"{path}: {field} must be a non-empty string"]
+    return []
+
+
+def ref_exists(ref: str) -> bool:
+    return bool(URL_RE.match(ref)) or (ROOT / ref).exists()
+
+
+def check_evidence(path: str, entity: dict[str, Any]) -> list[str]:
+    errors = check_nonempty_list(path, "evidence_refs", entity.get("evidence_refs"))
+    for ref in entity.get("evidence_refs", []):
+        if not isinstance(ref, str) or not ref_exists(ref):
+            errors.append(f"{path}: evidence ref does not resolve: {ref!r}")
+    return errors
+
+
+def check_industry_ref(path: str, ref: Any) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(ref, dict):
+        return [f"{path}: industry_ref must be object"]
+    if set(ref) - {"domain", "capability", "feature", "function"}:
+        errors.append(f"{path}: industry_ref has unexpected keys {sorted(set(ref) - {'domain', 'capability', 'feature', 'function'})}")
+    for field in ("domain", "capability", "feature", "function"):
+        if field in ref:
+            errors += check_slug(path, f"industry_ref.{field}", ref[field])
+    domain = ref.get("domain")
+    capability = ref.get("capability")
+    feature = ref.get("feature")
+    function = ref.get("function")
+    if domain not in INDUSTRY:
+        errors.append(f"{path}: unknown industry domain {domain!r}")
+        return errors
+    if feature and not capability:
+        errors.append(f"{path}: industry_ref.feature requires capability")
+    if function and not feature:
+        errors.append(f"{path}: industry_ref.function requires feature")
+    if capability:
+        capabilities = INDUSTRY[domain]
+        if capability not in capabilities:
+            errors.append(f"{path}: unknown capability {domain}/{capability}")
+            return errors
+        if feature:
+            features = capabilities[capability]
+            if feature not in features:
+                errors.append(f"{path}: unknown feature {domain}/{capability}/{feature}")
+                return errors
+            if function and function not in features[feature]:
+                errors.append(f"{path}: unknown function {domain}/{capability}/{feature}/{function}")
+    return errors
+
+
+def check_facets(path: str, alignment: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    facets = alignment.get("facets")
+    if facets is None:
+        return errors
+    if not isinstance(facets, dict):
+        return [f"{path}: facets must be object"]
+    channel = facets.get("channel")
+    if channel:
+        if not isinstance(channel, dict):
+            errors.append(f"{path}: channel facet must be object")
+        else:
+            if channel.get("channel_kind") not in CHANNEL_KIND:
+                errors.append(f"{path}: invalid channel_kind {channel.get('channel_kind')!r}")
+            if channel.get("synchronicity") not in SYNCHRONICITY:
+                errors.append(f"{path}: invalid synchronicity {channel.get('synchronicity')!r}")
+            if channel.get("direction") not in DIRECTION:
+                errors.append(f"{path}: invalid direction {channel.get('direction')!r}")
+    if "ai_assisted" in facets and not isinstance(facets["ai_assisted"], bool):
+        errors.append(f"{path}: ai_assisted must be boolean")
+    return errors
+
+
+def check_mapping_gap(path: str, alignment: dict[str, Any]) -> list[str]:
+    gap = alignment.get("mapping_gap")
+    if gap is None:
+        return []
+    if not isinstance(gap, dict):
+        return [f"{path}: mapping_gap must be object"]
+    errors: list[str] = []
+    if gap.get("missing_level") not in {"domain", "capability", "feature", "function"}:
+        errors.append(f"{path}: invalid mapping_gap.missing_level {gap.get('missing_level')!r}")
+    errors += check_slug(path, "mapping_gap.proposed_id", gap.get("proposed_id"))
+    errors += check_string(path, "mapping_gap.reason", gap.get("reason"))
+    return errors
+
+
+def check_alignments(path: str, maps_to: Any) -> tuple[list[dict[str, Any]], list[str]]:
+    errors: list[str] = []
+    if not isinstance(maps_to, dict):
+        return [], [f"{path}: maps_to must be object"]
+    alignments = maps_to.get("industry_alignment")
+    if not isinstance(alignments, list) or not alignments:
+        return [], [f"{path}: maps_to.industry_alignment must be non-empty array"]
+    primary_count = 0
+    for index, alignment in enumerate(alignments):
+        item_path = f"{path}.maps_to.industry_alignment[{index}]"
+        if not isinstance(alignment, dict):
+            errors.append(f"{item_path}: alignment must be object")
+            continue
+        if alignment.get("alignment_type") not in ALIGNMENT_TYPES:
+            errors.append(f"{item_path}: invalid alignment_type {alignment.get('alignment_type')!r}")
+        if alignment.get("alignment_type") == "primary":
+            primary_count += 1
+        errors += check_industry_ref(item_path, alignment.get("industry_ref"))
+        evidence = alignment.get("evidence_refs", [])
+        if not isinstance(evidence, list) or not evidence:
+            errors.append(f"{item_path}: evidence_refs must be non-empty array")
+        else:
+            for ref in evidence:
+                if not isinstance(ref, str) or not ref_exists(ref):
+                    errors.append(f"{item_path}: evidence ref does not resolve: {ref!r}")
+        errors += check_facets(item_path, alignment)
+        errors += check_mapping_gap(item_path, alignment)
+        ref = alignment.get("industry_ref", {})
+        if (
+            isinstance(ref, dict)
+            and ref.get("domain") == "voice-ucaas"
+            and ref.get("capability") in {"sip-connectivity", "number-management"}
+            and isinstance(alignment.get("facets"), dict)
+            and "channel" in alignment["facets"]
+        ):
+            errors.append(f"{item_path}: pure voice infrastructure must not carry channel facet")
+    if primary_count == 0 and not any(
+        isinstance(a, dict) and a.get("supporting_only_reason") for a in alignments
+    ):
+        errors.append(f"{path}: missing primary alignment and supporting_only_reason")
+    return alignments, errors
+
+
+def check_common(path: str, entity: dict[str, Any], expected_level: str, require_maps: bool = True) -> list[str]:
+    errors: list[str] = []
+    errors += check_slug(path, "id", entity.get("id"))
+    if entity.get("level") != expected_level:
+        errors.append(f"{path}: level must be {expected_level!r}, got {entity.get('level')!r}")
+    if not entity.get("name_ru") and not entity.get("name_en"):
+        errors.append(f"{path}: name_ru or name_en is required")
+    if entity.get("lifecycle_status") not in LIFECYCLE:
+        errors.append(f"{path}: invalid lifecycle_status {entity.get('lifecycle_status')!r}")
+    errors += check_evidence(path, entity)
+    if require_maps:
+        _, map_errors = check_alignments(path, entity.get("maps_to"))
+        errors += map_errors
+    return errors
+
+
+def check_entities(official_data: dict[str, Any], internal_data: dict[str, Any]) -> tuple[dict[str, dict[str, Any]], list[str]]:
+    errors: list[str] = []
+    all_entities: dict[str, dict[str, Any]] = {}
+    official_taxonomy = official_data.get("taxonomy", {})
+    internal_taxonomy = internal_data.get("taxonomy", {})
+
+    if official_taxonomy.get("version") != 1:
+        errors.append(f"{OFFICIAL}: taxonomy.version must be 1")
+    if internal_taxonomy.get("version") != 1:
+        errors.append(f"{INTERNAL}: taxonomy.version must be 1")
+
+    collections = {
+        "official_products": official_taxonomy.get("official_products"),
+        "products": internal_taxonomy.get("products"),
+        "internal_services": internal_taxonomy.get("internal_services"),
+        "modules": internal_taxonomy.get("modules"),
+        "functions": internal_taxonomy.get("functions"),
+    }
+    minimums = {
+        "official_products": 8,
+        "products": 8,
+        "internal_services": 24,
+        "modules": 32,
+        "functions": 64,
+    }
+    for name, value in collections.items():
+        if not isinstance(value, list):
+            errors.append(f"taxonomy.{name}: must be array")
+        elif len(value) < minimums[name]:
+            errors.append(f"taxonomy.{name}: expected at least {minimums[name]} entries, got {len(value)}")
+
+    for collection_name, expected_level in (
+        ("official_products", "official-product"),
+        ("products", "product"),
+        ("internal_services", "service"),
+        ("modules", "module"),
+        ("functions", "function"),
+    ):
+        for index, entity in enumerate(collections.get(collection_name) or []):
+            path = f"taxonomy.{collection_name}[{index}]"
+            if not isinstance(entity, dict):
+                errors.append(f"{path}: entity must be object")
+                continue
+            errors += check_common(path, entity, expected_level)
+            entity_id = entity.get("id")
+            if entity_id in all_entities:
+                errors.append(f"{path}: duplicate entity id {entity_id!r}")
+            elif is_slug(entity_id):
+                all_entities[entity_id] = entity
+
+    official_ids = {e["id"] for e in collections.get("official_products") or [] if isinstance(e, dict) and is_slug(e.get("id"))}
+    product_ids = {e["id"] for e in collections.get("products") or [] if isinstance(e, dict) and is_slug(e.get("id"))}
+    service_ids = {e["id"] for e in collections.get("internal_services") or [] if isinstance(e, dict) and is_slug(e.get("id"))}
+    module_ids = {e["id"] for e in collections.get("modules") or [] if isinstance(e, dict) and is_slug(e.get("id"))}
+    function_ids = {e["id"] for e in collections.get("functions") or [] if isinstance(e, dict) and is_slug(e.get("id"))}
+
+    for index, official in enumerate(collections.get("official_products") or []):
+        path = f"taxonomy.official_products[{index}]"
+        urls = official.get("official_urls") if isinstance(official, dict) else None
+        errors += check_nonempty_list(path, "official_urls", urls)
+        for url in urls or []:
+            if not isinstance(url, str) or not URL_RE.match(url):
+                errors.append(f"{path}: invalid official URL {url!r}")
+        for service in official.get("supported_by_services", []):
+            if service not in service_ids:
+                errors.append(f"{path}: unknown supported_by_services id {service!r}")
+
+    for index, product in enumerate(collections.get("products") or []):
+        path = f"taxonomy.products[{index}]"
+        if not product.get("official_refs") and not product.get("internal_only_reason"):
+            errors.append(f"{path}: official_refs or internal_only_reason is required")
+        for official_ref in product.get("official_refs", []):
+            if official_ref not in official_ids:
+                errors.append(f"{path}: unknown official_ref {official_ref!r}")
+        errors += check_nonempty_list(path, "services", product.get("services"))
+        for service in product.get("services", []):
+            if service not in service_ids:
+                errors.append(f"{path}: unknown service id {service!r}")
+
+    cluster_hits: set[str] = set()
+    for index, service in enumerate(collections.get("internal_services") or []):
+        path = f"taxonomy.internal_services[{index}]"
+        if service.get("cluster") not in CLUSTERS:
+            errors.append(f"{path}: invalid cluster {service.get('cluster')!r}")
+        else:
+            cluster_hits.add(service["cluster"])
+        errors += check_nonempty_list(path, "parent_products", service.get("parent_products"))
+        for product in service.get("parent_products", []):
+            if product not in product_ids:
+                errors.append(f"{path}: unknown parent_product {product!r}")
+        errors += check_nonempty_list(path, "modules", service.get("modules"))
+        for module in service.get("modules", []):
+            if module not in module_ids:
+                errors.append(f"{path}: unknown module id {module!r}")
+
+    missing_clusters = sorted(CLUSTERS - cluster_hits)
+    if missing_clusters:
+        errors.append(f"{INTERNAL}: missing service coverage for clusters {missing_clusters}")
+
+    for index, module in enumerate(collections.get("modules") or []):
+        path = f"taxonomy.modules[{index}]"
+        if module.get("cluster") not in CLUSTERS:
+            errors.append(f"{path}: invalid cluster {module.get('cluster')!r}")
+        errors += check_nonempty_list(path, "parent_services", module.get("parent_services"))
+        for service in module.get("parent_services", []):
+            if service not in service_ids:
+                errors.append(f"{path}: unknown parent_service {service!r}")
+        if not module.get("functions") and not module.get("function_extraction_status"):
+            errors.append(f"{path}: functions or function_extraction_status is required")
+        for function in module.get("functions", []):
+            if function not in function_ids:
+                errors.append(f"{path}: unknown function id {function!r}")
+
+    function_type_hits: set[str] = set()
+    for index, function in enumerate(collections.get("functions") or []):
+        path = f"taxonomy.functions[{index}]"
+        if function.get("parent_module") not in module_ids:
+            errors.append(f"{path}: unknown parent_module {function.get('parent_module')!r}")
+        if function.get("function_type") not in FUNCTION_TYPES:
+            errors.append(f"{path}: invalid function_type {function.get('function_type')!r}")
+        else:
+            function_type_hits.add(function["function_type"])
+        if function.get("interaction_surface") not in INTERACTION_SURFACES:
+            errors.append(f"{path}: invalid interaction_surface {function.get('interaction_surface')!r}")
+
+    missing_types = sorted(FUNCTION_TYPES - function_type_hits)
+    if missing_types:
+        errors.append(f"{INTERNAL}: missing function_type coverage {missing_types}")
+
+    return all_entities, errors
+
+
+def check_mapping_file(mapping_data: dict[str, Any], all_entities: dict[str, dict[str, Any]]) -> list[str]:
+    errors: list[str] = []
+    root = mapping_data.get("taxonomy_mapping")
+    if not isinstance(root, dict):
+        return [f"{MAPPING}: missing taxonomy_mapping object"]
+    for field, expected in (
+        ("version", 1),
+        ("mapping_scope", "mango-to-industry"),
+        ("source_taxonomy", "mango-taxonomy"),
+        ("target_taxonomy", "industry-taxonomy"),
+    ):
+        if root.get(field) != expected:
+            errors.append(f"{MAPPING}: {field} must be {expected!r}")
+    entities = root.get("entities")
+    if not isinstance(entities, list):
+        return errors + [f"{MAPPING}: taxonomy_mapping.entities must be array"]
+
+    mapped: dict[str, dict[str, Any]] = {}
+    for index, item in enumerate(entities):
+        path = f"taxonomy_mapping.entities[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{path}: mapping entity must be object")
+            continue
+        source_id = item.get("source_id")
+        source_level = item.get("source_level")
+        if source_id not in all_entities:
+            errors.append(f"{path}: unknown source_id {source_id!r}")
+            continue
+        if source_id in mapped:
+            errors.append(f"{path}: duplicate source_id {source_id!r}")
+        mapped[source_id] = item
+        expected_level = all_entities[source_id]["level"]
+        if source_level != expected_level:
+            errors.append(f"{path}: source_level {source_level!r} != {expected_level!r}")
+        _, map_errors = check_alignments(path, {"industry_alignment": item.get("industry_alignment")})
+        errors += map_errors
+        if item.get("industry_alignment") != all_entities[source_id].get("maps_to", {}).get("industry_alignment"):
+            errors.append(f"{path}: mapping must match entity maps_to.industry_alignment")
+
+    missing = sorted(set(all_entities) - set(mapped))
+    if missing:
+        errors.append(f"{MAPPING}: missing mapping entries for {missing}")
+    return errors
+
+
+def check_readme_changelog_ci() -> list[str]:
+    errors: list[str] = []
+    errors += require_text(
+        README,
+        "Mango Taxonomy Registry",
+        "Official Layer",
+        "Internal Layer",
+        "Product -> Service -> Module -> Function",
+        "vats-core",
+        "contact-center-core",
+        "digital-channels",
+        "mango-talker",
+        "ai-speech-quality",
+        "analytics-marketing",
+        "platform-integrations",
+        "security-access",
+        "AI-agent",
+        "Industry Taxonomy",
+        "standards/mango-taxonomy-standard.md",
+        "standards/decisions/ADR-012-mango-taxonomy.md",
+        "standards/industry-taxonomy-standard.md",
+    )
+    errors += require_text(
+        CHANGELOG,
+        "Issue #160",
+        OFFICIAL,
+        INTERNAL,
+        MAPPING,
+        README,
+        VALIDATOR,
+    )
+    errors += require_text(MAKEFILE, VALIDATOR)
+    errors += require_text(
+        KB_WORKFLOW,
+        "Validate issue #160 Mango registry",
+        f"python3 {VALIDATOR}",
+    )
+    if (ROOT / "research").exists():
+        errors.append("research/: forbidden by issue #160")
+    return errors
+
+
+def main() -> int:
+    errors: list[str] = []
+    official_data, load_errors = load_json_yaml(OFFICIAL)
+    errors += load_errors
+    internal_data, load_errors = load_json_yaml(INTERNAL)
+    errors += load_errors
+    mapping_data, load_errors = load_json_yaml(MAPPING)
+    errors += load_errors
+
+    all_entities: dict[str, dict[str, Any]] = {}
+    if official_data and internal_data:
+        all_entities, entity_errors = check_entities(official_data, internal_data)
+        errors += entity_errors
+    if mapping_data and all_entities:
+        errors += check_mapping_file(mapping_data, all_entities)
+    errors += check_readme_changelog_ci()
+
+    if errors:
+        print("Issue #160 Mango registry validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("Issue #160 Mango registry validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds `kb/mango/` as the machine-readable Mango Taxonomy Registry with Official Layer, Internal Layer, and Mango-to-Industry mapping files.
- Covers 10 official products, 8 internal products, 32 services, 32 modules, and 64 functions across all 8 Mango Taxonomy clusters.
- Adds `scripts/validate_issue_160_mango_registry.py` and wires it into `make kb-validate` plus the KB workflow alongside the upstream Industry registry validator.
- Updates KB docs and changelog, and keeps the generated crosswalk synchronized with entity-level `maps_to.industry_alignment`.
- Rebased onto current `main` and resolved conflicts with the merged Industry Reference Data/audit changes.

## Reproduction

Before the registry files were added, `python3 scripts/validate_issue_160_mango_registry.py` failed with missing `kb/mango/official-products.yaml`, `kb/mango/internal-registry.yaml`, `kb/mango/product-mapping.yaml`, `kb/mango/README.md`, and CI/changelog wiring.

## Verification

- `python3 scripts/validate_issue_144_kb_structure_readmes.py`
- `python3 scripts/validate_issue_156_industry_taxonomy_registry.py`
- `python3 scripts/validate_issue_160_mango_registry.py`
- Non-LFS KB validator set: issue #111, #115, #117, #121, #129, #137, #144, #146, #148, #152, #154, #156, #160 validators all passed locally.
- `python3 -m py_compile scripts/validate_issue_160_mango_registry.py experiments/issue-160-generate-mango-registry.py`
- `git diff --check upstream/main...HEAD`

`make kb-validate` is blocked in this local environment because `git-lfs` is not installed and `scripts/validate_issue_131_kb_processed_outputs.py` sees LFS pointer files instead of checked-out PDF payloads. The KB workflow uses `actions/checkout` with `lfs: true`, so CI should exercise that validator with real LFS files.

Fixes G-Ivan-A/mango_ba_prompts#160
