### PR TITLE
docs: rewrite RFC-243 as readable Markdown

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Validate issue #243 BA-processes observability RFC
         run: python3 scripts/validate_issue_243_ba_processes_observability_rfc.py
 
+      - name: Validate issue #245 RFC-243 Markdown format
+        run: python3 scripts/validate_issue_245_rfc_243_markdown_format.py
+
       - name: Validate issue #199 BCREQ-1027 section 4.3 API methods
         run: python3 scripts/validate_issue_199_bcreq_1027_section_4_3.py
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-25T21:02:30.564Z for PR creation at branch issue-245-6ca494060ac8 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/245

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-25T21:02:30.564Z for PR creation at branch issue-245-6ca494060ac8 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/245

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ ai-generated: true
 
 ## Unreleased
 
+### Changed — Issue #245 формат RFC-243
+
+- Переписан
+  [`governance/rfc/ba-processes-observability-implementation-proposal.md`](governance/rfc/ba-processes-observability-implementation-proposal.md)
+  из YAML-heavy тела в читаемый L3 RFC: Markdown + YAML frontmatter, с compact
+  machine-readable вставками только для traceability, impact, implementation
+  plan и canonical criteria.
+- Зафиксирована Причина нарушения формата: первичная версия RFC ошибочно
+  интерпретировала `machine_readable_shape`/`yaml_blocks_required` из L1
+  [`governance/rfc-generation-contract.md`](governance/rfc-generation-contract.md)
+  как требование писать каждый раздел L3 RFC в YAML.
+- Обновлён регрессионный валидатор
+  [`scripts/validate_issue_243_ba_processes_observability_rfc.py`](scripts/validate_issue_243_ba_processes_observability_rfc.py),
+  чтобы он проверял сохранение согласованных решений 1-5 без закрепления
+  ошибочного YAML-heavy формата.
+- Добавлен валидатор
+  [`scripts/validate_issue_245_rfc_243_markdown_format.py`](scripts/validate_issue_245_rfc_243_markdown_format.py),
+  подключённый к GitHub Pages workflow.
+
 ### Added — Issue #243 RFC по БА-процессам и observability
 
 - Добавлен L3 RFC proposal

--- a/governance/rfc/ba-processes-observability-implementation-proposal.md
+++ b/governance/rfc/ba-processes-observability-implementation-proposal.md
@@ -1,7 +1,7 @@
 ---
 id: RFC-243
 status: draft
-title: "RFC-243: BA process and observability implementation proposal"
+title: "RFC-243: предложение по БА-процессам и observability"
 author: "OpenAI Codex"
 created: 2026-06-25
 updated: 2026-06-25
@@ -25,363 +25,200 @@ target_artifacts:
   - "runs/stats/by-type.md"
 ---
 
-# RFC-243: BA process and observability implementation proposal
+# RFC-243: предложение по БА-процессам и observability
 
-This RFC records the agreed decisions from the BA-process and observability
-research chain. It is a proposal only: it does not implement standards,
-contracts, prompt mappings, run metadata, or existing BA artifacts.
+Статус этого документа - `draft`. RFC-243 является предложением, а не
+реализацией: он не меняет стандарты, контракты, prompt assets, run metadata,
+продуктовые документы или `kb/operation-prompt-mapping/registry.json`.
 
 ## 1. Context and motivation
 
