### PR TITLE
процесс: стандартизировать Markdown-логи runs

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Validate issue #133 runs restructure
         run: python3 scripts/validate_issue_133_runs_restructure.py
 
+      - name: Validate issue #217 runs log contract
+        run: python3 scripts/validate_issue_217_runs_log_contract.py
+
       - name: Validate issue #125 cascading context loading
         run: python3 scripts/validate_issue_125_cascading_context.py
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-24T07:34:21.294Z for PR creation at branch issue-217-b165f2856540 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/217

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-24T07:34:21.294Z for PR creation at branch issue-217-b165f2856540 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/217

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ ai-generated: true
 
 ## Unreleased
 
+### Fixed — Issue #217 контракт logs для runs
+
+- `runs/CONTRACT.md` получил kebab-case идентификатор `runs-contract`, явный
+  заголовок таблицы `Типы run'ов (run_type)` и MUST-правило: каждый факт
+  прохода создаёт основной Markdown-лог в `logs/`, а `.gitkeep` не считается
+  логом.
+- Все существующие `RUN-0001`..`RUN-0013` получили канонический Markdown-лог по
+  `run_type`, а `metadata.yaml` теперь содержит `logs:` со ссылкой на основной
+  лог; `runs/REGISTRY.md` показывает отдельную колонку `Лог`.
+- Исследование контрактов записано в
+  [`docs/analysis/runs-contract-log-policy-audit.md`](docs/analysis/runs-contract-log-policy-audit.md);
+  добавлен регрессионный валидатор
+  [`scripts/validate_issue_217_runs_log_contract.py`](scripts/validate_issue_217_runs_log_contract.py),
+  подключённый к GitHub Pages workflow.
+
 ### Fixed — Issue #215 контракт BCREQ-FR в 100% YAML
 
 - Контракт

--- a/docs/analysis/runs-contract-log-policy-audit.md
+++ b/docs/analysis/runs-contract-log-policy-audit.md
@@ -1,0 +1,76 @@
+---
+status: draft
+version: 0.1
+updated: 2026-06-24
+ai-generated: true
+type: analysis
+scope: runs
+related_issues:
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/217"
+related_artifacts:
+  - "runs/CONTRACT.md"
+  - "standards/runs-contract-standard.md"
+  - "scripts/validate_issue_217_runs_log_contract.py"
+---
+
+# Аудит контракта runs: Markdown-логи
+
+## Контекст
+
+Issue #217 зафиксировал проблему: в `runs/REGISTRY.md` видны основные
+результаты в `outputs/`, но логи либо не записаны, либо записаны в разных
+форматах. Требование: для каждого факта прохода должен существовать
+Markdown-лог, чтобы можно было анализировать успешные, неуспешные и частично
+успешные действия.
+
+Запрошенный путь `docs/analisis` нормализован в существующий каталог
+`docs/analysis/`.
+
+## Проверенные контракты и артефакты
+
+| Артефакт | Наблюдение до исправления | Решение |
+| --- | --- | --- |
+| `runs/CONTRACT.md` | Требовал каталог `logs/`, но не требовал Markdown-лог. Заголовок типов не связывал таблицу явно с `run_type`. | Добавлены `contract_id: runs-contract`, заголовок `# runs-contract`, таблица `Типы run'ов (run_type)` и обязательное правило Markdown-лога. |
+| `standards/runs-contract-standard.md` | Для `logs/` использовалось SHOULD, а `run_type` отсутствовал в минимальных обязательных полях стандарта. | `run_type` и основной Markdown-лог переведены в MUST. |
+| `runs/REGISTRY.md` | Таблица показывала основной результат, но не показывала лог прохода. | Добавлена колонка `Лог` с каноническим Markdown-логом каждого run. |
+| `runs/2026/*/metadata.yaml` | RUN-0001..RUN-0010 не имели `logs:`; `RUN-0013` ссылался только на технический `.log`. | В metadata добавлены ссылки на канонические Markdown-логи. |
+| `scripts/validate_issue_123_runs_contract.py` и `scripts/validate_issue_133_runs_restructure.py` | Проверяли структуру каталогов и типы run, но не наличие реального Markdown-лога. | Добавлен отдельный валидатор issue #217. |
+
+## Найденные несоответствия
+
+- RUN-0001..RUN-0010 содержали только `logs/.gitkeep`, то есть фактический лог
+  отсутствовал.
+- `RUN-0011` и `RUN-0012` имели `logs/experiment-log.md`, но как
+  `business-task` не имели канонического `logs/business-task-log.md`.
+- `RUN-0013` имел `logs/generation.log`, но не имел Markdown-лог, пригодный для
+  просмотра как основной журнал прохода.
+- Контракт не фиксировал, что `.gitkeep` не является логом.
+
+## Принятое правило
+
+Каждый факт прохода MUST иметь основной Markdown-лог в `logs/`, даже если проход
+завершился ошибкой или частичным успехом. Имя основного лога выбирается по
+`run_type`:
+
+| `run_type` | Основной Markdown-лог |
+| --- | --- |
+| `experiment` | `logs/experiment-log.md` |
+| `generation` | `logs/generation-log.md` |
+| `validation` | `logs/validation-log.md` |
+| `documentation` | `logs/documentation-log.md` |
+| `business-task` | `logs/business-task-log.md` |
+
+Дополнительные технические журналы могут оставаться рядом с основным
+Markdown-логом, но не заменяют его. `metadata.yaml` должен содержать `logs:` со
+ссылкой на основной Markdown-лог.
+
+## Проверка
+
+Регрессионная проверка:
+
+```bash
+python3 scripts/validate_issue_217_runs_log_contract.py
+```
+
+Проверка блокирует отсутствие Markdown-лога, отсутствие ссылки в `metadata.yaml`,
+слабую формулировку контракта и отсутствие логов в `runs/REGISTRY.md`.

--- a/runs/2026/RUN-0001/logs/experiment-log.md
+++ b/runs/2026/RUN-0001/logs/experiment-log.md
@@ -1,0 +1,26 @@
+---
+status: draft
+version: 0.1
+updated: 2026-06-24
+ai-generated: true
+type: run-log
+scope: runs
+run_id: RUN-0001
+run_type: experiment
+---
+
+# RUN-0001 experiment log
+
+## Ход выполнения
+
+- Проход `RUN-0001` выполнен как `experiment` для прототипа статистики ТЗ.
+- Основной результат зафиксирован в
+  [`outputs/tz-stats-prototype-2026-05.md`](../outputs/tz-stats-prototype-2026-05.md).
+- Детальная сессионная трассировка не была записана при первичной миграции; этот
+  Markdown-лог восстановлен по `metadata.yaml` и сохранённому результату для
+  выполнения контракта issue #217.
+
+## Итог
+
+- Статус run'а: `experimental`.
+- Канонический Markdown-лог `experiment` создан в `logs/experiment-log.md`.

--- a/runs/2026/RUN-0001/metadata.yaml
+++ b/runs/2026/RUN-0001/metadata.yaml
@@ -10,6 +10,8 @@ source_paths:
   - runs/2026/RUN-0001/outputs/tz-stats-prototype-2026-05.md
 outputs:
   - outputs/tz-stats-prototype-2026-05.md
+logs:
+  - logs/experiment-log.md
 related_artifacts:
   - prompts/archive/tz-stats-generator-legacy.md
   - prompts/archive/tz-stats-generator-simple-legacy.md

--- a/runs/2026/RUN-0002/logs/generation-log.md
+++ b/runs/2026/RUN-0002/logs/generation-log.md
@@ -1,0 +1,27 @@
+---
+status: draft
+version: 0.1
+updated: 2026-06-24
+ai-generated: true
+type: run-log
+scope: runs
+run_id: RUN-0002
+run_type: generation
+---
+
+# RUN-0002 generation log
+
+## Ход выполнения
+
+- Проход `RUN-0002` выполнен как `generation` для генерации user story из
+  сырого запроса.
+- Основной результат зафиксирован в
+  [`outputs/user-story_gen-from-raw-request_2026-05-26.md`](../outputs/user-story_gen-from-raw-request_2026-05-26.md).
+- Детальная сессионная трассировка не была записана при первичной миграции; этот
+  Markdown-лог восстановлен по `metadata.yaml` и сохранённому результату для
+  выполнения контракта issue #217.
+
+## Итог
+
+- Статус run'а: `partial-success`.
+- Канонический Markdown-лог `generation` создан в `logs/generation-log.md`.

--- a/runs/2026/RUN-0002/metadata.yaml
+++ b/runs/2026/RUN-0002/metadata.yaml
@@ -10,6 +10,8 @@ source_paths:
   - runs/2026/RUN-0002/outputs/user-story_gen-from-raw-request_2026-05-26.md
 outputs:
   - outputs/user-story_gen-from-raw-request_2026-05-26.md
+logs:
+  - logs/generation-log.md
 related_artifacts:
   - prompts/archive/user-story-generator-legacy.md
   - prompts/archive/user-story-generator-simple-legacy.md

