### PR TITLE
governance: add RFC-243 BA process observability proposal

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Validate issue #241 analysis artifact naming
         run: python3 scripts/validate_issue_241_analysis_naming.py
 
+      - name: Validate issue #243 BA-processes observability RFC
+        run: python3 scripts/validate_issue_243_ba_processes_observability_rfc.py
+
       - name: Validate issue #199 BCREQ-1027 section 4.3 API methods
         run: python3 scripts/validate_issue_199_bcreq_1027_section_4_3.py
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-25T19:50:37.906Z for PR creation at branch issue-243-ca36ce19b2e8 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/243

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-25T19:50:37.906Z for PR creation at branch issue-243-ca36ce19b2e8 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/243

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,28 @@ ai-generated: true
 
 ## Unreleased
 
+### Added — Issue #243 RFC по БА-процессам и observability
+
+- Добавлен L3 RFC proposal
+  [`governance/rfc/ba-processes-observability-implementation-proposal.md`](governance/rfc/ba-processes-observability-implementation-proposal.md),
+  фиксирующий согласованные решения из исследований A3/A4 и PR #234: RFC как
+  артефакт решения вместо ADR на этом этапе, atomic/composite BA taxonomy,
+  классификацию BCREQ-FR как `type: frd` и BCREQ-SR как `type: srs`, шесть
+  BABOK-операций поверх существующей декомпозиции, будущий
+  `operation_id -> prompt_id@version` registry, `applied_operations` для
+  contracts и `applied_prompts` для runs.
+- Обновлены [`governance/rfc-register.md`](governance/rfc-register.md) и
+  [`governance/BACKLOG.md`](governance/BACKLOG.md): добавлен RFC-243 и sprint
+  backlog с волнами, dependencies, priorities и fork issue links. Из-за
+  `READ`-доступа токена к upstream issues/labels созданы в fork
+  `konard/G-Ivan-A-mango_ba_prompts` как переносимый tracking set.
+- Добавлен регрессионный валидатор
+  [`scripts/validate_issue_243_ba_processes_observability_rfc.py`](scripts/validate_issue_243_ba_processes_observability_rfc.py),
+  подключённый к GitHub Pages workflow.
+- Изменение является только proposal: стандарты, контракты, runs, prompts,
+  `kb/operation-prompt-mapping/registry.json` и существующие BA-артефакты не
+  реализуются в рамках issue #243.
+
 ### Changed — Issue #241 формат имён аналитических артефактов
 
 - Переименованы все 21 Markdown-файла в `docs/analysis/` в формат