-```yaml
-context:
-  source_issue: "https://github.com/G-Ivan-A/mango_ba_prompts/issues/243"
-  source_pr: "https://github.com/G-Ivan-A/mango_ba_prompts/pull/244"
-  chain: "research -> rfc/adr -> standard -> artifact"
-  proposal_scope: "L3 governance proposal for later standard and artifact changes"
-  product_docs: "not_applicable"
-  source_refs:
-    - id: A3
-      path: "docs/analysis/2026-06-25-runs-observability-research.md"
-      signal: "Runs lack prompt-level observability, versioning, lineage, and prompt-to-rule mapping."
-    - id: A4
-      path: "docs/analysis/2026-06-25-bcreq-fr-contract-process-analysis.md"
-      signal: "BCREQ-FR is applied as a monolithic contract because L1 contracts are not linked to operation/prompt mappings."
-    - id: A5
-      path: "docs/analysis/2026-06-25-ba-processes-industry-analysis.md"
-      source_pr: "https://github.com/G-Ivan-A/mango_ba_prompts/pull/234"
-      signal: "The project model matches industry practice but needs explicit atomic/composite taxonomy, API spec, RTM, and BABOK operation alignment."
-    - id: BA_PROCESS_INDEX
-      path: "docs/ba-processes/00-index.md"
-      signal: "Current BA process map has nine processes, thirteen operations, and prompt chains."
-    - id: BA_PROCESS_EXECUTABLE
-      path: "docs/ba-processes/00-index.executable.md"
-      signal: "Executable companion for machine-readable process navigation."
-    - id: BCREQ_FR_CONTRACT
-      path: "governance/bcreq-fr-generation-contract.md"
-      signal: "L1 generation contract exists but does not declare applied operations."
-    - id: RUNS_CONTRACT
-      path: "runs/CONTRACT.md"
-      signal: "Run metadata contract exists but does not declare applied prompts or prompt lineage."
-    - id: EXECUTABLE_CONTRACT_STANDARD
-      path: "standards/executable-contract-standard.md"
-      signal: "L1 contracts are self-contained; reusable mappings belong in L2 registries, not runtime-only L3 prose."
-    - id: RFC_GENERATION_CONTRACT
-      path: "governance/rfc-generation-contract.md"
-      signal: "RFC artifacts must be L3 proposals with explicit problem, proposal, impact, and canonical criteria."
-  permission_note:
-    upstream_permission: "READ"
-    fork_permission: "ADMIN"
-    fork_tracking_issues:
-      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/1"
-      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/2"
-      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/3"
-      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/4"
-      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/5"
-      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/6"
-      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/7"
-      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/8"
-```
+Issue [#243](https://github.com/G-Ivan-A/mango_ba_prompts/issues/243) попросил
+зафиксировать согласованные решения из цепочки исследований
+`research -> rfc/adr -> standard -> artifact` и подготовить спринт дальнейшей
+реализации. Входами для RFC являются:
+
+- A3:
+  [`docs/analysis/2026-06-25-runs-observability-research.md`](../../docs/analysis/2026-06-25-runs-observability-research.md)
+  - исследование трассируемости prompt usage, версий и lineage в `runs/`.
+- A4:
+  [`docs/analysis/2026-06-25-bcreq-fr-contract-process-analysis.md`](../../docs/analysis/2026-06-25-bcreq-fr-contract-process-analysis.md)
+  - анализ применения BCREQ-FR как монолитного L1-контракта вместо
+  последовательности операций.
+- PR #234:
+  [`docs/analysis/2026-06-25-ba-processes-industry-analysis.md`](../../docs/analysis/2026-06-25-ba-processes-industry-analysis.md)
+  - анализ BA-процессов, артефактов и индустриальных практик
+  (<https://github.com/G-Ivan-A/mango_ba_prompts/pull/234>).
+- Текущие артефакты процесса:
+  [`docs/ba-processes/00-index.md`](../../docs/ba-processes/00-index.md),
+  [`docs/ba-processes/00-index.executable.md`](../../docs/ba-processes/00-index.executable.md),
+  [`governance/bcreq-fr-generation-contract.md`](../bcreq-fr-generation-contract.md),
+  [`runs/CONTRACT.md`](../../runs/CONTRACT.md) и
+  [`standards/executable-contract-standard.md`](../../standards/executable-contract-standard.md).
+
+Product docs для этого RFC не применяются: предложение меняет governance,
+таксономию БА-артефактов, mapping и observability, но не описывает поведение
+конкретного продукта Mango.
 
 ### Почему RFC, а не ADR
 
-The artifact type is RFC, not ADR, because issue #243 asks to propose a coherent
-governance and implementation path across process documentation, standards, L1
-contracts, L2 registry data, and run metadata. The decision is not yet an
-accepted architecture record; it is a reviewable proposal that must become
-canonical before downstream implementation. An ADR would be appropriate only if
-a human reviewer needs to record a final architecture choice after RFC review.
+RFC выбран потому, что задача формулирует проектное предложение "что изменить":
+процессную карту, BA ontology, будущий L2 registry, поля контрактов и поля run
+metadata. ADR нужен после review, если человек принимает архитектурное решение
+или необратимую границу владения. Пока это не принятое решение, а проверяемое
+предложение.
+
+### Причина нарушения формата в PR #244
+
+Причина нарушения формата: первичная версия RFC прочитала
+`machine_readable_shape` и `yaml_blocks_required` из L1-контракта
+[`governance/rfc-generation-contract.md`](../rfc-generation-contract.md) как
+требование писать каждый раздел L3 RFC в YAML. Это была ошибка интерпретации:
+L1-контракт описывает проверяемую структуру, но L3 RFC должен быть
+Markdown-документом с YAML frontmatter. Машиночитаемые вставки нужны для
+трассируемости и validation checks; они не должны заменять человеческий текст
+RFC.
+
+Исправленная версия сохраняет YAML только как compact machine-readable inserts:
+traceability index, impact, implementation plan и canonical criteria. Контекст,
+проблемы, предложение, альтернативы и rationale читаются как обычный Markdown.
 
 ## 2. Problem
 
-```yaml
-problems:
-  - id: RFC-243-P1
-    title: "Research decisions are not fixed in an RFC/ADR artifact."
-    source_refs:
-      - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/243"
-      - "docs/analysis/2026-06-25-runs-observability-research.md"
-      - "docs/analysis/2026-06-25-bcreq-fr-contract-process-analysis.md"
-      - "docs/analysis/2026-06-25-ba-processes-industry-analysis.md"
-    effect: "The chain research -> rfc/adr -> standard -> artifact is blocked."
-  - id: RFC-243-P2
-    title: "Atomic and composite BA artifact taxonomy is not canonical."
-    source_refs:
-      - "docs/analysis/2026-06-25-ba-processes-industry-analysis.md"
-      - "standards/ba-ontology.md"
-    effect: "API specification, RTM entry, FRD/SRS distinction, and BCREQ type semantics remain ambiguous."
-  - id: RFC-243-P3
-    title: "Operation hierarchy is mixed with implementation-level decomposition."
-    source_refs:
-      - "docs/ba-processes/00-index.md"
-      - "docs/analysis/2026-06-25-ba-processes-industry-analysis.md"
-    effect: "The project has useful thirteen-operation detail but lacks a first-class six-operation BABOK-compatible layer."
-  - id: RFC-243-P4
-    title: "Contracts cannot declare which BA operations they execute."
-    source_refs:
-      - "docs/analysis/2026-06-25-bcreq-fr-contract-process-analysis.md"
-      - "governance/bcreq-fr-generation-contract.md"
-    effect: "BCREQ-FR remains a monolithic contract application instead of a traceable operation sequence."
-  - id: RFC-243-P5
-    title: "Runs cannot record applied prompt versions and lineage."
-    source_refs:
-      - "docs/analysis/2026-06-25-runs-observability-research.md"
-      - "runs/CONTRACT.md"
-    effect: "It is not possible to reconstruct prompt_id, version, model settings, prompt result, or previous_run_id from run metadata."
-  - id: RFC-243-P6
-    title: "Migration conflicts are not staged as issue-backed implementation work."
-    source_refs:
-      - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/243"
-      - "governance/BACKLOG.md"
-    effect: "Without a sprint backlog, later implementation may change standards and artifacts out of order."
-```
+| ID | Проблема | Источник | Последствие |
+| --- | --- | --- | --- |
+| `RFC-243-P1` | Решения из A3/A4/PR #234 не закреплены в RFC/ADR-артефакте. | Issue #243; A3; A4; PR #234 | Цепочка `research -> rfc/adr -> standard -> artifact` заблокирована. |
+| `RFC-243-P2` | Atomic/composite taxonomy для BA artifacts не является canonical. | PR #234; `standards/ba-ontology.md` | API specification, RTM entry, FRD/SRS и BCREQ type semantics остаются неоднозначными. |
+| `RFC-243-P3` | Верхний уровень операций смешан с проектной декомпозицией. | `docs/ba-processes/00-index.md`; PR #234 | Текущие 13 операций полезны, но не дают первого BABOK-compatible слоя. |
+| `RFC-243-P4` | L1-контракты не декларируют, какие BA operations они исполняют. | A4; `governance/bcreq-fr-generation-contract.md` | BCREQ-FR выглядит как монолит, а не как traceable operation sequence. |
+| `RFC-243-P5` | Runs не фиксируют prompt_id, prompt version, model settings, result и previous_run_id. | A3; `runs/CONTRACT.md` | Нельзя восстановить prompt lineage и объяснить различия между проходами. |
+| `RFC-243-P6` | Реализация не разбита на issue-backed sprint с зависимостями. | Issue #243; `governance/BACKLOG.md` | Стандарты, контракты и статистика могут изменяться вне правильного порядка. |
+| `RFC-243-P7` | Первая версия RFC была YAML-heavy и плохо читалась человеком. | Issue #245; `governance/rfc-generation-contract.md` | L3 proposal стал похож на L1 contract и нарушил требование "Markdown with YAML frontmatter". |
 
 ## 3. Proposal
 
+RFC-243 фиксирует согласованные решения 1-5 из issue #243 и добавляет
+implementation boundary: этот PR только оформляет proposal, а downstream changes
+идут отдельными задачами после review.
+
+| ID | Предложение | Покрывает |
+| --- | --- | --- |
+| `RFC-243-R1` | Оставить RFC-243 L3 RFC draft до human review; ADR создавать только если reviewer просит зафиксировать принятое архитектурное решение. | `RFC-243-P1` |
+| `RFC-243-R2` | Принять atomic BA artifacts: Singular requirement, User Story, Use Case, Business Rule, Glossary term, API specification (OpenAPI/TMF Open API), RTM entry. Атомар = один источник, один владелец, одна проверка. | `RFC-243-P2` |
+| `RFC-243-R3` | Принять composite artifacts: BRD, FRD/SRS, RFP Response/Bid Requirements. Классифицировать BCREQ-FR как `type: frd`, BCREQ-SR как `type: srs`. | `RFC-243-P2` |
+| `RFC-243-R4` | Принять 6 BABOK-compatible operations как верхний слой: Elicitation, Analysis, Documentation, Validation, Verification, Management. Текущие 13 операций оставить project-specific suboperations. | `RFC-243-P3` |
+| `RFC-243-R5` | Ввести L2 registry `kb/operation-prompt-mapping/registry.json` с key edge `operation_id -> prompt_id@version`. | `RFC-243-P4`, `RFC-243-P5` |
+| `RFC-243-R6` | В будущих миграциях добавить `applied_operations` в generation contracts, `applied_prompts` и `previous_run_id` в runs. | `RFC-243-P4`, `RFC-243-P5` |
+| `RFC-243-R7` | Реализовывать в порядке: сверка `00-index.md`, затем BA ontology, затем L2 registry, затем поля L1 contracts и runs. | `RFC-243-P6` |
+| `RFC-243-R8` | Вести внедрение через issue-backed sprint backlog с волнами, priorities и dependencies. | `RFC-243-P6` |
+| `RFC-243-R9` | Сохранить формат RFC как readable Markdown with YAML frontmatter; YAML в теле использовать только для compact machine-readable inserts. | `RFC-243-P7` |
+
+Машиночитаемая вставка ниже нужна для проверки связей proposal -> problem и
+target artifacts. Она не заменяет таблицу предложений.
+
 ```yaml
-proposal:
-  RFC-243-R1:
-    title: "Use RFC as the decision artifact."
-    decision: "RFC-243 remains an L3 RFC draft until human review moves it to canonical, rejects it, or asks for an ADR."
-    rationale: "The proposal coordinates several downstream artifacts and standards; it is not an already accepted architecture decision."
-  RFC-243-R2:
-    title: "Fix atomic BA artifacts as one-source/one-owner/one-check units."
-    atomic_artifacts:
-      - "Singular requirement"
-      - "User Story"
-      - "Use Case"
-      - "Business Rule"
-      - "Glossary term"
-      - "API specification (OpenAPI/TMF Open API)"
-      - "RTM entry"
-    atomic_definition: "One source, one owner, one check."
-  RFC-243-R3:
-    title: "Fix composite BA artifacts as aggregates of atomic artifacts."
-    composite_artifacts:
-      - "BRD"
-      - "FRD/SRS"
-      - "RFP Response/Bid Requirements"
-    classification:
-      BCREQ-FR: "`type: frd`"
-      BCREQ-SR: "`type: srs`"
-    composite_definition: "Aggregation of atomics plus structure and traceability."
-  RFC-243-R4:
-    title: "Adopt six BABOK-compatible operations as the top-level operation layer."
-    operations:
-      - "Elicitation"
-      - "Analysis"
-      - "Documentation"
-      - "Validation"
-      - "Verification"
-      - "Management"
-    decomposition_rule: "Existing thirteen operations remain as project-specific decomposition/suboperations."
-  RFC-243-R5:
-    title: "Introduce an L2 operation-prompt mapping registry."
-    target: "kb/operation-prompt-mapping/registry.json"
-    key_edge: "operation_id -> prompt_id@version"
-    minimum_fields:
-      - "operation_id"
-      - "prompt_id"
-      - "prompt_version"
-      - "source_process"
-      - "artifact_scope"
-      - "contract_rule_refs"
-      - "owner"
-  RFC-243-R6:
-    title: "Add operation and prompt trace fields in later contract/run migrations."
-    contract_field: "applied_operations"
-    run_field: "applied_prompts"
-    lineage_field: "previous_run_id"
-    boundary: "Contracts reference operation IDs; runs record prompt IDs and versions used during execution."
-  RFC-243-R7:
-    title: "Reconcile process documentation before implementation."
-    order:
-      - "First reconcile docs/ba-processes/00-index.md with the industry-normal six-operation layer."
-      - "Then update ontology/standards for atomic/composite artifacts."
-      - "Then implement the L2 registry and L1/run metadata fields."
-    reason: "The implementation proposal depends on process-model reconciliation."
-  RFC-243-R8:
-    title: "Use an issue-backed sprint backlog."
-    backlog: "governance/BACKLOG.md#спринт-rfc-243"
-    upstream_issue: "https://github.com/G-Ivan-A/mango_ba_prompts/issues/243"
-    fork_tracking_issues:
-      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/1"
-      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/2"
-      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/3"
-      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/4"
-      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/5"
-      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/6"
-      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/7"
-      - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/8"
+proposal_traceability:
+  RFC-243-R1: {problem_ids: [RFC-243-P1], target_artifacts: ["governance/rfc/ba-processes-observability-implementation-proposal.md"]}
+  RFC-243-R2: {problem_ids: [RFC-243-P2], target_artifacts: ["standards/ba-ontology.md"]}
+  RFC-243-R3: {problem_ids: [RFC-243-P2], target_artifacts: ["standards/ba-ontology.md", "governance/bcreq-fr-generation-contract.md"]}
+  RFC-243-R4: {problem_ids: [RFC-243-P3], target_artifacts: ["docs/ba-processes/00-index.md", "docs/ba-processes/00-index.executable.md"]}
+  RFC-243-R5: {problem_ids: [RFC-243-P4, RFC-243-P5], target_artifacts: ["kb/operation-prompt-mapping/registry.json"]}
+  RFC-243-R6: {problem_ids: [RFC-243-P4, RFC-243-P5], target_artifacts: ["governance/bcreq-fr-generation-contract.md", "runs/CONTRACT.md"]}
+  RFC-243-R7: {problem_ids: [RFC-243-P6], target_artifacts: ["governance/BACKLOG.md"]}
+  RFC-243-R8: {problem_ids: [RFC-243-P6], target_artifacts: ["governance/BACKLOG.md"]}
+  RFC-243-R9: {problem_ids: [RFC-243-P7], target_artifacts: ["governance/rfc/ba-processes-observability-implementation-proposal.md"]}
 ```
 
 ## 4. Alternatives considered
 
-```yaml
-alternatives:
-  - id: RFC-243-A1
-    title: "Write an ADR immediately."
-    outcome: "rejected_for_now"
-    reason: "The work is still a proposal across several governance surfaces; an ADR would prematurely record an accepted architecture decision."
-  - id: RFC-243-A2
-    title: "Implement standards and contracts directly in issue #243."
-    outcome: "rejected"
-    reason: "Issue #243 explicitly requires documentation and a sprint proposal, not implementation of standards, contracts, runs, prompts, or existing artifacts."
-  - id: RFC-243-A3
-    title: "Keep operation-to-prompt mapping only in docs/ba-processes/00-index.md."
-    outcome: "rejected"
-    reason: "Prose is useful for navigation but cannot safely serve L1 contracts and run validators as an L2 registry."
-  - id: RFC-243-A4
-    title: "Embed prompt mapping directly in each L1 contract."
-    outcome: "rejected"
-    reason: "This duplicates prompt mappings, increases drift, and conflicts with the L1 self-contained contract plus L2 reusable-data boundary."
-```
+| ID | Альтернатива | Решение | Причина |
+| --- | --- | --- | --- |
+| `RFC-243-A1` | Сразу написать ADR. | Not selected. | Issue #243 требует proposal across governance surfaces; ADR преждевременно фиксирует accepted decision. |
+| `RFC-243-A2` | Реализовать стандарты и контракты прямо в issue #243. | Not selected. | Issue #243 явно запрещает implementation до согласования RFC/ADR. |
+| `RFC-243-A3` | Оставить mapping process -> operation -> prompt только в `00-index.md`. | Not selected. | Prose удобен для навигации, но не подходит как L2 registry для validators и run metadata. |
+| `RFC-243-A4` | Встроить prompt mapping в каждый L1 contract. | Not selected. | Это дублирует mapping, усиливает drift и нарушает границу L1 self-contained contract + L2 reusable data. |
+| `RFC-243-A5` | Оставить RFC-243 в YAML-heavy форме. | Rejected. | Issue #245 подтвердил, что такой формат плохо читается и смешивает L1 contract style с L3 RFC style. |
 
 ## 5. Rationale
 
-```yaml
-rationale:
-  source_traceability:
-    - "A3 supports RFC-243-R5 and RFC-243-R6: prompt observability requires prompt IDs, prompt versions, and lineage in runs."
-    - "A4 supports RFC-243-R5 and RFC-243-R6: contract application needs an operation layer before prompt-level execution can be audited."
-    - "PR #234 / A5 supports RFC-243-R2, RFC-243-R3, and RFC-243-R4: industry practice separates atomic artifacts, composite documents, and top-level BA operations."
-  boundary_rules:
-    - "RFC-243 is L3 governance and does not implement L1/L2 artifacts."
-    - "L2 registry data is the right home for operation_id -> prompt_id@version because it is reusable by contracts, runs, and validators."
-    - "L1 contracts should reference applied_operations, while runs should record applied_prompts with concrete prompt versions."
-  migration_order:
-    - "The process index must be reconciled before generated contracts can safely reference operation IDs."
-    - "The artifact ontology must define atomic/composite/API/RTM semantics before BCREQ-FR and BCREQ-SR type fields can be migrated."
-    - "Run observability should follow the registry and contract-field changes so validators can check real references."
-```
+A3 показывает, что run observability требует prompt IDs, версий, lineage и
+связи с результатом. Поэтому `RFC-243-R5` и `RFC-243-R6` вводят registry и поля
+execution metadata, но не создают их в этом PR.
+
+A4 показывает, что BCREQ-FR применяется как крупный L1-монолит. Чтобы сделать
+его traceable, контракту нужен уровень applied BA operations, а конкретные
+prompt versions должны фиксироваться на уровне run.
+
+PR #234 показывает, что индустриальная модель различает atomic artifacts,
+composite documents и top-level BA operations. Поэтому `RFC-243-R2`,
+`RFC-243-R3` и `RFC-243-R4` не заменяют текущие 13 операций, а вводят над ними
+совместимый верхний слой.
+
+Порядок из `RFC-243-R7` нужен потому, что contracts и runs не должны ссылаться
+на operation IDs до того, как процессная карта и BA ontology дадут этим IDs
+устойчивый смысл.
+
+Форматная правка `RFC-243-R9` нужна потому, что L3 RFC служит review artifact.
+Машиночитаемые блоки остаются только там, где они дают проверяемую
+трассируемость: proposal links, impact, implementation plan и canonical
+criteria.
 
 ## 6. Impact
+
+RFC-243 не требует ADR сейчас, потому что не принимает архитектурное решение.
+Он требует будущих standard/contract changes, если станет canonical: изменятся
+BA ontology, process documentation, mapping registry, generation contract fields
+и run metadata rules. Переходные правила RFC -> ADR или RFC -> standard этот
+документ не определяет.
 
 ```yaml
 impact:
   requires_adr: false
-  adr_reason: "This RFC is the reviewable proposal. No irreversible architecture decision is accepted in this PR."
+  adr_reason: "RFC-243 is a reviewable proposal; no irreversible architecture decision is accepted here."
   requires_standard: true
-  standard_reason: "Later implementation will need normative updates to BA ontology, process documentation, contract fields, and run metadata rules."
-  target_artifacts:
-    - "docs/ba-processes/00-index.md"
-    - "docs/ba-processes/00-index.executable.md"
-    - "standards/ba-ontology.md"
-    - "governance/bcreq-fr-generation-contract.md"
-    - "runs/CONTRACT.md"
-    - "kb/operation-prompt-mapping/registry.json"
-    - "runs/REGISTRY.md"
-    - "runs/stats/by-process.md"
-    - "runs/stats/by-type.md"
-  conflicts:
-    - id: RFC-243-C1
-      description: "`type: contract` is overloaded in some L3-adjacent artifacts and must not be reused for BCREQ-FR/BCREQ-SR document type classification."
-      migration: "Audit and migrate metadata only in dedicated implementation issues."
-    - id: RFC-243-C2
-      description: "Existing thirteen operations are valuable detail but not the canonical top-level operation set."
-      migration: "Preserve them as suboperations when adding the six-operation layer."
-    - id: RFC-243-C3
-      description: "Current runs do not contain prompt lineage."
-      migration: "Add new optional fields first; backfill only when evidence exists."
-  non_implementation_guards:
-    - "This RFC does not implement kb/operation-prompt-mapping/registry.json."
-    - "This RFC does not change standards/ba-ontology.md."
-    - "This RFC does not change governance/bcreq-fr-generation-contract.md."
-    - "This RFC does not change runs/CONTRACT.md."
+  standard_reason: "Canonical RFC-243 requires later normative updates to BA ontology, process docs, contract fields, registry data, and run metadata."
+  target_artifacts: ["docs/ba-processes/00-index.md", "docs/ba-processes/00-index.executable.md", "standards/ba-ontology.md", "governance/bcreq-fr-generation-contract.md", "runs/CONTRACT.md", "kb/operation-prompt-mapping/registry.json", "runs/REGISTRY.md", "runs/stats/by-process.md", "runs/stats/by-type.md"]
+  affected_contracts: ["governance/bcreq-fr-generation-contract.md", "runs/CONTRACT.md"]
+  migration_or_backfill: ["Add new metadata fields before backfill.", "Backfill prompt lineage only when source evidence exists."]
+  risks: ["13-operation map can be misread as replaced.", "`type: contract` must not be reused for BCREQ-FR/BCREQ-SR document type classification.", "Fork tracking issues may need upstream recreation."]
 ```
 
 ## 7. Implementation plan
 
+План ниже не выполняется в этом PR. Он задает порядок downstream work после
+review. Fork issue URLs сохранены из PR #244, потому что upstream issue/label
+creation был заблокирован правами токена.
+
 ```yaml
 implementation_plan:
   status: "proposal_only"
-  waves:
-    - wave: 0
-      title: "Decision gate"
-      tasks:
-        - title: "decision: зафиксировать RFC-243 governance proposal"
-          issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/1"
-          type: "decision"
-          priority: "P1"
-          dependency_mode: "independent"
-    - wave: 1
-      title: "Process and taxonomy reconciliation"
-      tasks:
-        - title: "implementation: сверить 00-index.md с BABOK-операциями"
-          issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/3"
-          type: "implementation"
-          priority: "P1"
-          dependency_mode: "dependent"
-          depends_on:
-            - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/1"
-        - title: "implementation: обновить БА-онтологию для atomic-composite taxonomy"
-          issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/4"
-          type: "implementation"
-          priority: "P1"
-          dependency_mode: "dependent"
-          depends_on:
-            - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/1"
-            - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/3"
-    - wave: 2
-      title: "Mapping and execution metadata"
-      tasks:
-        - title: "implementation: создать L2-реестр operation-prompt mapping"
-          issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/2"
-          type: "implementation"
-          priority: "P1"
-          dependency_mode: "dependent"
-          depends_on:
-            - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/1"
-        - title: "implementation: добавить applied_operations в generation contracts"
-          issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/5"
-          type: "implementation"
-          priority: "P1"
-          dependency_mode: "dependent"
-          depends_on:
-            - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/2"
-            - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/3"
-        - title: "implementation: добавить applied_prompts и lineage в runs contract"
-          issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/6"
-          type: "implementation"
-          priority: "P1"
-          dependency_mode: "dependent"
-          depends_on:
-            - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/2"
-    - wave: 3
-      title: "Validation and domain follow-up"
-      tasks:
-        - title: "implementation: обновить валидаторы и статистику под трассируемость"
-          issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/7"
-          type: "implementation"
-          priority: "P2"
-          dependency_mode: "dependent"
-          depends_on:
-            - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/5"
-            - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/6"
-        - title: "research: оценить eTOM/SID как доменные БА-артефакты"
-          issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/8"
-          type: "research"
-          priority: "P3"
-          dependency_mode: "dependent"
-          depends_on:
-            - "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/4"
-  note: "The fork issue URLs are used because the current GitHub token cannot create upstream issues or labels."
+  steps:
+    - {id: RFC-243-STEP-1, wave: 0, action: "decision: зафиксировать RFC-243 governance proposal", issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/1", depends_on: []}
+    - {id: RFC-243-STEP-2, wave: 1, action: "implementation: сверить 00-index.md с BABOK-операциями", issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/3", depends_on: ["https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/1"]}
+    - {id: RFC-243-STEP-3, wave: 1, action: "implementation: обновить БА-онтологию для atomic-composite taxonomy", issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/4", depends_on: ["https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/1", "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/3"]}
+    - {id: RFC-243-STEP-4, wave: 2, action: "implementation: создать L2-реестр operation-prompt mapping", issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/2", depends_on: ["https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/1"]}
+    - {id: RFC-243-STEP-5, wave: 2, action: "implementation: добавить applied_operations в generation contracts", issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/5", depends_on: ["https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/2", "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/3"]}
+    - {id: RFC-243-STEP-6, wave: 2, action: "implementation: добавить applied_prompts и lineage в runs contract", issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/6", depends_on: ["https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/2"]}
+    - {id: RFC-243-STEP-7, wave: 3, action: "implementation: обновить валидаторы и статистику под трассируемость", issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/7", depends_on: ["https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/5", "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/6"]}
+    - {id: RFC-243-STEP-8, wave: 3, action: "research: оценить eTOM/SID как доменные БА-артефакты", issue: "https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/8", depends_on: ["https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/4"]}
+  validation:
+    - "python3 scripts/validate_issue_243_ba_processes_observability_rfc.py"
+    - "python3 scripts/validate_issue_245_rfc_243_markdown_format.py"
 ```
 
 ## 8. Canonical criteria
 
+Критерии ниже проверяют, что RFC можно переводить в canonical без скрытой
+реализации. Каждый критерий связан хотя бы с одним proposal ID.
+
 ```yaml
 canonical_criteria:
-  - id: RFC-243-CC1
-    criterion: "A human reviewer accepts RFC as the correct artifact type or explicitly requests ADR conversion."
-  - id: RFC-243-CC2
-    criterion: "Atomic and composite artifact decisions are accepted without changing standards in this PR."
-  - id: RFC-243-CC3
-    criterion: "The six-operation BABOK layer and thirteen-operation decomposition rule are accepted."
-  - id: RFC-243-CC4
-    criterion: "The operation_id -> prompt_id@version L2 registry is accepted as a future implementation target."
-  - id: RFC-243-CC5
-    criterion: "`applied_operations` for contracts and `applied_prompts` for runs are accepted as future migration fields."
-  - id: RFC-243-CC6
-    criterion: "The sprint backlog is accepted as the implementation sequence, with upstream issues recreated if maintainers require upstream tracking."
+  - {id: RFC-243-C1, statement: "Reviewer accepts RFC artifact type or requests ADR conversion.", verifies: [RFC-243-R1], check: "Manual review."}
+  - {id: RFC-243-C2, statement: "Atomic artifact set and definition are accepted.", verifies: [RFC-243-R2], check: "Review confirms atomic list."}
+  - {id: RFC-243-C3, statement: "Composite hierarchy and BCREQ-FR/BCREQ-SR classification are accepted.", verifies: [RFC-243-R3], check: "Review confirms document types."}
+  - {id: RFC-243-C4, statement: "Six-operation BABOK layer and 13-operation decomposition are accepted.", verifies: [RFC-243-R4], check: "Review confirms operation layer."}
+  - {id: RFC-243-C5, statement: "operation_id -> prompt_id@version registry is accepted as a future target.", verifies: [RFC-243-R5], check: "Review confirms registry path."}
+  - {id: RFC-243-C6, statement: "`applied_operations`, `applied_prompts`, and `previous_run_id` are accepted as future fields.", verifies: [RFC-243-R6], check: "Review confirms metadata boundary."}
+  - {id: RFC-243-C7, statement: "Sprint backlog order and issue-backed sequence are accepted.", verifies: [RFC-243-R7, RFC-243-R8], check: "Review confirms waves and dependencies."}
+  - {id: RFC-243-C8, statement: "RFC-243 remains readable Markdown with compact machine-readable inserts.", verifies: [RFC-243-R9], check: "python3 scripts/validate_issue_245_rfc_243_markdown_format.py"}
 ```

--- a/scripts/validate_issue_243_ba_processes_observability_rfc.py
+++ b/scripts/validate_issue_243_ba_processes_observability_rfc.py
@@ -68,7 +68,7 @@ def validate_rfc() -> None:
     frontmatter_needles = (
         "id: RFC-243",
         "status: draft",
-        'title: "RFC-243: BA process and observability implementation proposal"',
+        'title: "RFC-243: предложение по БА-процессам и observability"',
         'author: "OpenAI Codex"',
         "created: 2026-06-25",
         "updated: 2026-06-25",
@@ -88,21 +88,23 @@ def validate_rfc() -> None:
 
     require_ordered_sections(RFC, body)
 
-    required_yaml_keys = (
-        "context:",
-        "problems:",
-        "proposal:",
-        "alternatives:",
-        "rationale:",
+    required_machine_readable_inserts = (
+        "proposal_traceability:",
         "impact:",
         "implementation_plan:",
         "canonical_criteria:",
     )
-    for key in required_yaml_keys:
-        require(re.search(rf"(^|\n){re.escape(key)}", body), f"{RFC}: missing YAML key {key}")
+    for key in required_machine_readable_inserts:
+        require(
+            re.search(rf"(^|\n){re.escape(key)}", body),
+            f"{RFC}: missing machine-readable insert {key}",
+        )
 
     required_fragments = (
         "Почему RFC, а не ADR",
+        "Причина нарушения формата",
+        "machine_readable_shape",
+        "Markdown-документом с YAML frontmatter",
         "requires_adr: false",
         "requires_standard: true",
         "docs/analysis/2026-06-25-runs-observability-research.md",
@@ -139,7 +141,7 @@ def validate_rfc() -> None:
         "applied_operations",
         "applied_prompts",
         "research -> rfc/adr -> standard -> artifact",
-        "does not implement",
+        "не меняет стандарты",
     )
     for fragment in required_fragments:
         require(fragment in text, f"{RFC}: missing required fragment {fragment!r}")

--- a/scripts/validate_issue_245_rfc_243_markdown_format.py
+++ b/scripts/validate_issue_245_rfc_243_markdown_format.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Regression check for issue #245: RFC-243 must be readable Markdown."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+RFC = Path("governance/rfc/ba-processes-observability-implementation-proposal.md")
+ISSUE_243_VALIDATOR = Path("scripts/validate_issue_243_ba_processes_observability_rfc.py")
+VALIDATOR = Path("scripts/validate_issue_245_rfc_243_markdown_format.py")
+WORKFLOW = Path(".github/workflows/github-pages.yml")
+CHANGELOG = Path("CHANGELOG.md")
+
+REQUIRED_SECTIONS = (
+    "## 1. Context and motivation",
+    "## 2. Problem",
+    "## 3. Proposal",
+    "## 4. Alternatives considered",
+    "## 5. Rationale",
+    "## 6. Impact",
+    "## 7. Implementation plan",
+    "## 8. Canonical criteria",
+)
+
+REQUIRED_DECISION_FRAGMENTS = (
+    "Singular requirement",
+    "User Story",
+    "Use Case",
+    "Business Rule",
+    "Glossary term",
+    "API specification",
+    "OpenAPI/TMF Open API",
+    "RTM entry",
+    "BRD",
+    "FRD/SRS",
+    "RFP Response",
+    "BCREQ-FR",
+    "`type: frd`",
+    "BCREQ-SR",
+    "`type: srs`",
+    "Elicitation",
+    "Analysis",
+    "Documentation",
+    "Validation",
+    "Verification",
+    "Management",
+    "operation_id -> prompt_id@version",
+    "applied_operations",
+    "applied_prompts",
+)
+
+FORBIDDEN_BODY_YAML_KEYS = (
+    "context:",
+    "problems:",
+    "alternatives:",
+    "rationale:",
+)
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        fail(message)
+
+
+def read_text(path: Path) -> str:
+    full_path = ROOT / path
+    require(full_path.exists(), f"missing file: {path}")
+    return full_path.read_text(encoding="utf-8")
+
+
+def split_frontmatter(path: Path, text: str) -> tuple[str, str]:
+    require(text.startswith("---\n"), f"{path}: missing YAML frontmatter")
+    end = text.find("\n---", 4)
+    require(end != -1, f"{path}: unterminated YAML frontmatter")
+    return text[4:end].strip(), text[end + len("\n---") :].strip()
+
+
+def require_ordered_sections(path: Path, body: str) -> None:
+    previous = -1
+    for section in REQUIRED_SECTIONS:
+        current = body.find(section)
+        require(current != -1, f"{path}: missing section {section!r}")
+        require(current > previous, f"{path}: section order is invalid at {section!r}")
+        previous = current
+
+
+def fenced_yaml_ranges(body: str) -> list[tuple[int, int]]:
+    ranges: list[tuple[int, int]] = []
+    start = None
+    for index, line in enumerate(body.splitlines(), start=1):
+        if line.strip() == "```yaml":
+            require(start is None, f"{RFC}: nested YAML fence starts at body line {index}")
+            start = index
+            continue
+        if line.strip() == "```" and start is not None:
+            ranges.append((start, index))
+            start = None
+    require(start is None, f"{RFC}: unterminated YAML fence starting at body line {start}")
+    return ranges
+
+
+def line_after_heading_is_yaml(body: str, heading: str) -> bool:
+    lines = body.splitlines()
+    for index, line in enumerate(lines):
+        if line.strip() != heading:
+            continue
+        for next_line in lines[index + 1 :]:
+            if not next_line.strip():
+                continue
+            return next_line.strip() == "```yaml"
+    return False
+
+
+def validate_rfc_format() -> None:
+    text = read_text(RFC)
+    _frontmatter, body = split_frontmatter(RFC, text)
+    require_ordered_sections(RFC, body)
+
+    for fragment in REQUIRED_DECISION_FRAGMENTS:
+        require(fragment in text, f"{RFC}: missing agreed decision fragment {fragment!r}")
+
+    root_cause_fragments = (
+        "Причина нарушения формата",
+        "machine_readable_shape",
+        "L1",
+        "L3 RFC",
+        "YAML",
+        "Markdown",
+    )
+    for fragment in root_cause_fragments:
+        require(fragment in text, f"{RFC}: missing format root-cause fragment {fragment!r}")
+
+    ranges = fenced_yaml_ranges(body)
+    body_lines = body.splitlines()
+    yaml_line_count = sum(end - start + 1 for start, end in ranges)
+    yaml_ratio = yaml_line_count / max(len(body_lines), 1)
+    require(
+        yaml_ratio <= 0.45,
+        f"{RFC}: YAML fences dominate the body ({yaml_line_count}/{len(body_lines)} lines)",
+    )
+    require(len(ranges) <= 5, f"{RFC}: too many fenced YAML blocks ({len(ranges)} > 5)")
+
+    for heading in REQUIRED_SECTIONS[:6]:
+        require(
+            not line_after_heading_is_yaml(body, heading),
+            f"{RFC}: {heading!r} must start with readable Markdown, not YAML",
+        )
+
+    for key in FORBIDDEN_BODY_YAML_KEYS:
+        require(
+            not re.search(rf"```yaml\s*\n{re.escape(key)}", body),
+            f"{RFC}: body must not encode {key!r} as a top-level YAML block",
+        )
+
+    required_machine_readable_inserts = (
+        "proposal_traceability:",
+        "impact:",
+        "implementation_plan:",
+        "canonical_criteria:",
+    )
+    for key in required_machine_readable_inserts:
+        require(
+            re.search(rf"```yaml[\s\S]*\n{re.escape(key)}", body),
+            f"{RFC}: missing required machine-readable insert {key!r}",
+        )
+
+
+def validate_project_hooks() -> None:
+    workflow = read_text(WORKFLOW)
+    require(
+        "Validate issue #245 RFC-243 Markdown format" in workflow,
+        f"{WORKFLOW}: missing validation step name",
+    )
+    require(VALIDATOR.as_posix() in workflow, f"{WORKFLOW}: missing validator path")
+
+    changelog = read_text(CHANGELOG)
+    for fragment in (
+        "Issue #245",
+        RFC.as_posix(),
+        ISSUE_243_VALIDATOR.as_posix(),
+        VALIDATOR.as_posix(),
+        "Причина нарушения формата",
+    ):
+        require(fragment in changelog, f"{CHANGELOG}: missing {fragment!r}")
+
+
+def main() -> None:
+    validate_rfc_format()
+    validate_project_hooks()
+    print("OK: issue #245 RFC-243 Markdown format validated")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fixes https://github.com/G-Ivan-A/mango_ba_prompts/issues/245.

This PR corrects RFC-243 after PR #244 produced a YAML-heavy body instead of a readable L3 RFC:

- Rewrites `governance/rfc/ba-processes-observability-implementation-proposal.md` as Markdown + YAML frontmatter.
- Preserves the agreed decisions 1-5 from issue #243: atomic/composite BA artifacts, BCREQ-FR/BCREQ-SR type classification, six BABOK operations, `operation_id -> prompt_id@version`, and the implementation order.
- Records the root cause: the first version interpreted `machine_readable_shape` / `yaml_blocks_required` from the L1 RFC generation contract as a requirement to write every L3 RFC body section in YAML.
- Keeps compact machine-readable inserts only for traceability, impact, implementation plan, and canonical criteria.
- Updates the issue #243 validator and adds a new issue #245 validator to prevent the YAML-heavy RFC format from returning.

## Conflict Resolution

- Merged latest `upstream/main` (`de961241`, PR #249) into `issue-245-6ca494060ac8`.
- Resolved conflicts in `.github/workflows/github-pages.yml` and `CHANGELOG.md` by preserving both issue #245 and issue #247 validator/changelog entries.
- Confirmed the PR diff against `upstream/main` is still scoped to the RFC-243 Markdown-format fix.

## Reproduction

Before the rewrite, the new regression check failed against RFC-243:

```text
FAIL: governance/rfc/ba-processes-observability-implementation-proposal.md: missing format root-cause fragment 'Причина нарушения формата'
```

It also detects YAML-dominated RFC bodies by checking YAML block ratio, top-level YAML body keys, and section starts.

## Verification

- `node scripts/generate-pages-data.mjs`
- `python3 scripts/validate_issue_243_ba_processes_observability_rfc.py`
- `python3 scripts/validate_issue_245_rfc_243_markdown_format.py`
- `python3 scripts/validate_issue_247_backlog_contract.py`
- All 32 Python validators referenced by `.github/workflows/github-pages.yml` passed locally after the merge.