--- a/runs/2026/RUN-0003/logs/generation-log.md
+++ b/runs/2026/RUN-0003/logs/generation-log.md
@@ -1,0 +1,26 @@
+---
+status: draft
+version: 0.1
+updated: 2026-06-24
+ai-generated: true
+type: run-log
+scope: runs
+run_id: RUN-0003
+run_type: generation
+---
+
+# RUN-0003 generation log
+
+## Ход выполнения
+
+- Проход `RUN-0003` выполнен как `generation` для stepwise-генерации use case.
+- Основной результат зафиксирован в
+  [`outputs/usecase_gen-stepwise-alignment_2026-05-26.md`](../outputs/usecase_gen-stepwise-alignment_2026-05-26.md).
+- Детальная сессионная трассировка не была записана при первичной миграции; этот
+  Markdown-лог восстановлен по `metadata.yaml` и сохранённому результату для
+  выполнения контракта issue #217.
+
+## Итог
+
+- Статус run'а: `partial-success`.
+- Канонический Markdown-лог `generation` создан в `logs/generation-log.md`.

--- a/runs/2026/RUN-0003/metadata.yaml
+++ b/runs/2026/RUN-0003/metadata.yaml
@@ -10,6 +10,8 @@ source_paths:
   - runs/2026/RUN-0003/outputs/usecase_gen-stepwise-alignment_2026-05-26.md
 outputs:
   - outputs/usecase_gen-stepwise-alignment_2026-05-26.md
+logs:
+  - logs/generation-log.md
 related_artifacts:
   - prompts/archive/usecase-stepwise-generator-legacy.md
   - prompts/archive/usecase-stepwise-generator-simple-legacy.md

--- a/runs/2026/RUN-0004/logs/validation-log.md
+++ b/runs/2026/RUN-0004/logs/validation-log.md
@@ -1,0 +1,26 @@
+---
+status: draft
+version: 0.1
+updated: 2026-06-24
+ai-generated: true
+type: run-log
+scope: runs
+run_id: RUN-0004
+run_type: validation
+---
+
+# RUN-0004 validation log
+
+## Ход выполнения
+
+- Проход `RUN-0004` выполнен как `validation` для аудита набора промптов.
+- Основной результат зафиксирован в
+  [`outputs/prompts-audit-2026-05-26.md`](../outputs/prompts-audit-2026-05-26.md).
+- Детальная сессионная трассировка не была записана при первичной миграции; этот
+  Markdown-лог восстановлен по `metadata.yaml` и сохранённому результату для
+  выполнения контракта issue #217.
+
+## Итог
+
+- Статус run'а: `draft`.
+- Канонический Markdown-лог `validation` создан в `logs/validation-log.md`.

--- a/runs/2026/RUN-0004/metadata.yaml
+++ b/runs/2026/RUN-0004/metadata.yaml
@@ -10,6 +10,8 @@ source_paths:
   - runs/2026/RUN-0004/outputs/prompts-audit-2026-05-26.md
 outputs:
   - outputs/prompts-audit-2026-05-26.md
+logs:
+  - logs/validation-log.md
 related_runs:
   - RUN-0001
   - RUN-0002

--- a/runs/2026/RUN-0005/logs/validation-log.md
+++ b/runs/2026/RUN-0005/logs/validation-log.md
@@ -1,0 +1,26 @@
+---
+status: draft
+version: 0.1
+updated: 2026-06-24
+ai-generated: true
+type: run-log
+scope: runs
+run_id: RUN-0005
+run_type: validation
+---
+
+# RUN-0005 validation log
+
+## Ход выполнения
+
+- Проход `RUN-0005` выполнен как `validation` для self-test промптов.
+- Основной результат зафиксирован в
+  [`outputs/prompts-selftest-2026-05-26.md`](../outputs/prompts-selftest-2026-05-26.md).
+- Детальная сессионная трассировка не была записана при первичной миграции; этот
+  Markdown-лог восстановлен по `metadata.yaml` и сохранённому результату для
+  выполнения контракта issue #217.
+
+## Итог
+
+- Статус run'а: `draft`.
+- Канонический Markdown-лог `validation` создан в `logs/validation-log.md`.

--- a/runs/2026/RUN-0005/metadata.yaml
+++ b/runs/2026/RUN-0005/metadata.yaml
@@ -10,6 +10,8 @@ source_paths:
   - runs/2026/RUN-0005/outputs/prompts-selftest-2026-05-26.md
 outputs:
   - outputs/prompts-selftest-2026-05-26.md
+logs:
+  - logs/validation-log.md
 related_runs:
   - RUN-0001
   - RUN-0002

--- a/runs/2026/RUN-0006/logs/documentation-log.md
+++ b/runs/2026/RUN-0006/logs/documentation-log.md
@@ -1,0 +1,26 @@
+---
+status: draft
+version: 0.1
+updated: 2026-06-24
+ai-generated: true
+type: run-log
+scope: runs
+run_id: RUN-0006
+run_type: documentation
+---
+
+# RUN-0006 documentation log
+
+## Ход выполнения
+
+- Проход `RUN-0006` выполнен как `documentation` для фиксации debug-сессии.
+- Основной результат зафиксирован в
+  [`outputs/session-debug-summarizer-2026-06-13.md`](../outputs/session-debug-summarizer-2026-06-13.md).
+- Детальная сессионная трассировка не была записана при первичной миграции; этот
+  Markdown-лог восстановлен по `metadata.yaml` и сохранённому результату для
+  выполнения контракта issue #217.
+
+## Итог
+
+- Статус run'а: `success`.
+- Канонический Markdown-лог `documentation` создан в `logs/documentation-log.md`.

--- a/runs/2026/RUN-0006/metadata.yaml
+++ b/runs/2026/RUN-0006/metadata.yaml
@@ -10,5 +10,7 @@ source_paths:
   - runs/2026/RUN-0006/outputs/session-debug-summarizer-2026-06-13.md
 outputs:
   - outputs/session-debug-summarizer-2026-06-13.md
+logs:
+  - logs/documentation-log.md
 related_artifacts:
   - prompts/session-debug-documentation-oneshot.md

--- a/runs/2026/RUN-0007/logs/generation-log.md
+++ b/runs/2026/RUN-0007/logs/generation-log.md
@@ -1,0 +1,26 @@
+---
+status: draft
+version: 0.1
+updated: 2026-06-24
+ai-generated: true
+type: run-log
+scope: runs
+run_id: RUN-0007
+run_type: generation
+---
+
+# RUN-0007 generation log
+
+## Ход выполнения
+
+- Проход `RUN-0007` выполнен как `generation` для FR generation live-сценария.
+- Основной результат зафиксирован в
+  [`outputs/fr-generation-1027-live_2026-06-16.md`](../outputs/fr-generation-1027-live_2026-06-16.md).
+- Детальная сессионная трассировка не была записана при первичной миграции; этот
+  Markdown-лог восстановлен по `metadata.yaml` и сохранённому результату для
+  выполнения контракта issue #217.
+
+## Итог
+
+- Статус run'а: `works-with-edits`.
+- Канонический Markdown-лог `generation` создан в `logs/generation-log.md`.

--- a/runs/2026/RUN-0007/metadata.yaml
+++ b/runs/2026/RUN-0007/metadata.yaml
@@ -10,6 +10,8 @@ source_paths:
   - runs/2026/RUN-0007/outputs/fr-generation-1027-live_2026-06-16.md
 outputs:
   - outputs/fr-generation-1027-live_2026-06-16.md
+logs:
+  - logs/generation-log.md
 related_artifacts:
   - docs/analysis/experiment-1027-analysis.md
   - prompts/fr-documentation-stepwise.md

--- a/runs/2026/RUN-0008/logs/validation-log.md
+++ b/runs/2026/RUN-0008/logs/validation-log.md
@@ -1,0 +1,27 @@
+---
+status: draft
+version: 0.1
+updated: 2026-06-24
+ai-generated: true
+type: run-log
+scope: runs
+run_id: RUN-0008
+run_type: validation
+---
+
+# RUN-0008 validation log
+
+## Ход выполнения
+
+- Проход `RUN-0008` выполнен как `validation` для проверки цитирования базы
+  знаний.
+- Основной результат зафиксирован в
+  [`outputs/kb-citation-check-2026-06-16.md`](../outputs/kb-citation-check-2026-06-16.md).
+- Детальная сессионная трассировка не была записана при первичной миграции; этот
+  Markdown-лог восстановлен по `metadata.yaml` и сохранённому результату для
+  выполнения контракта issue #217.
+
+## Итог
+
+- Статус run'а: `draft`.
+- Канонический Markdown-лог `validation` создан в `logs/validation-log.md`.

--- a/runs/2026/RUN-0008/metadata.yaml
+++ b/runs/2026/RUN-0008/metadata.yaml
@@ -10,6 +10,8 @@ source_paths:
   - runs/2026/RUN-0008/outputs/kb-citation-check-2026-06-16.md
 outputs:
   - outputs/kb-citation-check-2026-06-16.md
+logs:
+  - logs/validation-log.md
 related_artifacts:
   - standards/kb-standard.md
   - docs/adr/007-kb-standard.md