--- a/governance/BACKLOG.md
+++ b/governance/BACKLOG.md
@@ -316,6 +316,72 @@ M-009)`. Задачи M-001 (README) и M-008 (workflow) независимы и
       заказчику). Источник:
       [`docs/analysis/2026-06-16-experiment-1027-analysis.md`](../docs/analysis/2026-06-16-experiment-1027-analysis.md).
 
+## Спринт RFC-243: BA-процессы и observability
+
+Этот раздел формирует implementation sprint по Issue #243 и RFC-243:
+[`governance/rfc/ba-processes-observability-implementation-proposal.md`](rfc/ba-processes-observability-implementation-proposal.md).
+Спринт не реализует стандарты и артефакты сам по себе: он фиксирует порядок
+работ после review/canonical решения по RFC.
+
+> Ограничение доступа: текущий токен имеет `READ` на upstream
+> `G-Ivan-A/mango_ba_prompts`, поэтому labels/issues созданы в fork
+> `konard/G-Ivan-A-mango_ba_prompts`. При переносе в upstream требуется
+> воспроизвести labels `priority:P1`, `priority:P2`, `priority:P3`,
+> `type:decision`, `type:implementation`, `type:research`, `sprint-3`.
+
+### Метки спринта
+
+- Priority labels: `priority:P1`, `priority:P2`, `priority:P3`.
+- Type labels: `type:decision`, `type:implementation`, `type:research`.
+- Sprint label: `sprint-3`.
+- Domain labels: `governance`, `ba-processes`, `observability`.
+
+### Волны
+
+- **Волна 0** — decision gate: принять RFC/ADR-формат и статус RFC-243.
+- **Волна 1** — процессная и онтологическая сверка: сначала `00-index.md`,
+  затем BA-онтология.
+- **Волна 2** — execution mapping: L2 registry, `applied_operations`,
+  `applied_prompts`.
+- **Волна 3** — enforcement и доменные уточнения: validators/stats и eTOM/SID.
+
+| № | Title | Type | Priority | Dependencies | Issue in repo |
+| --- | --- | --- | --- | --- | --- |
+| 1 | decision: зафиксировать RFC-243 governance proposal | decision | P1 | independent: upstream Issue #243 and PR #244 | <https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/1> |
+| 2 | implementation: сверить 00-index.md с BABOK-операциями | implementation | P1 | dependent: #1 | <https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/3> |
+| 3 | implementation: обновить БА-онтологию для atomic-composite taxonomy | implementation | P1 | dependent: #1, #3 | <https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/4> |
+| 4 | implementation: создать L2-реестр operation-prompt mapping | implementation | P1 | dependent: #1 | <https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/2> |
+| 5 | implementation: добавить applied_operations в generation contracts | implementation | P1 | dependent: #2, #3 | <https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/5> |
+| 6 | implementation: добавить applied_prompts и lineage в runs contract | implementation | P1 | dependent: #2 | <https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/6> |
+| 7 | implementation: обновить валидаторы и статистику под трассируемость | implementation | P2 | dependent: #5, #6 | <https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/7> |
+| 8 | research: оценить eTOM/SID как доменные БА-артефакты | research | P3 | dependent: #4 | <https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/8> |
+
+### Dependency map
+
+```mermaid
+graph TD
+    T1[decision RFC-243] --> T2[00-index.md BABOK reconciliation]
+    T1 --> T4[L2 operation-prompt mapping]
+    T1 --> T3[BA ontology taxonomy]
+    T2 --> T3
+    T2 --> T5[applied_operations in contracts]
+    T4 --> T5
+    T4 --> T6[applied_prompts in runs]
+    T5 --> T7[validators and stats]
+    T6 --> T7
+    T3 --> T8[eTOM/SID research]
+```
+
+### DoD спринта
+
+- Каждая задача имеет тип `decision` / `implementation` / `research`, priority
+  `P1` / `P2` / `P3`, sprint label `sprint-3` и явные dependencies.
+- Волна 1 не стартует до review решения по RFC-243.
+- Волна 2 не стартует до сверки `docs/ba-processes/00-index.md` и фиксации
+  operation IDs.
+- Ни одна задача из спринта не изменяется в этом PR; этот раздел только
+  формирует backlog и issue links.
+
 ---
 
 ## Связанные артефакты

--- a/governance/rfc-register.md
+++ b/governance/rfc-register.md
@@ -1,7 +1,7 @@
 ---
 status: draft
-version: 0.4
-updated: 2026-06-22
+version: 0.5
+updated: 2026-06-25
 ai-generated: true
 type: register
 scope: governance
@@ -10,6 +10,7 @@ related_issues:
   - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/107"
   - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/109"
   - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/184"
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/243"
 related_artifacts:
   - "governance/rfc-process.md"
   - "governance/prompt-debugging-process.md"
@@ -20,6 +21,7 @@ related_artifacts:
   - "governance/rfc/prompt-improvement-bcreq-1025-proposal.md"
   - "governance/rfc/prompt-improvement-multichannel-proposal.md"
   - "governance/rfc/bcreq-ft-scope-formation-rules-proposal.md"
+  - "governance/rfc/ba-processes-observability-implementation-proposal.md"
 ---
 
 # Реестр RFC (живой документ)
@@ -44,6 +46,19 @@ proposed → in-review → accepted  → implemented
 | `accepted` | принят к реализации | **только пользователь** |
 | `rejected` | отклонён (с причиной) | **только пользователь** |
 | `implemented` | внесён, связан с PR | исполнитель после merge |
+
+## Открытые RFC по БА-процессам и observability (источник: issue #243)
+
+RFC-243 фиксирует согласованные решения из research chain:
+[`docs/analysis/2026-06-25-runs-observability-research.md`](../docs/analysis/2026-06-25-runs-observability-research.md),
+[`docs/analysis/2026-06-25-bcreq-fr-contract-process-analysis.md`](../docs/analysis/2026-06-25-bcreq-fr-contract-process-analysis.md),
+[`docs/analysis/2026-06-25-ba-processes-industry-analysis.md`](../docs/analysis/2026-06-25-ba-processes-industry-analysis.md).
+Документ является proposal: он не меняет стандарты, контракты, runs или
+существующие BA-артефакты.
+
+| RFC | Документ | Суть предложения | Источник-сигнал | Статус | PR реализации |
+| --- | --- | --- | --- | --- | --- |
+| RFC-243 | [`governance/rfc/ba-processes-observability-implementation-proposal.md`](rfc/ba-processes-observability-implementation-proposal.md) | Зафиксировать RFC-vs-ADR choice, atomic/composite BA taxonomy, BABOK operation layer, `operation_id -> prompt_id@version`, `applied_operations`, `applied_prompts` и issue-backed sprint | issue #243; A3 observability; A4 BCREQ-FR process; PR #234 BA-processes industry analysis | `draft` | PR #244 |
 
 ## Открытые RFC по промптам (источник: эксперимент 1027, issue #101)
 
@@ -159,3 +174,7 @@ PR #105 **не изменены** — сверка и правка идут то
   масштаба). RFC-документ —
   [`governance/rfc/bcreq-ft-scope-formation-rules-proposal.md`](rfc/bcreq-ft-scope-formation-rules-proposal.md).
   Расширяет RFC-1027-P4 (фильтр текущего поведения) с Раздела 6 на Разделы 2 и 4.
+- **2026-06-25** — добавлен RFC-243 в статусе `draft` по issue #243: governance
+  proposal для сверки BA-процессов, atomic/composite артефактов, observability
+  runs и sprint backlog после исследований A3/A4/PR #234. RFC-документ —
+  [`governance/rfc/ba-processes-observability-implementation-proposal.md`](rfc/ba-processes-observability-implementation-proposal.md).

--- a/governance/rfc/ba-processes-observability-implementation-proposal.md
+++ b/governance/rfc/ba-processes-observability-implementation-proposal.md
@@ -1,0 +1,387 @@
+---
+id: RFC-243
+status: draft
+title: "RFC-243: BA process and observability implementation proposal"
+author: "OpenAI Codex"
+created: 2026-06-25
+updated: 2026-06-25
+layer: L3
+type: rfc
+related_contracts:
+  - "governance/rfc-generation-contract.md"
+  - "governance/rfc-process.md"
+  - "governance/bcreq-fr-generation-contract.md"
+  - "runs/CONTRACT.md"
+  - "standards/executable-contract-standard.md"
+target_artifacts:
+  - "docs/ba-processes/00-index.md"
+  - "docs/ba-processes/00-index.executable.md"
+  - "standards/ba-ontology.md"
+  - "governance/bcreq-fr-generation-contract.md"
+  - "runs/CONTRACT.md"
+  - "kb/operation-prompt-mapping/registry.json"
+  - "runs/REGISTRY.md"
+  - "runs/stats/by-process.md"
+  - "runs/stats/by-type.md"
+---
+
+# RFC-243: BA process and observability implementation proposal
+
+This RFC records the agreed decisions from the BA-process and observability
+research chain. It is a proposal only: it does not implement standards,
+contracts, prompt mappings, run metadata, or existing BA artifacts.
+
+## 1. Context and motivation
+
+```yaml
+context:
+  source_issue: "https://github.com/G-Ivan-A/mango_ba_prompts/issues/243"
+  source_pr: "https://github.com/G-Ivan-A/mango_ba_prompts/pull/244"
+  chain: "research -> rfc/adr -> standard -> artifact"
+  proposal_scope: "L3 governance proposal for later standard and artifact changes"
+  product_docs: "not_applicable"
+  source_refs:
+    - id: A3
+      path: "docs/analysis/2026-06-25-runs-observability-research.md"
+      signal: "Runs lack prompt-level observability, versioning, lineage, and prompt-to-rule mapping."
+    - id: A4
+      path: "docs/analysis/2026-06-25-bcreq-fr-contract-process-analysis.md"
+      signal: "BCREQ-FR is applied as a monolithic contract because L1 contracts are not linked to operation/prompt mappings."
+    - id: A5
+      path: "docs/analysis/2026-06-25-ba-processes-industry-analysis.md"
+      source_pr: "https://github.com/G-Ivan-A/mango_ba_prompts/pull/234"
+      signal: "The project model matches industry practice but needs explicit atomic/composite taxonomy, API spec, RTM, and BABOK operation alignment."
+    - id: BA_PROCESS_INDEX
+      path: "docs/ba-processes/00-index.md"
+      signal: "Current BA process map has nine processes, thirteen operations, and prompt chains."
+    - id: BA_PROCESS_EXECUTABLE
+      path: "docs/ba-processes/00-index.executable.md"
+      signal: "Executable companion for machine-readable process navigation."
+    - id: BCREQ_FR_CONTRACT
+      path: "governance/bcreq-fr-generation-contract.md"
+      signal: "L1 generation contract exists but does not declare applied operations."
+    - id: RUNS_CONTRACT
+      path: "runs/CONTRACT.md"
+      signal: "Run metadata contract exists but does not declare applied prompts or prompt lineage."
+    - id: EXECUTABLE_CONTRACT_STANDARD
+      path: "standards/executable-contract-standard.md"
+      signal: "L1 contracts are self-contained; reusable mappings belong in L2 registries, not runtime-only L3 prose."
+    - id: RFC_GENERATION_CONTRACT
+      path: "governance/rfc-generation-contract.md"
+      signal: "RFC artifacts must be L3 proposals with explicit problem, proposal, impact, and canonical criteria."
+  permission_note:
+    upstream_permission: "READ"
+    fork_permission: "ADMIN"
+    fork_tracking_issues:
+      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/1"
+      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/2"
+      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/3"
+      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/4"
+      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/5"
+      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/6"
+      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/7"
+      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/8"
+```
+
+### Почему RFC, а не ADR
+
+The artifact type is RFC, not ADR, because issue #243 asks to propose a coherent
+governance and implementation path across process documentation, standards, L1
+contracts, L2 registry data, and run metadata. The decision is not yet an
+accepted architecture record; it is a reviewable proposal that must become
+canonical before downstream implementation. An ADR would be appropriate only if
+a human reviewer needs to record a final architecture choice after RFC review.
+
+## 2. Problem
+
+```yaml
+problems:
+  - id: RFC-243-P1
+    title: "Research decisions are not fixed in an RFC/ADR artifact."
+    source_refs:
+      - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/243"
+      - "docs/analysis/2026-06-25-runs-observability-research.md"
+      - "docs/analysis/2026-06-25-bcreq-fr-contract-process-analysis.md"
+      - "docs/analysis/2026-06-25-ba-processes-industry-analysis.md"
+    effect: "The chain research -> rfc/adr -> standard -> artifact is blocked."
+  - id: RFC-243-P2
+    title: "Atomic and composite BA artifact taxonomy is not canonical."
+    source_refs:
+      - "docs/analysis/2026-06-25-ba-processes-industry-analysis.md"
+      - "standards/ba-ontology.md"
+    effect: "API specification, RTM entry, FRD/SRS distinction, and BCREQ type semantics remain ambiguous."
+  - id: RFC-243-P3
+    title: "Operation hierarchy is mixed with implementation-level decomposition."
+    source_refs:
+      - "docs/ba-processes/00-index.md"
+      - "docs/analysis/2026-06-25-ba-processes-industry-analysis.md"
+    effect: "The project has useful thirteen-operation detail but lacks a first-class six-operation BABOK-compatible layer."
+  - id: RFC-243-P4
+    title: "Contracts cannot declare which BA operations they execute."
+    source_refs:
+      - "docs/analysis/2026-06-25-bcreq-fr-contract-process-analysis.md"
+      - "governance/bcreq-fr-generation-contract.md"
+    effect: "BCREQ-FR remains a monolithic contract application instead of a traceable operation sequence."
+  - id: RFC-243-P5
+    title: "Runs cannot record applied prompt versions and lineage."
+    source_refs:
+      - "docs/analysis/2026-06-25-runs-observability-research.md"
+      - "runs/CONTRACT.md"
+    effect: "It is not possible to reconstruct prompt_id, version, model settings, prompt result, or previous_run_id from run metadata."
+  - id: RFC-243-P6
+    title: "Migration conflicts are not staged as issue-backed implementation work."
+    source_refs:
+      - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/243"
+      - "governance/BACKLOG.md"
+    effect: "Without a sprint backlog, later implementation may change standards and artifacts out of order."
+```
+
+## 3. Proposal
+
+```yaml
+proposal:
+  RFC-243-R1:
+    title: "Use RFC as the decision artifact."
+    decision: "RFC-243 remains an L3 RFC draft until human review moves it to canonical, rejects it, or asks for an ADR."
+    rationale: "The proposal coordinates several downstream artifacts and standards; it is not an already accepted architecture decision."
+  RFC-243-R2:
+    title: "Fix atomic BA artifacts as one-source/one-owner/one-check units."
+    atomic_artifacts:
+      - "Singular requirement"
+      - "User Story"
+      - "Use Case"
+      - "Business Rule"
+      - "Glossary term"
+      - "API specification (OpenAPI/TMF Open API)"
+      - "RTM entry"
+    atomic_definition: "One source, one owner, one check."
+  RFC-243-R3:
+    title: "Fix composite BA artifacts as aggregates of atomic artifacts."
+    composite_artifacts:
+      - "BRD"
+      - "FRD/SRS"
+      - "RFP Response/Bid Requirements"
+    classification:
+      BCREQ-FR: "`type: frd`"
+      BCREQ-SR: "`type: srs`"
+    composite_definition: "Aggregation of atomics plus structure and traceability."
+  RFC-243-R4:
+    title: "Adopt six BABOK-compatible operations as the top-level operation layer."
+    operations:
+      - "Elicitation"
+      - "Analysis"
+      - "Documentation"
+      - "Validation"
+      - "Verification"
+      - "Management"
+    decomposition_rule: "Existing thirteen operations remain as project-specific decomposition/suboperations."
+  RFC-243-R5:
+    title: "Introduce an L2 operation-prompt mapping registry."
+    target: "kb/operation-prompt-mapping/registry.json"
+    key_edge: "operation_id -> prompt_id@version"
+    minimum_fields:
+      - "operation_id"
+      - "prompt_id"
+      - "prompt_version"
+      - "source_process"
+      - "artifact_scope"
+      - "contract_rule_refs"
+      - "owner"
+  RFC-243-R6:
+    title: "Add operation and prompt trace fields in later contract/run migrations."
+    contract_field: "applied_operations"
+    run_field: "applied_prompts"
+    lineage_field: "previous_run_id"
+    boundary: "Contracts reference operation IDs; runs record prompt IDs and versions used during execution."
+  RFC-243-R7:
+    title: "Reconcile process documentation before implementation."
+    order:
+      - "First reconcile docs/ba-processes/00-index.md with the industry-normal six-operation layer."
+      - "Then update ontology/standards for atomic/composite artifacts."
+      - "Then implement the L2 registry and L1/run metadata fields."
+    reason: "The implementation proposal depends on process-model reconciliation."
+  RFC-243-R8:
+    title: "Use an issue-backed sprint backlog."
+    backlog: "governance/BACKLOG.md#спринт-rfc-243"
+    upstream_issue: "https://github.com/G-Ivan-A/mango_ba_prompts/issues/243"
+    fork_tracking_issues:
+      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/1"
+      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/2"
+      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/3"
+      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/4"
+      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/5"
+      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/6"
+      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/7"
+      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/8"
+```
+
+## 4. Alternatives considered
+
+```yaml
+alternatives:
+  - id: RFC-243-A1
+    title: "Write an ADR immediately."
+    outcome: "rejected_for_now"
+    reason: "The work is still a proposal across several governance surfaces; an ADR would prematurely record an accepted architecture decision."
+  - id: RFC-243-A2
+    title: "Implement standards and contracts directly in issue #243."
+    outcome: "rejected"
+    reason: "Issue #243 explicitly requires documentation and a sprint proposal, not implementation of standards, contracts, runs, prompts, or existing artifacts."
+  - id: RFC-243-A3
+    title: "Keep operation-to-prompt mapping only in docs/ba-processes/00-index.md."
+    outcome: "rejected"
+    reason: "Prose is useful for navigation but cannot safely serve L1 contracts and run validators as an L2 registry."
+  - id: RFC-243-A4
+    title: "Embed prompt mapping directly in each L1 contract."
+    outcome: "rejected"
+    reason: "This duplicates prompt mappings, increases drift, and conflicts with the L1 self-contained contract plus L2 reusable-data boundary."
+```
+
+## 5. Rationale
+
+```yaml
+rationale:
+  source_traceability:
+    - "A3 supports RFC-243-R5 and RFC-243-R6: prompt observability requires prompt IDs, prompt versions, and lineage in runs."
+    - "A4 supports RFC-243-R5 and RFC-243-R6: contract application needs an operation layer before prompt-level execution can be audited."
+    - "PR #234 / A5 supports RFC-243-R2, RFC-243-R3, and RFC-243-R4: industry practice separates atomic artifacts, composite documents, and top-level BA operations."
+  boundary_rules:
+    - "RFC-243 is L3 governance and does not implement L1/L2 artifacts."
+    - "L2 registry data is the right home for operation_id -> prompt_id@version because it is reusable by contracts, runs, and validators."
+    - "L1 contracts should reference applied_operations, while runs should record applied_prompts with concrete prompt versions."
+  migration_order:
+    - "The process index must be reconciled before generated contracts can safely reference operation IDs."
+    - "The artifact ontology must define atomic/composite/API/RTM semantics before BCREQ-FR and BCREQ-SR type fields can be migrated."
+    - "Run observability should follow the registry and contract-field changes so validators can check real references."
+```
+
+## 6. Impact
+
+```yaml
+impact:
+  requires_adr: false
+  adr_reason: "This RFC is the reviewable proposal. No irreversible architecture decision is accepted in this PR."
+  requires_standard: true
+  standard_reason: "Later implementation will need normative updates to BA ontology, process documentation, contract fields, and run metadata rules."
+  target_artifacts:
+    - "docs/ba-processes/00-index.md"
+    - "docs/ba-processes/00-index.executable.md"
+    - "standards/ba-ontology.md"
+    - "governance/bcreq-fr-generation-contract.md"
+    - "runs/CONTRACT.md"
+    - "kb/operation-prompt-mapping/registry.json"
+    - "runs/REGISTRY.md"
+    - "runs/stats/by-process.md"
+    - "runs/stats/by-type.md"
+  conflicts:
+    - id: RFC-243-C1
+      description: "`type: contract` is overloaded in some L3-adjacent artifacts and must not be reused for BCREQ-FR/BCREQ-SR document type classification."
+      migration: "Audit and migrate metadata only in dedicated implementation issues."
+    - id: RFC-243-C2
+      description: "Existing thirteen operations are valuable detail but not the canonical top-level operation set."
+      migration: "Preserve them as suboperations when adding the six-operation layer."
+    - id: RFC-243-C3
+      description: "Current runs do not contain prompt lineage."
+      migration: "Add new optional fields first; backfill only when evidence exists."
+  non_implementation_guards:
+    - "This RFC does not implement kb/operation-prompt-mapping/registry.json."
+    - "This RFC does not change standards/ba-ontology.md."
+    - "This RFC does not change governance/bcreq-fr-generation-contract.md."
+    - "This RFC does not change runs/CONTRACT.md."
+```
+
+## 7. Implementation plan
+
+```yaml
+implementation_plan:
+  status: "proposal_only"
+  waves:
+    - wave: 0
+      title: "Decision gate"
+      tasks:
+        - title: "decision: зафиксировать RFC-243 governance proposal"
+          issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/1"
+          type: "decision"
+          priority: "P1"
+          dependency_mode: "independent"
+    - wave: 1
+      title: "Process and taxonomy reconciliation"
+      tasks:
+        - title: "implementation: сверить 00-index.md с BABOK-операциями"
+          issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/3"
+          type: "implementation"
+          priority: "P1"
+          dependency_mode: "dependent"
+          depends_on:
+            - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/1"
+        - title: "implementation: обновить БА-онтологию для atomic-composite taxonomy"
+          issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/4"
+          type: "implementation"
+          priority: "P1"
+          dependency_mode: "dependent"
+          depends_on:
+            - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/1"
+            - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/3"
+    - wave: 2
+      title: "Mapping and execution metadata"
+      tasks:
+        - title: "implementation: создать L2-реестр operation-prompt mapping"
+          issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/2"
+          type: "implementation"
+          priority: "P1"
+          dependency_mode: "dependent"
+          depends_on:
+            - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/1"
+        - title: "implementation: добавить applied_operations в generation contracts"
+          issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/5"
+          type: "implementation"
+          priority: "P1"
+          dependency_mode: "dependent"
+          depends_on:
+            - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/2"
+            - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/3"
+        - title: "implementation: добавить applied_prompts и lineage в runs contract"
+          issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/6"
+          type: "implementation"
+          priority: "P1"
+          dependency_mode: "dependent"
+          depends_on:
+            - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/2"
+    - wave: 3
+      title: "Validation and domain follow-up"
+      tasks:
+        - title: "implementation: обновить валидаторы и статистику под трассируемость"
+          issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/7"
+          type: "implementation"
+          priority: "P2"
+          dependency_mode: "dependent"
+          depends_on:
+            - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/5"
+            - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/6"
+        - title: "research: оценить eTOM/SID как доменные БА-артефакты"
+          issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/8"
+          type: "research"
+          priority: "P3"
+          dependency_mode: "dependent"
+          depends_on:
+            - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/4"
+  note: "The fork issue URLs are used because the current GitHub token cannot create upstream issues or labels."
+```
+
+## 8. Canonical criteria
+
+```yaml
+canonical_criteria:
+  - id: RFC-243-CC1
+    criterion: "A human reviewer accepts RFC as the correct artifact type or explicitly requests ADR conversion."
+  - id: RFC-243-CC2
+    criterion: "Atomic and composite artifact decisions are accepted without changing standards in this PR."
+  - id: RFC-243-CC3
+    criterion: "The six-operation BABOK layer and thirteen-operation decomposition rule are accepted."
+  - id: RFC-243-CC4
+    criterion: "The operation_id -> prompt_id@version L2 registry is accepted as a future implementation target."
+  - id: RFC-243-CC5
+    criterion: "`applied_operations` for contracts and `applied_prompts` for runs are accepted as future migration fields."
+  - id: RFC-243-CC6
+    criterion: "The sprint backlog is accepted as the implementation sequence, with upstream issues recreated if maintainers require upstream tracking."
+```

--- a/scripts/validate_issue_243_ba_processes_observability_rfc.py
+++ b/scripts/validate_issue_243_ba_processes_observability_rfc.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Regression check for issue #243 RFC and implementation sprint."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+RFC = Path("governance/rfc/ba-processes-observability-implementation-proposal.md")
+BACKLOG = Path("governance/BACKLOG.md")
+REGISTER = Path("governance/rfc-register.md")
+CHANGELOG = Path("CHANGELOG.md")
+WORKFLOW = Path(".github/workflows/github-pages.yml")
+VALIDATOR = Path("scripts/validate_issue_243_ba_processes_observability_rfc.py")
+
+REQUIRED_SECTIONS = (
+    "## 1. Context and motivation",
+    "## 2. Problem",
+    "## 3. Proposal",
+    "## 4. Alternatives considered",
+    "## 5. Rationale",
+    "## 6. Impact",
+    "## 7. Implementation plan",
+    "## 8. Canonical criteria",
+)
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        fail(message)
+
+
+def read_text(path: Path) -> str:
+    full_path = ROOT / path
+    require(full_path.exists(), f"missing file: {path}")
+    return full_path.read_text(encoding="utf-8")
+
+
+def split_frontmatter(path: Path, text: str) -> tuple[str, str]:
+    require(text.startswith("---\n"), f"{path}: missing YAML frontmatter")
+    end = text.find("\n---", 4)
+    require(end != -1, f"{path}: unterminated YAML frontmatter")
+    return text[4:end].strip(), text[end + len("\n---") :].strip()
+
+
+def require_ordered_sections(path: Path, body: str) -> None:
+    previous = -1
+    for section in REQUIRED_SECTIONS:
+        current = body.find(section)
+        require(current != -1, f"{path}: missing section {section!r}")
+        require(current > previous, f"{path}: section order is invalid at {section!r}")
+        previous = current
+
+
+def validate_rfc() -> None:
+    text = read_text(RFC)
+    frontmatter, body = split_frontmatter(RFC, text)
+
+    frontmatter_needles = (
+        "id: RFC-243",
+        "status: draft",
+        'title: "RFC-243: BA process and observability implementation proposal"',
+        'author: "OpenAI Codex"',
+        "created: 2026-06-25",
+        "updated: 2026-06-25",
+        "layer: L3",
+        "type: rfc",
+        "related_contracts:",
+        "target_artifacts:",
+        "governance/rfc-generation-contract.md",
+        "governance/bcreq-fr-generation-contract.md",
+        "runs/CONTRACT.md",
+        "standards/executable-contract-standard.md",
+        "docs/ba-processes/00-index.md",
+        "kb/operation-prompt-mapping/registry.json",
+    )
+    for needle in frontmatter_needles:
+        require(needle in frontmatter, f"{RFC}: frontmatter missing {needle!r}")
+
+    require_ordered_sections(RFC, body)
+
+    required_yaml_keys = (
+        "context:",
+        "problems:",
+        "proposal:",
+        "alternatives:",
+        "rationale:",
+        "impact:",
+        "implementation_plan:",
+        "canonical_criteria:",
+    )
+    for key in required_yaml_keys:
+        require(re.search(rf"(^|\n){re.escape(key)}", body), f"{RFC}: missing YAML key {key}")
+
+    required_fragments = (
+        "Почему RFC, а не ADR",
+        "requires_adr: false",
+        "requires_standard: true",
+        "docs/analysis/2026-06-25-runs-observability-research.md",
+        "docs/analysis/2026-06-25-bcreq-fr-contract-process-analysis.md",
+        "docs/analysis/2026-06-25-ba-processes-industry-analysis.md",
+        "https://github.com/G-Ivan-A/mango_ba_prompts/pull/234",
+        "docs/ba-processes/00-index.md",
+        "governance/bcreq-fr-generation-contract.md",
+        "runs/CONTRACT.md",
+        "standards/executable-contract-standard.md",
+        "Singular requirement",
+        "User Story",
+        "Use Case",
+        "Business Rule",
+        "Glossary term",
+        "API specification",
+        "OpenAPI/TMF Open API",
+        "RTM entry",
+        "BRD",
+        "FRD/SRS",
+        "RFP Response",
+        "BCREQ-FR",
+        "`type: frd`",
+        "BCREQ-SR",
+        "`type: srs`",
+        "Elicitation",
+        "Analysis",
+        "Documentation",
+        "Validation",
+        "Verification",
+        "Management",
+        "operation_id -> prompt_id@version",
+        "kb/operation-prompt-mapping/registry.json",
+        "applied_operations",
+        "applied_prompts",
+        "research -> rfc/adr -> standard -> artifact",
+        "does not implement",
+    )
+    for fragment in required_fragments:
+        require(fragment in text, f"{RFC}: missing required fragment {fragment!r}")
+
+    problems = set(re.findall(r"RFC-243-P[0-9]+", text))
+    proposals = set(re.findall(r"RFC-243-R[0-9]+", text))
+    require(len(problems) >= 6, f"{RFC}: expected at least 6 problem IDs, found {len(problems)}")
+    require(len(proposals) >= 7, f"{RFC}: expected at least 7 proposal IDs, found {len(proposals)}")
+
+    require(
+        not (ROOT / "kb/operation-prompt-mapping/registry.json").exists(),
+        "issue #243 must not implement kb/operation-prompt-mapping/registry.json",
+    )
+
+
+def validate_backlog() -> None:
+    text = read_text(BACKLOG)
+    marker = "## Спринт RFC-243"
+    require(marker in text, f"{BACKLOG}: missing sprint section {marker!r}")
+    sprint = text[text.index(marker) :]
+
+    required_fragments = (
+        "Issue #243",
+        "| № | Title | Type | Priority | Dependencies | Issue in repo |",
+        "Волна 0",
+        "Волна 1",
+        "Волна 2",
+        "Волна 3",
+        "independent",
+        "dependent",
+        "priority:P1",
+        "type:implementation",
+        "type:decision",
+        "type:research",
+        "sprint-3",
+        "decision: зафиксировать RFC-243",
+        "implementation: создать L2-реестр operation-prompt mapping",
+        "implementation: сверить 00-index.md",
+        "implementation: обновить БА-онтологию",
+        "implementation: добавить applied_operations",
+        "implementation: добавить applied_prompts",
+        "implementation: обновить валидаторы",
+        "research: оценить eTOM/SID",
+    )
+    for fragment in required_fragments:
+        require(fragment in sprint, f"{BACKLOG}: sprint section missing {fragment!r}")
+
+    issue_links = set(
+        re.findall(
+            r"https://github\.com/(?:G-Ivan-A/mango_ba_prompts|konard/G-Ivan-A-mango_ba_prompts)/issues/[0-9]+",
+            sprint,
+        )
+    )
+    require(len(issue_links) >= 8, f"{BACKLOG}: expected at least 8 issue links, found {len(issue_links)}")
+
+
+def validate_register() -> None:
+    text = read_text(REGISTER)
+    required_fragments = (
+        "RFC-243",
+        RFC.as_posix(),
+        "issue #243",
+        "docs/analysis/2026-06-25-runs-observability-research.md",
+        "docs/analysis/2026-06-25-bcreq-fr-contract-process-analysis.md",
+        "docs/analysis/2026-06-25-ba-processes-industry-analysis.md",
+    )
+    for fragment in required_fragments:
+        require(fragment in text, f"{REGISTER}: missing {fragment!r}")
+
+
+def validate_project_hooks() -> None:
+    changelog = read_text(CHANGELOG)
+    for fragment in (
+        "Issue #243",
+        RFC.as_posix(),
+        BACKLOG.as_posix(),
+        VALIDATOR.as_posix(),
+        "только proposal",
+    ):
+        require(fragment in changelog, f"{CHANGELOG}: missing {fragment!r}")
+
+    workflow = read_text(WORKFLOW)
+    require(
+        "Validate issue #243 BA-processes observability RFC" in workflow,
+        f"{WORKFLOW}: missing validation step name",
+    )
+    require(VALIDATOR.as_posix() in workflow, f"{WORKFLOW}: missing validator path")
+
+
+def main() -> None:
+    validate_rfc()
+    validate_backlog()
+    validate_register()
+    validate_project_hooks()
+    print("OK: issue #243 RFC and sprint deliverables validated")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fixes https://github.com/G-Ivan-A/mango_ba_prompts/issues/243.

This PR adds the L3 RFC draft for the BA-process/observability decision chain:

- `governance/rfc/ba-processes-observability-implementation-proposal.md` records the RFC-vs-ADR choice, atomic/composite BA artifact decisions, BCREQ-FR/BCREQ-SR type proposal, six BABOK operation layer, future `operation_id -> prompt_id@version` registry, and future `applied_operations` / `applied_prompts` fields.
- `governance/rfc-register.md` registers RFC-243 and links it back to A3, A4, and PR #234 research sources.
- `governance/BACKLOG.md` adds the RFC-243 implementation sprint with waves, priorities, dependencies, and issue links.
- `scripts/validate_issue_243_ba_processes_observability_rfc.py` validates the deliverables and is wired into the GitHub Pages workflow.

The RFC is proposal-only. It does not implement standards, contracts, prompts, runs, product artifacts, or `kb/operation-prompt-mapping/registry.json`.

## Sprint tracking issues

The token used for this PR has `READ` permission on upstream `G-Ivan-A/mango_ba_prompts`, so upstream issue/label creation failed with GitHub 404. I created the required labels and sprint tracking issues in the fork instead so maintainers can transfer/recreate them upstream if needed:

- https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/1
- https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/2
- https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/3
- https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/4
- https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/5
- https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/6
- https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/7
- https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/8

## Reproduction

Before adding the RFC/backlog/register artifacts, the new regression validator failed with:

```text
FAIL: missing file: governance/rfc/ba-processes-observability-implementation-proposal.md
```

## Verification

- `node scripts/generate-pages-data.mjs`
- `python3 scripts/validate_issue_243_ba_processes_observability_rfc.py`
- All Python validators from `.github/workflows/github-pages.yml` passed locally; log saved at `/tmp/issue-243-github-pages-validators.log`.