--- a/runs/2026/RUN-0009/logs/experiment-log.md
+++ b/runs/2026/RUN-0009/logs/experiment-log.md
@@ -1,0 +1,27 @@
+---
+status: draft
+version: 0.1
+updated: 2026-06-24
+ai-generated: true
+type: run-log
+scope: runs
+run_id: RUN-0009
+run_type: experiment
+---
+
+# RUN-0009 experiment log
+
+## Ход выполнения
+
+- Проход `RUN-0009` выполнен как `experiment` для A/B проверки применения
+  отраслевых стандартов.
+- Основной результат зафиксирован в
+  [`outputs/standards-applied-ab-2026-06-16.md`](../outputs/standards-applied-ab-2026-06-16.md).
+- Детальная сессионная трассировка не была записана при первичной миграции; этот
+  Markdown-лог восстановлен по `metadata.yaml` и сохранённому результату для
+  выполнения контракта issue #217.
+
+## Итог
+
+- Статус run'а: `draft`.
+- Канонический Markdown-лог `experiment` создан в `logs/experiment-log.md`.

--- a/runs/2026/RUN-0009/metadata.yaml
+++ b/runs/2026/RUN-0009/metadata.yaml
@@ -10,6 +10,8 @@ source_paths:
   - runs/2026/RUN-0009/outputs/standards-applied-ab-2026-06-16.md
 outputs:
   - outputs/standards-applied-ab-2026-06-16.md
+logs:
+  - logs/experiment-log.md
 related_artifacts:
   - standards/industry-standards-standard.md
   - docs/adr/008-industry-standards-standard.md

--- a/runs/2026/RUN-0010/logs/business-task-log.md
+++ b/runs/2026/RUN-0010/logs/business-task-log.md
@@ -1,0 +1,28 @@
+---
+status: draft
+version: 0.1
+updated: 2026-06-24
+ai-generated: true
+type: run-log
+scope: runs
+run_id: RUN-0010
+run_type: business-task
+---
+
+# RUN-0010 business-task log
+
+## Ход выполнения
+
+- Проход `RUN-0010` выполнен как `business-task` для BCREQ-1025 email routing.
+- Основные результаты зафиксированы в
+  [`outputs/2026-06-17-bcreq-1025-email-routing.md`](../outputs/2026-06-17-bcreq-1025-email-routing.md)
+  и
+  [`outputs/analysis-bcreq-1025-2026-06-17.md`](../outputs/analysis-bcreq-1025-2026-06-17.md).
+- Детальная сессионная трассировка не была записана при первичной миграции; этот
+  Markdown-лог восстановлен по `metadata.yaml` и сохранённым результатам для
+  выполнения контракта issue #217.
+
+## Итог
+
+- Статус run'а: `works-with-edits`.
+- Канонический Markdown-лог `business-task` создан в `logs/business-task-log.md`.

--- a/runs/2026/RUN-0010/metadata.yaml
+++ b/runs/2026/RUN-0010/metadata.yaml
@@ -12,6 +12,8 @@ source_paths:
 outputs:
   - outputs/2026-06-17-bcreq-1025-email-routing.md
   - outputs/analysis-bcreq-1025-2026-06-17.md
+logs:
+  - logs/business-task-log.md
 related_issues:
   - https://github.com/G-Ivan-A/mango_ba_prompts/issues/107
 related_artifacts:

--- a/runs/2026/RUN-0011/logs/business-task-log.md
+++ b/runs/2026/RUN-0011/logs/business-task-log.md
@@ -1,0 +1,26 @@
+---
+status: draft
+version: 0.1
+updated: 2026-06-24
+ai-generated: true
+type: run-log
+scope: runs
+run_id: RUN-0011
+run_type: business-task
+---
+
+# RUN-0011 business-task log
+
+## Ход выполнения
+
+- Проход `RUN-0011` выполнен как `business-task` для задачи
+  multichannel-agent-workload.
+- Основной результат описан в [`outputs/README.md`](../outputs/README.md).
+- Подробный исторический журнал эксперимента сохранён в
+  [`experiment-log.md`](experiment-log.md); этот файл добавляет канонический
+  Markdown-лог по `run_type` для выполнения контракта issue #217.
+
+## Итог
+
+- Статус run'а: `works-with-edits`.
+- Канонический Markdown-лог `business-task` создан в `logs/business-task-log.md`.

--- a/runs/2026/RUN-0011/metadata.yaml
+++ b/runs/2026/RUN-0011/metadata.yaml
@@ -22,6 +22,7 @@ outputs:
   - outputs/steps/step-4-story.md
   - outputs/steps/step-5-options.md
 logs:
+  - logs/business-task-log.md
   - logs/experiment-log.md
 related_issues:
   - https://github.com/G-Ivan-A/mango_ba_prompts/issues/109

--- a/runs/2026/RUN-0012/logs/business-task-log.md
+++ b/runs/2026/RUN-0012/logs/business-task-log.md
@@ -1,0 +1,29 @@
+---
+status: draft
+version: 0.1
+updated: 2026-06-24
+ai-generated: true
+type: run-log
+scope: runs
+run_id: RUN-0012
+run_type: business-task
+---
+
+# RUN-0012 business-task log
+
+## Ход выполнения
+
+- Проход `RUN-0012` выполнен как `business-task` для BCREQ-180 MT group video
+  call.
+- Основные результаты зафиксированы в
+  [`outputs/2026-06-22-bcreq-180-mt-group-video-call-ft.md`](../outputs/2026-06-22-bcreq-180-mt-group-video-call-ft.md)
+  и
+  [`outputs/summary-bcreq-180-2026-06-22.md`](../outputs/summary-bcreq-180-2026-06-22.md).
+- Подробный исторический журнал эксперимента сохранён в
+  [`experiment-log.md`](experiment-log.md); этот файл добавляет канонический
+  Markdown-лог по `run_type` для выполнения контракта issue #217.
+
+## Итог
+
+- Статус run'а: `draft`.
+- Канонический Markdown-лог `business-task` создан в `logs/business-task-log.md`.

--- a/runs/2026/RUN-0012/metadata.yaml
+++ b/runs/2026/RUN-0012/metadata.yaml
@@ -17,6 +17,7 @@ outputs:
   - outputs/2026-06-22-bcreq-180-mt-group-video-call-ft.md
   - outputs/summary-bcreq-180-2026-06-22.md
 logs:
+  - logs/business-task-log.md
   - logs/experiment-log.md
 related_issues:
   - https://github.com/G-Ivan-A/mango_ba_prompts/issues/180

--- a/runs/2026/RUN-0013/logs/business-task-log.md
+++ b/runs/2026/RUN-0013/logs/business-task-log.md
@@ -1,0 +1,26 @@
+---
+status: draft
+version: 0.1
+updated: 2026-06-24
+ai-generated: true
+type: run-log
+scope: runs
+run_id: RUN-0013
+run_type: business-task
+---
+
+# RUN-0013 business-task log
+
+## Ход выполнения
+
+- Проход `RUN-0013` выполнен как `business-task` для BCREQ-1027.
+- Основной результат зафиксирован в
+  [`outputs/section-4-3-api.md`](../outputs/section-4-3-api.md).
+- Технический журнал генерации сохранён в [`generation.log`](generation.log);
+  этот файл добавляет обязательный Markdown-лог по `run_type` для выполнения
+  контракта issue #217.
+
+## Итог
+
+- Статус run'а: `draft`.
+- Канонический Markdown-лог `business-task` создан в `logs/business-task-log.md`.

--- a/runs/2026/RUN-0013/metadata.yaml
+++ b/runs/2026/RUN-0013/metadata.yaml
@@ -24,6 +24,7 @@ inputs:
 outputs:
   - "outputs/section-4-3-api.md"
 logs:
+  - logs/business-task-log.md
   - logs/generation.log
 feedback:
   - feedback/corrections.md

--- a/runs/CONTRACT.md
+++ b/runs/CONTRACT.md
@@ -1,18 +1,22 @@
 ---
 status: draft
-version: 0.2
-updated: 2026-06-20
+version: 0.3
+updated: 2026-06-24
 ai-generated: true
 type: contract
 scope: runs
+contract_id: runs-contract
 related_issues:
   - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/123"
   - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/133"
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/217"
 related_artifacts:
   - "standards/runs-contract-standard.md"
 ---
 
-# Контракт записи runs/
+# runs-contract
+
+Контракт записи `runs/`.
 
 Каждая запись живёт по схеме `runs/YYYY/RUN-XXXX/`.
 
@@ -25,6 +29,7 @@ runs/
         ├── outputs/
         ├── feedback/
         └── logs/
+            └── <run-type>-log.md
 ```
 
 ## metadata.yaml
@@ -45,15 +50,32 @@ runs/
 Дополнительные поля разрешены: `source_paths`, `inputs`, `outputs`, `logs`,
 `related_issues`, `related_artifacts`, `related_runs`.
 
-## Типы run'ов
+## Типы run'ов (`run_type`)
 
-| Тип | Назначение | Примеры |
-| --- | --- | --- |
-| `experiment` | Проверка гипотез, A/B тесты. | `RUN-0001`, `RUN-0009` |
-| `generation` | Создание артефактов: ТЗ, US, UC, FR. | `RUN-0002`, `RUN-0003`, `RUN-0007` |
-| `validation` | Аудит и проверка качества. | `RUN-0004`, `RUN-0005`, `RUN-0008` |
-| `documentation` | Фиксация сессий и отладка. | `RUN-0006` |
-| `business-task` | Решение конкретных BCREQ-задач. | `RUN-0010`, `RUN-0011` |
+| `run_type` | Назначение | Канонический Markdown-лог | Примеры |
+| --- | --- | --- | --- |
+| `experiment` | Проверка гипотез, A/B тесты. | `logs/experiment-log.md` | `RUN-0001`, `RUN-0009` |
+| `generation` | Создание артефактов: ТЗ, US, UC, FR. | `logs/generation-log.md` | `RUN-0002`, `RUN-0003`, `RUN-0007` |
+| `validation` | Аудит и проверка качества. | `logs/validation-log.md` | `RUN-0004`, `RUN-0005`, `RUN-0008` |
+| `documentation` | Фиксация сессий и отладка. | `logs/documentation-log.md` | `RUN-0006` |
+| `business-task` | Решение конкретных BCREQ-задач. | `logs/business-task-log.md` | `RUN-0010`, `RUN-0011`, `RUN-0012`, `RUN-0013` |
+
+## Обязательное логирование
+
+Markdown-лог обязателен для каждого факта прохода: успешного, неуспешного или частично успешного.
+Лог создаётся в `logs/` сразу при фиксации run'а, даже если основной результат
+не был получен.
+
+Правила:
+
+- имя основного лога выбирается по таблице `run_type`;
+- основной лог MUST быть Markdown-файлом `.md`;
+- `metadata.yaml` MUST содержать `logs:` со ссылкой на основной Markdown-лог;
+- лог MUST фиксировать ход выполнения, ключевые действия, блокеры и итоговый
+  статус;
+- `.gitkeep` не считается логом и не заменяет Markdown-лог;
+- дополнительные технические журналы (`.log`, `.json`, трассировки) разрешены,
+  но не заменяют основной Markdown-лог.
 
 ## Назначение подкаталогов
 
@@ -62,7 +84,7 @@ runs/
 | `inputs/` | Сырой вход, выдержки БЗ, исходные данные, которые можно хранить в репозитории. |
 | `outputs/` | Итоговые и промежуточные артефакты выполнения процесса. |
 | `feedback/` | Комментарии ревью, обратная связь, решения по результату. |
-| `logs/` | Логи эксперимента, метрики, трассировка выполнения, технические журналы. |
+| `logs/` | Обязательный Markdown-лог прохода, метрики, трассировка выполнения, технические журналы. |
 
 Если подкаталог пока пустой, он сохраняется через `.gitkeep`, чтобы структура
 каждого run была одинаковой.
@@ -72,4 +94,5 @@ runs/
 ```bash
 python3 scripts/validate_issue_123_runs_contract.py
 python3 scripts/validate_issue_133_runs_restructure.py
+python3 scripts/validate_issue_217_runs_log_contract.py
 ```

--- a/runs/README.md
+++ b/runs/README.md
@@ -28,9 +28,11 @@ related_artifacts:
 - Найти существующий run: откройте [`REGISTRY.md`](REGISTRY.md) или статистику
   по типам, датам и процессам.
 - Создать новый run: заведите каталог `runs/YYYY/RUN-XXXX/` с
-  `metadata.yaml`, `inputs/`, `outputs/`, `feedback/` и `logs/`.
+  `metadata.yaml`, `inputs/`, `outputs/`, `feedback/` и `logs/`; в `logs/`
+  сразу создайте основной Markdown-лог по `run_type`.
 - Минимальные поля `metadata.yaml`: `run_id`, `process`, `run_type`,
   `version`, `date`, `author`, `model`, `status`.
+- В `metadata.yaml` поле `logs:` должно ссылаться на основной Markdown-лог.
 - Проверить контракт: сверяйтесь с [`CONTRACT.md`](CONTRACT.md) и запускайте
   локальную валидацию.
 
@@ -42,6 +44,7 @@ sed -n '1,80p' runs/REGISTRY.md
 sed -n '1,120p' runs/stats/by-type.md
 python3 scripts/validate_issue_123_runs_contract.py
 python3 scripts/validate_issue_133_runs_restructure.py
+python3 scripts/validate_issue_217_runs_log_contract.py
 ```
 
 ## Навигация

--- a/runs/REGISTRY.md
+++ b/runs/REGISTRY.md
@@ -12,18 +12,18 @@ related_issues:
 
 # Реестр runs/
 
-| Run | Дата | Тип | Процесс | Основной результат |
-| --- | --- | --- | --- | --- |
-| [`RUN-0001`](2026/RUN-0001/metadata.yaml) | 2026-05-26 | 🧪 `experiment` | prompt-experiment | [`tz-stats-prototype-2026-05.md`](2026/RUN-0001/outputs/tz-stats-prototype-2026-05.md) |
-| [`RUN-0002`](2026/RUN-0002/metadata.yaml) | 2026-05-26 | 🏭 `generation` | user-story-generation | [`user-story_gen-from-raw-request_2026-05-26.md`](2026/RUN-0002/outputs/user-story_gen-from-raw-request_2026-05-26.md) |
-| [`RUN-0003`](2026/RUN-0003/metadata.yaml) | 2026-05-26 | 🏭 `generation` | usecase-generation | [`usecase_gen-stepwise-alignment_2026-05-26.md`](2026/RUN-0003/outputs/usecase_gen-stepwise-alignment_2026-05-26.md) |
-| [`RUN-0004`](2026/RUN-0004/metadata.yaml) | 2026-05-26 | 🔍 `validation` | prompt-audit | [`prompts-audit-2026-05-26.md`](2026/RUN-0004/outputs/prompts-audit-2026-05-26.md) |
-| [`RUN-0005`](2026/RUN-0005/metadata.yaml) | 2026-05-26 | 🔍 `validation` | prompt-selftest | [`prompts-selftest-2026-05-26.md`](2026/RUN-0005/outputs/prompts-selftest-2026-05-26.md) |
-| [`RUN-0006`](2026/RUN-0006/metadata.yaml) | 2026-06-13 | 📝 `documentation` | session-debug-documentation | [`session-debug-summarizer-2026-06-13.md`](2026/RUN-0006/outputs/session-debug-summarizer-2026-06-13.md) |
-| [`RUN-0007`](2026/RUN-0007/metadata.yaml) | 2026-06-16 | 🏭 `generation` | fr-generation | [`fr-generation-1027-live_2026-06-16.md`](2026/RUN-0007/outputs/fr-generation-1027-live_2026-06-16.md) |
-| [`RUN-0008`](2026/RUN-0008/metadata.yaml) | 2026-06-16 | 🔍 `validation` | kb-citation-check | [`kb-citation-check-2026-06-16.md`](2026/RUN-0008/outputs/kb-citation-check-2026-06-16.md) |
-| [`RUN-0009`](2026/RUN-0009/metadata.yaml) | 2026-06-16 | 🧪 `experiment` | industry-standards-ab-check | [`standards-applied-ab-2026-06-16.md`](2026/RUN-0009/outputs/standards-applied-ab-2026-06-16.md) |
-| [`RUN-0010`](2026/RUN-0010/metadata.yaml) | 2026-06-17 | 💼 `business-task` | bcreq-1025-email-routing | [`2026-06-17-bcreq-1025-email-routing.md`](2026/RUN-0010/outputs/2026-06-17-bcreq-1025-email-routing.md), [`analysis-bcreq-1025-2026-06-17.md`](2026/RUN-0010/outputs/analysis-bcreq-1025-2026-06-17.md) |
-| [`RUN-0011`](2026/RUN-0011/metadata.yaml) | 2026-06-18 | 💼 `business-task` | multichannel-agent-workload | [`outputs/README.md`](2026/RUN-0011/outputs/README.md), [`logs/experiment-log.md`](2026/RUN-0011/logs/experiment-log.md) |
-| [`RUN-0012`](2026/RUN-0012/metadata.yaml) | 2026-06-22 | 💼 `business-task` | bcreq-180-mt-group-video-call | [`2026-06-22-bcreq-180-mt-group-video-call-ft.md`](2026/RUN-0012/outputs/2026-06-22-bcreq-180-mt-group-video-call-ft.md), [`summary-bcreq-180-2026-06-22.md`](2026/RUN-0012/outputs/summary-bcreq-180-2026-06-22.md) |
-| [`RUN-0013`](2026/RUN-0013/metadata.yaml) | 2026-06-24 | 💼 `business-task` | bcreq-1027 | [`section-4-3-api.md`](2026/RUN-0013/outputs/section-4-3-api.md) |
+| Run | Дата | Тип | Процесс | Основной результат | Лог |
+| --- | --- | --- | --- | --- | --- |
+| [`RUN-0001`](2026/RUN-0001/metadata.yaml) | 2026-05-26 | 🧪 `experiment` | prompt-experiment | [`tz-stats-prototype-2026-05.md`](2026/RUN-0001/outputs/tz-stats-prototype-2026-05.md) | [`logs/experiment-log.md`](2026/RUN-0001/logs/experiment-log.md) |
+| [`RUN-0002`](2026/RUN-0002/metadata.yaml) | 2026-05-26 | 🏭 `generation` | user-story-generation | [`user-story_gen-from-raw-request_2026-05-26.md`](2026/RUN-0002/outputs/user-story_gen-from-raw-request_2026-05-26.md) | [`logs/generation-log.md`](2026/RUN-0002/logs/generation-log.md) |
+| [`RUN-0003`](2026/RUN-0003/metadata.yaml) | 2026-05-26 | 🏭 `generation` | usecase-generation | [`usecase_gen-stepwise-alignment_2026-05-26.md`](2026/RUN-0003/outputs/usecase_gen-stepwise-alignment_2026-05-26.md) | [`logs/generation-log.md`](2026/RUN-0003/logs/generation-log.md) |
+| [`RUN-0004`](2026/RUN-0004/metadata.yaml) | 2026-05-26 | 🔍 `validation` | prompt-audit | [`prompts-audit-2026-05-26.md`](2026/RUN-0004/outputs/prompts-audit-2026-05-26.md) | [`logs/validation-log.md`](2026/RUN-0004/logs/validation-log.md) |
+| [`RUN-0005`](2026/RUN-0005/metadata.yaml) | 2026-05-26 | 🔍 `validation` | prompt-selftest | [`prompts-selftest-2026-05-26.md`](2026/RUN-0005/outputs/prompts-selftest-2026-05-26.md) | [`logs/validation-log.md`](2026/RUN-0005/logs/validation-log.md) |
+| [`RUN-0006`](2026/RUN-0006/metadata.yaml) | 2026-06-13 | 📝 `documentation` | session-debug-documentation | [`session-debug-summarizer-2026-06-13.md`](2026/RUN-0006/outputs/session-debug-summarizer-2026-06-13.md) | [`logs/documentation-log.md`](2026/RUN-0006/logs/documentation-log.md) |
+| [`RUN-0007`](2026/RUN-0007/metadata.yaml) | 2026-06-16 | 🏭 `generation` | fr-generation | [`fr-generation-1027-live_2026-06-16.md`](2026/RUN-0007/outputs/fr-generation-1027-live_2026-06-16.md) | [`logs/generation-log.md`](2026/RUN-0007/logs/generation-log.md) |
+| [`RUN-0008`](2026/RUN-0008/metadata.yaml) | 2026-06-16 | 🔍 `validation` | kb-citation-check | [`kb-citation-check-2026-06-16.md`](2026/RUN-0008/outputs/kb-citation-check-2026-06-16.md) | [`logs/validation-log.md`](2026/RUN-0008/logs/validation-log.md) |
+| [`RUN-0009`](2026/RUN-0009/metadata.yaml) | 2026-06-16 | 🧪 `experiment` | industry-standards-ab-check | [`standards-applied-ab-2026-06-16.md`](2026/RUN-0009/outputs/standards-applied-ab-2026-06-16.md) | [`logs/experiment-log.md`](2026/RUN-0009/logs/experiment-log.md) |
+| [`RUN-0010`](2026/RUN-0010/metadata.yaml) | 2026-06-17 | 💼 `business-task` | bcreq-1025-email-routing | [`2026-06-17-bcreq-1025-email-routing.md`](2026/RUN-0010/outputs/2026-06-17-bcreq-1025-email-routing.md), [`analysis-bcreq-1025-2026-06-17.md`](2026/RUN-0010/outputs/analysis-bcreq-1025-2026-06-17.md) | [`logs/business-task-log.md`](2026/RUN-0010/logs/business-task-log.md) |
+| [`RUN-0011`](2026/RUN-0011/metadata.yaml) | 2026-06-18 | 💼 `business-task` | multichannel-agent-workload | [`outputs/README.md`](2026/RUN-0011/outputs/README.md), [`logs/experiment-log.md`](2026/RUN-0011/logs/experiment-log.md) | [`logs/business-task-log.md`](2026/RUN-0011/logs/business-task-log.md) |
+| [`RUN-0012`](2026/RUN-0012/metadata.yaml) | 2026-06-22 | 💼 `business-task` | bcreq-180-mt-group-video-call | [`2026-06-22-bcreq-180-mt-group-video-call-ft.md`](2026/RUN-0012/outputs/2026-06-22-bcreq-180-mt-group-video-call-ft.md), [`summary-bcreq-180-2026-06-22.md`](2026/RUN-0012/outputs/summary-bcreq-180-2026-06-22.md) | [`logs/business-task-log.md`](2026/RUN-0012/logs/business-task-log.md) |
+| [`RUN-0013`](2026/RUN-0013/metadata.yaml) | 2026-06-24 | 💼 `business-task` | bcreq-1027 | [`section-4-3-api.md`](2026/RUN-0013/outputs/section-4-3-api.md) | [`logs/business-task-log.md`](2026/RUN-0013/logs/business-task-log.md) |

--- a/scripts/validate_issue_133_runs_restructure.py
+++ b/scripts/validate_issue_133_runs_restructure.py
@@ -94,7 +94,7 @@ def check_docs() -> list[str]:
         "stats/by-type.md",
     )
     errors += require_text("runs/CONTRACT.md", "run_type", "runs/YYYY/RUN-XXXX/", "metadata.yaml")
-    errors += require_text("runs/REGISTRY.md", "| Run | Дата | Тип | Процесс | Основной результат |")
+    errors += require_text("runs/REGISTRY.md", "| Run | Дата | Тип | Процесс | Основной результат | Лог |")
     for run_id, run_type in RUN_TYPES.items():
         errors += require_text("runs/REGISTRY.md", run_id, run_type)
     for run_type, label in TYPE_LABELS.items():

--- a/scripts/validate_issue_217_runs_log_contract.py
+++ b/scripts/validate_issue_217_runs_log_contract.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Regression check for issue #217: mandatory Markdown logs for every run."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+CONTRACT = "runs/CONTRACT.md"
+STANDARD = "standards/runs-contract-standard.md"
+REGISTRY = "runs/REGISTRY.md"
+ANALYSIS = "docs/analysis/runs-contract-log-policy-audit.md"
+CHANGELOG = "CHANGELOG.md"
+WORKFLOW = ".github/workflows/github-pages.yml"
+VALIDATOR = "scripts/validate_issue_217_runs_log_contract.py"
+
+RUN_ID_PATTERN = re.compile(r"^RUN-\d{4}$")
+CANONICAL_LOG_BY_RUN_TYPE = {
+    "experiment": "logs/experiment-log.md",
+    "generation": "logs/generation-log.md",
+    "validation": "logs/validation-log.md",
+    "documentation": "logs/documentation-log.md",
+    "business-task": "logs/business-task-log.md",
+}
+
+
+def read_text(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def require_path(path: str) -> list[str]:
+    return [] if (ROOT / path).exists() else [f"{path}: missing"]
+
+
+def require_text(path: str, *needles: str) -> list[str]:
+    errors = require_path(path)
+    if errors:
+        return errors
+    text = read_text(path)
+    return [f"{path}: missing {needle!r}" for needle in needles if needle not in text]
+
+
+def parse_simple_yaml(path: Path) -> dict[str, object]:
+    data: dict[str, object] = {}
+    current_list: str | None = None
+
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+
+        list_item = re.match(r"^\s+-\s+(.+?)\s*$", raw_line)
+        if list_item and current_list:
+            data.setdefault(current_list, [])
+            assert isinstance(data[current_list], list)
+            data[current_list].append(list_item.group(1).strip().strip('"'))
+            continue
+
+        match = re.match(r"^([A-Za-z0-9_-]+):\s*(.*?)\s*$", raw_line)
+        if not match:
+            continue
+
+        key = match.group(1)
+        value = match.group(2).strip()
+        if value:
+            data[key] = value.strip('"')
+            current_list = None
+        else:
+            data[key] = []
+            current_list = key
+
+    return data
+
+
+def iter_run_dirs() -> list[Path]:
+    runs_root = ROOT / "runs"
+    return sorted(
+        path
+        for year_dir in runs_root.iterdir()
+        if year_dir.is_dir() and re.fullmatch(r"\d{4}", year_dir.name)
+        for path in year_dir.iterdir()
+        if path.is_dir() and RUN_ID_PATTERN.match(path.name)
+    )
+
+
+def check_run_logs() -> list[str]:
+    errors: list[str] = []
+
+    for run_dir in iter_run_dirs():
+        relative_run_dir = run_dir.relative_to(ROOT)
+        metadata_path = run_dir / "metadata.yaml"
+        if not metadata_path.exists():
+            errors.append(f"{relative_run_dir}/metadata.yaml: missing")
+            continue
+
+        metadata = parse_simple_yaml(metadata_path)
+        run_id = str(metadata.get("run_id", ""))
+        run_type = str(metadata.get("run_type", ""))
+        if run_id != run_dir.name:
+            errors.append(f"{metadata_path.relative_to(ROOT)}: run_id must match directory name")
+        canonical_log = CANONICAL_LOG_BY_RUN_TYPE.get(run_type)
+        if not canonical_log:
+            errors.append(f"{metadata_path.relative_to(ROOT)}: unsupported run_type {run_type!r}")
+            continue
+
+        log_path = run_dir / canonical_log
+        if not log_path.exists():
+            errors.append(f"{log_path.relative_to(ROOT)}: missing required Markdown log")
+        elif log_path.suffix != ".md":
+            errors.append(f"{log_path.relative_to(ROOT)}: required log must be Markdown")
+        elif not log_path.read_text(encoding="utf-8").strip():
+            errors.append(f"{log_path.relative_to(ROOT)}: required log must not be empty")
+        else:
+            log_text = log_path.read_text(encoding="utf-8")
+            for needle in (run_id, run_type, "Ход выполнения", "Итог"):
+                if needle not in log_text:
+                    errors.append(f"{log_path.relative_to(ROOT)}: missing {needle!r}")
+
+        metadata_logs = metadata.get("logs")
+        if not isinstance(metadata_logs, list):
+            errors.append(f"{metadata_path.relative_to(ROOT)}: missing logs list")
+        elif canonical_log not in metadata_logs:
+            errors.append(
+                f"{metadata_path.relative_to(ROOT)}: logs must include {canonical_log!r}"
+            )
+
+        if (run_dir / "logs" / ".gitkeep").exists() and not any(
+            path.suffix == ".md" for path in (run_dir / "logs").glob("*.md")
+        ):
+            errors.append(f"{relative_run_dir}/logs/.gitkeep: .gitkeep is not a run log")
+
+    return errors
+
+
+def check_docs() -> list[str]:
+    errors: list[str] = []
+    errors += require_text(
+        CONTRACT,
+        "contract_id: runs-contract",
+        "# runs-contract",
+        "## Типы run'ов (`run_type`)",
+        "| `run_type` | Назначение | Канонический Markdown-лог | Примеры |",
+        "Markdown-лог обязателен для каждого факта прохода",
+        "успешного, неуспешного или частично успешного",
+        "`.gitkeep` не считается логом",
+    )
+    errors += require_text(
+        STANDARD,
+        "`run_type` | MUST",
+        "Markdown-лог",
+        "logs/experiment-log.md",
+        "logs/business-task-log.md",
+    )
+    errors += require_text(
+        REGISTRY,
+        "| Run | Дата | Тип | Процесс | Основной результат | Лог |",
+    )
+    for run_dir in iter_run_dirs():
+        metadata = parse_simple_yaml(run_dir / "metadata.yaml")
+        canonical_log = CANONICAL_LOG_BY_RUN_TYPE.get(str(metadata.get("run_type", "")))
+        if canonical_log:
+            errors += require_text(REGISTRY, run_dir.name, canonical_log)
+    errors += require_text(
+        ANALYSIS,
+        "Issue #217",
+        "RUN-0001..RUN-0010",
+        "RUN-0013",
+        "Markdown-лог",
+        "docs/analysis/",
+    )
+    errors += require_text(CHANGELOG, "Issue #217", VALIDATOR, ANALYSIS)
+    errors += require_text(WORKFLOW, "Validate issue #217 runs log contract", VALIDATOR)
+    return errors
+
+
+def main() -> int:
+    errors = check_run_logs() + check_docs()
+    if errors:
+        print("Issue #217 runs log contract validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("Issue #217 runs log contract validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/data/checks.json
+++ b/site/data/checks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-22T08:03:39.925Z",
+  "generatedAt": "2026-06-24T07:43:25.175Z",
   "sourceFiles": [
     {
       "path": "runs/",
@@ -16,8 +16,8 @@
     "archived": 6
   },
   "tests": {
-    "logs": 24,
-    "total": 136,
+    "logs": 37,
+    "total": 147,
     "coveredPrompts": 27
   },
   "feedback": {
@@ -25,7 +25,7 @@
     "total": 0,
     "prompts": 0
   },
-  "totalChecked": 136,
+  "totalChecked": 147,
   "testsPassed": {
     "covered": 27,
     "total": 30,
@@ -35,13 +35,13 @@
     {
       "label": "Формирование ФТ/ТЗ",
       "emoji": "📋",
-      "checks": 97,
+      "checks": 101,
       "coveredPrompts": 18
     },
     {
       "label": "Формирование UC/US",
       "emoji": "🎯",
-      "checks": 80,
+      "checks": 88,
       "coveredPrompts": 10
     },
     {
@@ -53,20 +53,20 @@
     {
       "label": "Помощь ПО/ПМ",
       "emoji": "🤝",
-      "checks": 9,
+      "checks": 10,
       "coveredPrompts": 5
+    },
+    {
+      "label": "Статистика",
+      "emoji": "📈",
+      "checks": 8,
+      "coveredPrompts": 2
     },
     {
       "label": "Валидация ФТ/ТЗ",
       "emoji": "✅",
       "checks": 6,
       "coveredPrompts": 3
-    },
-    {
-      "label": "Статистика",
-      "emoji": "📈",
-      "checks": 6,
-      "coveredPrompts": 2
     },
     {
       "label": "Визуализация UML/BPMN",
@@ -96,16 +96,16 @@
         {
           "id": "mango-us-modeling-oneshot",
           "file": "us-modeling-oneshot.md",
-          "tests": 11,
+          "tests": 12,
           "feedback": 0,
-          "usage": 11
+          "usage": 12
         },
         {
           "id": "mango-us-modeling-stepwise",
           "file": "us-modeling-stepwise.md",
-          "tests": 11,
+          "tests": 12,
           "feedback": 0,
-          "usage": 11
+          "usage": 12
         },
         {
           "id": "mango-glossary-context-understanding-oneshot",
@@ -194,30 +194,30 @@
         {
           "id": "mango-us-modeling-oneshot",
           "file": "us-modeling-oneshot.md",
-          "tests": 11,
+          "tests": 12,
           "feedback": 0,
-          "usage": 11
+          "usage": 12
         },
         {
           "id": "mango-us-modeling-stepwise",
           "file": "us-modeling-stepwise.md",
-          "tests": 11,
+          "tests": 12,
           "feedback": 0,
-          "usage": 11
+          "usage": 12
         },
         {
           "id": "mango-user-story-generator-legacy",
           "file": "user-story-generator-legacy.md",
-          "tests": 11,
+          "tests": 12,
           "feedback": 0,
-          "usage": 11
+          "usage": 12
         },
         {
           "id": "mango-user-story-generator-simple-legacy",
           "file": "user-story-generator-simple-legacy.md",
-          "tests": 11,
+          "tests": 12,
           "feedback": 0,
-          "usage": 11
+          "usage": 12
         }
       ]
     },
@@ -241,15 +241,15 @@
           "usage": 3
         },
         {
-          "id": "mango-asr-ingestion-legacy",
-          "file": "asr-ingestion-legacy.md",
-          "tests": 1,
+          "id": "mango-session-debug-documentation-oneshot",
+          "file": "session-debug-documentation-oneshot.md",
+          "tests": 2,
           "feedback": 0,
-          "usage": 1
+          "usage": 2
         },
         {
-          "id": "mango-asr-ingestion-oneshot",
-          "file": "asr-ingestion-oneshot.md",
+          "id": "mango-asr-ingestion-legacy",
+          "file": "asr-ingestion-legacy.md",
           "tests": 1,
           "feedback": 0,
           "usage": 1
@@ -264,16 +264,16 @@
         {
           "id": "mango-tz-stats-generator-legacy",
           "file": "tz-stats-generator-legacy.md",
-          "tests": 3,
+          "tests": 4,
           "feedback": 0,
-          "usage": 3
+          "usage": 4
         },
         {
           "id": "mango-tz-stats-generator-simple-legacy",
           "file": "tz-stats-generator-simple-legacy.md",
-          "tests": 3,
+          "tests": 4,
           "feedback": 0,
-          "usage": 3
+          "usage": 4
         }
       ]
     }
@@ -288,8 +288,9 @@
         "Формирование UC/US",
         "Формирование ФТ/ТЗ"
       ],
-      "tests": 11,
+      "tests": 12,
       "testFiles": [
+        "runs/2026/RUN-0002/logs/generation-log.md",
         "runs/2026/RUN-0002/outputs/user-story_gen-from-raw-request_2026-05-26.md",
         "runs/2026/RUN-0003/outputs/usecase_gen-stepwise-alignment_2026-05-26.md",
         "runs/2026/RUN-0004/outputs/prompts-audit-2026-05-26.md",
@@ -304,7 +305,7 @@
       ],
       "feedback": 0,
       "feedbackIssues": [],
-      "usage": 11
+      "usage": 12
     },
     {
       "id": "mango-us-modeling-stepwise",
@@ -315,8 +316,9 @@
         "Формирование UC/US",
         "Формирование ФТ/ТЗ"
       ],
-      "tests": 11,
+      "tests": 12,
       "testFiles": [
+        "runs/2026/RUN-0002/logs/generation-log.md",
         "runs/2026/RUN-0002/outputs/user-story_gen-from-raw-request_2026-05-26.md",
         "runs/2026/RUN-0003/outputs/usecase_gen-stepwise-alignment_2026-05-26.md",
         "runs/2026/RUN-0004/outputs/prompts-audit-2026-05-26.md",
@@ -331,7 +333,7 @@
       ],
       "feedback": 0,
       "feedbackIssues": [],
-      "usage": 11
+      "usage": 12
     },
     {
       "id": "mango-user-story-generator-legacy",
@@ -341,8 +343,9 @@
       "processes": [
         "Формирование UC/US"
       ],
-      "tests": 11,
+      "tests": 12,
       "testFiles": [
+        "runs/2026/RUN-0002/logs/generation-log.md",
         "runs/2026/RUN-0002/outputs/user-story_gen-from-raw-request_2026-05-26.md",
         "runs/2026/RUN-0003/outputs/usecase_gen-stepwise-alignment_2026-05-26.md",
         "runs/2026/RUN-0004/outputs/prompts-audit-2026-05-26.md",
@@ -357,7 +360,7 @@
       ],
       "feedback": 0,
       "feedbackIssues": [],
-      "usage": 11
+      "usage": 12
     },
     {
       "id": "mango-user-story-generator-simple-legacy",
@@ -367,8 +370,9 @@
       "processes": [
         "Формирование UC/US"
       ],
-      "tests": 11,
+      "tests": 12,
       "testFiles": [
+        "runs/2026/RUN-0002/logs/generation-log.md",
         "runs/2026/RUN-0002/outputs/user-story_gen-from-raw-request_2026-05-26.md",
         "runs/2026/RUN-0003/outputs/usecase_gen-stepwise-alignment_2026-05-26.md",
         "runs/2026/RUN-0004/outputs/prompts-audit-2026-05-26.md",
@@ -383,7 +387,7 @@
       ],
       "feedback": 0,
       "feedbackIssues": [],
-      "usage": 11
+      "usage": 12
     },
     {
       "id": "mango-glossary-context-understanding-oneshot",
@@ -482,6 +486,52 @@
       "usage": 7
     },
     {
+      "id": "mango-uc-modeling-oneshot",
+      "file": "uc-modeling-oneshot.md",
+      "status": "draft",
+      "operation": "modeling",
+      "processes": [
+        "Формирование UC/US",
+        "Формирование ФТ/ТЗ"
+      ],
+      "tests": 7,
+      "testFiles": [
+        "runs/2026/RUN-0003/logs/generation-log.md",
+        "runs/2026/RUN-0003/outputs/usecase_gen-stepwise-alignment_2026-05-26.md",
+        "runs/2026/RUN-0004/outputs/prompts-audit-2026-05-26.md",
+        "runs/2026/RUN-0005/outputs/prompts-selftest-2026-05-26.md",
+        "runs/2026/RUN-0011/logs/experiment-log.md",
+        "runs/2026/RUN-0011/outputs/prompts-chain.md",
+        "runs/2026/RUN-0011/outputs/steps/step-4-story.md"
+      ],
+      "feedback": 0,
+      "feedbackIssues": [],
+      "usage": 7
+    },
+    {
+      "id": "mango-uc-modeling-stepwise",
+      "file": "uc-modeling-stepwise.md",
+      "status": "draft",
+      "operation": "modeling",
+      "processes": [
+        "Формирование UC/US",
+        "Формирование ФТ/ТЗ"
+      ],
+      "tests": 7,
+      "testFiles": [
+        "runs/2026/RUN-0003/logs/generation-log.md",
+        "runs/2026/RUN-0003/outputs/usecase_gen-stepwise-alignment_2026-05-26.md",
+        "runs/2026/RUN-0004/outputs/prompts-audit-2026-05-26.md",
+        "runs/2026/RUN-0005/outputs/prompts-selftest-2026-05-26.md",
+        "runs/2026/RUN-0011/logs/experiment-log.md",
+        "runs/2026/RUN-0011/outputs/prompts-chain.md",
+        "runs/2026/RUN-0011/outputs/steps/step-4-story.md"
+      ],
+      "feedback": 0,
+      "feedbackIssues": [],
+      "usage": 7
+    },
+    {
       "id": "mango-constraints-documentation-oneshot",
       "file": "constraints-documentation-oneshot.md",
       "status": "draft",
@@ -524,48 +574,80 @@
       "usage": 6
     },
     {
-      "id": "mango-uc-modeling-oneshot",
-      "file": "uc-modeling-oneshot.md",
-      "status": "draft",
-      "operation": "modeling",
+      "id": "mango-tz-stats-generator-legacy",
+      "file": "tz-stats-generator-legacy.md",
+      "status": "archived",
+      "operation": "quality",
       "processes": [
-        "Формирование UC/US",
-        "Формирование ФТ/ТЗ"
+        "Статистика"
       ],
-      "tests": 6,
+      "tests": 4,
       "testFiles": [
-        "runs/2026/RUN-0003/outputs/usecase_gen-stepwise-alignment_2026-05-26.md",
+        "runs/2026/RUN-0001/logs/experiment-log.md",
+        "runs/2026/RUN-0001/outputs/tz-stats-prototype-2026-05.md",
         "runs/2026/RUN-0004/outputs/prompts-audit-2026-05-26.md",
-        "runs/2026/RUN-0005/outputs/prompts-selftest-2026-05-26.md",
-        "runs/2026/RUN-0011/logs/experiment-log.md",
-        "runs/2026/RUN-0011/outputs/prompts-chain.md",
-        "runs/2026/RUN-0011/outputs/steps/step-4-story.md"
+        "runs/2026/RUN-0005/outputs/prompts-selftest-2026-05-26.md"
       ],
       "feedback": 0,
       "feedbackIssues": [],
-      "usage": 6
+      "usage": 4
     },
     {
-      "id": "mango-uc-modeling-stepwise",
-      "file": "uc-modeling-stepwise.md",
-      "status": "draft",
-      "operation": "modeling",
+      "id": "mango-tz-stats-generator-simple-legacy",
+      "file": "tz-stats-generator-simple-legacy.md",
+      "status": "archived",
+      "operation": "quality",
       "processes": [
-        "Формирование UC/US",
-        "Формирование ФТ/ТЗ"
+        "Статистика"
       ],
-      "tests": 6,
+      "tests": 4,
       "testFiles": [
-        "runs/2026/RUN-0003/outputs/usecase_gen-stepwise-alignment_2026-05-26.md",
+        "runs/2026/RUN-0001/logs/experiment-log.md",
+        "runs/2026/RUN-0001/outputs/tz-stats-prototype-2026-05.md",
         "runs/2026/RUN-0004/outputs/prompts-audit-2026-05-26.md",
-        "runs/2026/RUN-0005/outputs/prompts-selftest-2026-05-26.md",
-        "runs/2026/RUN-0011/logs/experiment-log.md",
-        "runs/2026/RUN-0011/outputs/prompts-chain.md",
-        "runs/2026/RUN-0011/outputs/steps/step-4-story.md"
+        "runs/2026/RUN-0005/outputs/prompts-selftest-2026-05-26.md"
       ],
       "feedback": 0,
       "feedbackIssues": [],
-      "usage": 6
+      "usage": 4
+    },
+    {
+      "id": "mango-usecase-stepwise-generator-legacy",
+      "file": "usecase-stepwise-generator-legacy.md",
+      "status": "archived",
+      "operation": "modeling",
+      "processes": [
+        "Формирование UC/US"
+      ],
+      "tests": 4,
+      "testFiles": [
+        "runs/2026/RUN-0003/logs/generation-log.md",
+        "runs/2026/RUN-0003/outputs/usecase_gen-stepwise-alignment_2026-05-26.md",
+        "runs/2026/RUN-0004/outputs/prompts-audit-2026-05-26.md",
+        "runs/2026/RUN-0005/outputs/prompts-selftest-2026-05-26.md"
+      ],
+      "feedback": 0,
+      "feedbackIssues": [],
+      "usage": 4
+    },
+    {
+      "id": "mango-usecase-stepwise-generator-simple-legacy",
+      "file": "usecase-stepwise-generator-simple-legacy.md",
+      "status": "archived",
+      "operation": "modeling",
+      "processes": [
+        "Формирование UC/US"
+      ],
+      "tests": 4,
+      "testFiles": [
+        "runs/2026/RUN-0003/logs/generation-log.md",
+        "runs/2026/RUN-0003/outputs/usecase_gen-stepwise-alignment_2026-05-26.md",
+        "runs/2026/RUN-0004/outputs/prompts-audit-2026-05-26.md",
+        "runs/2026/RUN-0005/outputs/prompts-selftest-2026-05-26.md"
+      ],
+      "feedback": 0,
+      "feedbackIssues": [],
+      "usage": 4
     },
     {
       "id": "mango-questions-customer-understanding-legacy",
@@ -662,78 +744,6 @@
       "usage": 3
     },
     {
-      "id": "mango-tz-stats-generator-legacy",
-      "file": "tz-stats-generator-legacy.md",
-      "status": "archived",
-      "operation": "quality",
-      "processes": [
-        "Статистика"
-      ],
-      "tests": 3,
-      "testFiles": [
-        "runs/2026/RUN-0001/outputs/tz-stats-prototype-2026-05.md",
-        "runs/2026/RUN-0004/outputs/prompts-audit-2026-05-26.md",
-        "runs/2026/RUN-0005/outputs/prompts-selftest-2026-05-26.md"
-      ],
-      "feedback": 0,
-      "feedbackIssues": [],
-      "usage": 3
-    },
-    {
-      "id": "mango-tz-stats-generator-simple-legacy",
-      "file": "tz-stats-generator-simple-legacy.md",
-      "status": "archived",
-      "operation": "quality",
-      "processes": [
-        "Статистика"
-      ],
-      "tests": 3,
-      "testFiles": [
-        "runs/2026/RUN-0001/outputs/tz-stats-prototype-2026-05.md",
-        "runs/2026/RUN-0004/outputs/prompts-audit-2026-05-26.md",
-        "runs/2026/RUN-0005/outputs/prompts-selftest-2026-05-26.md"
-      ],
-      "feedback": 0,
-      "feedbackIssues": [],
-      "usage": 3
-    },
-    {
-      "id": "mango-usecase-stepwise-generator-legacy",
-      "file": "usecase-stepwise-generator-legacy.md",
-      "status": "archived",
-      "operation": "modeling",
-      "processes": [
-        "Формирование UC/US"
-      ],
-      "tests": 3,
-      "testFiles": [
-        "runs/2026/RUN-0003/outputs/usecase_gen-stepwise-alignment_2026-05-26.md",
-        "runs/2026/RUN-0004/outputs/prompts-audit-2026-05-26.md",
-        "runs/2026/RUN-0005/outputs/prompts-selftest-2026-05-26.md"
-      ],
-      "feedback": 0,
-      "feedbackIssues": [],
-      "usage": 3
-    },
-    {
-      "id": "mango-usecase-stepwise-generator-simple-legacy",
-      "file": "usecase-stepwise-generator-simple-legacy.md",
-      "status": "archived",
-      "operation": "modeling",
-      "processes": [
-        "Формирование UC/US"
-      ],
-      "tests": 3,
-      "testFiles": [
-        "runs/2026/RUN-0003/outputs/usecase_gen-stepwise-alignment_2026-05-26.md",
-        "runs/2026/RUN-0004/outputs/prompts-audit-2026-05-26.md",
-        "runs/2026/RUN-0005/outputs/prompts-selftest-2026-05-26.md"
-      ],
-      "feedback": 0,
-      "feedbackIssues": [],
-      "usage": 3
-    },
-    {
       "id": "mango-fr-validation-legacy",
       "file": "fr-validation-legacy.md",
       "status": "draft",
@@ -789,6 +799,23 @@
       "usage": 2
     },
     {
+      "id": "mango-session-debug-documentation-oneshot",
+      "file": "session-debug-documentation-oneshot.md",
+      "status": "draft",
+      "operation": "documentation",
+      "processes": [
+        "Помощь ПО/ПМ"
+      ],
+      "tests": 2,
+      "testFiles": [
+        "runs/2026/RUN-0006/logs/documentation-log.md",
+        "runs/2026/RUN-0006/outputs/session-debug-summarizer-2026-06-13.md"
+      ],
+      "feedback": 0,
+      "feedbackIssues": [],
+      "usage": 2
+    },
+    {
       "id": "mango-asr-ingestion-legacy",
       "file": "asr-ingestion-legacy.md",
       "status": "draft",
@@ -817,22 +844,6 @@
       "tests": 1,
       "testFiles": [
         "runs/2026/RUN-0011/outputs/prompts-chain.md"
-      ],
-      "feedback": 0,
-      "feedbackIssues": [],
-      "usage": 1
-    },
-    {
-      "id": "mango-session-debug-documentation-oneshot",
-      "file": "session-debug-documentation-oneshot.md",
-      "status": "draft",
-      "operation": "documentation",
-      "processes": [
-        "Помощь ПО/ПМ"
-      ],
-      "tests": 1,
-      "testFiles": [
-        "runs/2026/RUN-0006/outputs/session-debug-summarizer-2026-06-13.md"
       ],
       "feedback": 0,
       "feedbackIssues": [],

--- a/site/data/processes.json
+++ b/site/data/processes.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-22T08:03:39.998Z",
+  "generatedAt": "2026-06-24T07:43:25.183Z",
   "sourceFiles": [
     {
       "path": "docs/ba-processes/00-index.md",
@@ -264,7 +264,7 @@
           "nextArtifact": "prompts/ft-tz-orchestration-stepwise.md или отдельный issue на workflow prompt."
         }
       ],
-      "checks": 97,
+      "checks": 101,
       "coveredPrompts": 18
     },
     {
@@ -542,7 +542,7 @@
         }
       ],
       "gaps": [],
-      "checks": 80,
+      "checks": 88,
       "coveredPrompts": 10
     },
     {
@@ -700,7 +700,7 @@
           "nextArtifact": "Коммуникационный governance prompt."
         }
       ],
-      "checks": 9,
+      "checks": 10,
       "coveredPrompts": 5
     },
     {
@@ -743,7 +743,7 @@
           "nextArtifact": "Новый active statistics prompt вместо reliance on archive."
         }
       ],
-      "checks": 6,
+      "checks": 8,
       "coveredPrompts": 2
     },
     {

--- a/standards/runs-contract-standard.md
+++ b/standards/runs-contract-standard.md
@@ -1,14 +1,16 @@
 ---
 status: draft
-version: 0.1
-updated: 2026-06-20
+version: 0.2
+updated: 2026-06-24
 ai-generated: true
 type: standard
 scope: runs
 related_issues:
   - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/123"
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/217"
 related_artifacts:
   - "runs/README.md"
+  - "runs/CONTRACT.md"
 ---
 
 # Стандарт контракта Run
@@ -27,6 +29,7 @@ runs/YYYY/RUN-XXXX/
   outputs/
   feedback/
   logs/
+    <run-type>-log.md
 ```
 
 Каталог `runs/YYYY/RUN-XXXX/` MUST содержать все четыре подкаталога, даже если
@@ -49,6 +52,7 @@ MUST совпадать с именем каталога.
 | --- | --- |
 | `run_id` | MUST быть вида `RUN-XXXX` и совпадать с каталогом. |
 | `process` | MUST называть процесс, сценарий или эксперимент. |
+| `run_type` | MUST быть одним из `experiment`, `generation`, `validation`, `documentation`, `business-task`. |
 | `version` | MUST фиксировать версию записи или основного результата. |
 | `date` | MUST быть датой `YYYY-MM-DD`. |
 | `author` | MUST указывать автора фиксации. |
@@ -61,6 +65,24 @@ MUST совпадать с именем каталога.
 - `inputs`, `outputs`, `logs` — ключевые файлы внутри run.
 - `related_issues`, `related_artifacts`, `related_runs` — трассировка.
 
+## Типы и обязательные Markdown-логи
+
+Каждый факт прохода MUST иметь основной Markdown-лог в `logs/`, независимо от
+того, завершился проход успешно, неуспешно или частично успешно. `.gitkeep` не
+считается логом. Технические журналы других форматов разрешены только как
+дополнительные файлы.
+
+| `run_type` | Основной Markdown-лог |
+| --- | --- |
+| `experiment` | `logs/experiment-log.md` |
+| `generation` | `logs/generation-log.md` |
+| `validation` | `logs/validation-log.md` |
+| `documentation` | `logs/documentation-log.md` |
+| `business-task` | `logs/business-task-log.md` |
+
+`metadata.yaml` MUST содержать `logs:` и ссылку на основной Markdown-лог. Лог
+MUST фиксировать ход выполнения, ключевые действия, блокеры и итоговый статус.
+
 ## Назначение подкаталогов
 
 | Подкаталог | Правило |
@@ -68,7 +90,7 @@ MUST совпадать с именем каталога.
 | `inputs/` | SHOULD содержать входные данные, доступные для хранения в репозитории. |
 | `outputs/` | SHOULD содержать результаты и промежуточные артефакты выполнения. |
 | `feedback/` | SHOULD содержать обратную связь, review notes и решения по результату. |
-| `logs/` | SHOULD содержать экспериментальные логи, метрики и трассировку. |
+| `logs/` | MUST содержать основной Markdown-лог; MAY содержать метрики и трассировку. |
 
 ## Миграция существующих результатов
 
@@ -85,6 +107,7 @@ MUST совпадать с именем каталога.
 - `runs/README.md` описывает контракт и индекс текущих записей.
 - Каждый Run содержит `metadata.yaml`, `inputs/`, `outputs/`, `feedback/`, `logs/`.
 - Все обязательные поля `metadata.yaml` заполнены.
+- Каждый Run содержит основной Markdown-лог, соответствующий `run_type`.
 - Перенесённые результаты отсутствуют по старым путям.
 - `scripts/generate-pages-data.mjs` читает evidence из `runs/`.
 - CI вызывает `scripts/validate_issue_123_runs_contract.py`.
@@ -93,4 +116,5 @@ MUST совпадать с именем каталога.
 
 ```bash
 python3 scripts/validate_issue_123_runs_contract.py
+python3 scripts/validate_issue_217_runs_log_contract.py
 ```


### PR DESCRIPTION
Fixes G-Ivan-A/mango_ba_prompts#217

## Summary
- Strengthened `runs/CONTRACT.md` and `standards/runs-contract-standard.md`: `runs-contract` is now the explicit kebab-case contract id/title, the run type table is tied to `run_type`, and every run attempt MUST have a primary Markdown log.
- Added canonical Markdown logs for `RUN-0001`..`RUN-0013`, updated each `metadata.yaml` with `logs:`, and added a `Лог` column to `runs/REGISTRY.md`.
- Added `docs/analysis/runs-contract-log-policy-audit.md` and `scripts/validate_issue_217_runs_log_contract.py`; wired the validator into GitHub Pages CI.

## Reproduction
Before the fix, `python3 scripts/validate_issue_217_runs_log_contract.py` failed on missing Markdown logs for `RUN-0001`..`RUN-0010`, missing canonical business-task logs for `RUN-0011`..`RUN-0013`, weak contract wording, and the registry missing log links.

## Validation
- `node scripts/generate-pages-data.mjs`
- `python3 scripts/validate_issue_217_runs_log_contract.py`
- GitHub Pages validator batch from `.github/workflows/github-pages.yml`: passed
- KB validators: all non-LFS-dependent checks passed locally; `make kb-validate` cannot complete in this checkout because `git lfs` is not installed and issue #131 sees PDF pointer files instead of hydrated PDF bytes.
