### PR TITLE
governance: normalize BACKLOG.md

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Validate issue #243 BA-processes observability RFC
         run: python3 scripts/validate_issue_243_ba_processes_observability_rfc.py
 
+      - name: Validate issue #247 backlog contract
+        run: python3 scripts/validate_issue_247_backlog_contract.py
+
       - name: Validate issue #199 BCREQ-1027 section 4.3 API methods
         run: python3 scripts/validate_issue_199_bcreq_1027_section_4_3.py
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-25T21:04:54.820Z for PR creation at branch issue-247-566215827eab for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/247

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-25T21:04:54.820Z for PR creation at branch issue-247-566215827eab for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/247

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ ai-generated: true
 
 ## Unreleased
 
+### Changed — Issue #247 нормализация BACKLOG.md
+
+- Переписан [`governance/BACKLOG.md`](governance/BACKLOG.md) как единый
+  sprint backlog с явным контрактом: причина неконсистентности, **Индустриальная норма**
+  по GitHub Projects / Jira / Linear / Notion, формат строк, правила заполнения
+  и чтения.
+- Актуализированы статусы, зависимости и приоритеты `P1/P2/P3` для задач
+  миграции Фазы 1, открытых вопросов, RFC-243 implementation sprint и текущей
+  задачи обновления backlog; связанный
+  [`governance/migration-issues-registry.md`](governance/migration-issues-registry.md)
+  синхронизирован с закрытыми GitHub issues #28–#36.
+- Добавлен регрессионный валидатор
+  [`scripts/validate_issue_247_backlog_contract.py`](scripts/validate_issue_247_backlog_contract.py)
+  и обновлена проверка
+  [`scripts/validate_issue_243_ba_processes_observability_rfc.py`](scripts/validate_issue_243_ba_processes_observability_rfc.py)
+  под нормализованный формат backlog.
+
 ### Added — Issue #243 RFC по БА-процессам и observability
 
 - Добавлен L3 RFC proposal

--- a/governance/BACKLOG.md
+++ b/governance/BACKLOG.md
@@ -1,395 +1,209 @@
 ---
 status: draft
-version: 0.1
-updated: 2026-06-03
+version: 0.2
+updated: 2026-06-25
 ai-generated: true
 type: backlog
-scope: mango_ba_prompts-migration-execution
-based_on: "docs/analysis/2026-06-02-migration-strategy-rfc.md"
-human_review: "docs/reviews/migration-rfc-human-review-2026-06.md"
-issue: "https://github.com/G-Ivan-A/mango_ba_prompts/issues/14"
+title: "Backlog: Mango BA Prompts"
+scope: mango_ba_prompts-governance-and-execution
+primary_issue: "https://github.com/G-Ivan-A/mango_ba_prompts/issues/247"
 ---
 
-# BACKLOG: физическая миграция Mango из Хаба — Фаза 1
+# BACKLOG: Mango BA Prompts
 
-> 📋 **Это операционный план, а не реализация.** Документ разбивает утверждённую
-> стратегию [`docs/analysis/2026-06-02-migration-strategy-rfc.md`](../docs/analysis/2026-06-02-migration-strategy-rfc.md)
-> (v0.3, прошедшую Human Review —
-> [`docs/reviews/migration-rfc-human-review-2026-06.md`](../docs/reviews/migration-rfc-human-review-2026-06.md))
-> на атомарные задачи для физического переноса Фазы 1. Сам перенос **не
-> выполняется** в рамках этой задачи — здесь только формируется бэклог.
+This file is the operational backlog and the single tracker for open project
+questions. It does not implement product, governance, or run artifacts by
+itself; implementation happens in separate reviewable issues and pull requests.
 
-## 1. Введение
+## 1. Backlog contract
 
-### 1.1. Назначение
+### 1.1. Purpose
 
-Этот файл — **операционный план миграции Фазы 1** проекта Mango из Хаба
-(`hybrid-Intelligence-lab`, монорепо) в standalone-спок `mango_ba_prompts`.
-Бэклог переводит фазовую стратегию RFC (раздел §3 «Предлагаемая стратегия
-миграции») в исполняемый список атомарных задач: перенос стандартов, prompt
-assets и продуктовых экспериментов, нормализацию frontmatter и создание единого
-реестра зависимостей от исследований Хаба.
+`governance/BACKLOG.md` keeps work that is not yet better represented by a
+canonical standard, RFC, ADR, run artifact, or GitHub issue. A row may point to
+an issue, but the row remains useful because it shows the project-wide sequence,
+dependencies, and evidence in one place.
 
-**Источник истины** — утверждённый
-[`docs/analysis/2026-06-02-migration-strategy-rfc.md`](../docs/analysis/2026-06-02-migration-strategy-rfc.md).
-Бэклог не вводит новых решений: каждая задача трассируется на конкретный раздел
-RFC. Открытые вопросы Q1–Q4 (RFC §7) остаются на решение Пользователя и не
-переопределяются здесь.
+### 1.2. Root cause of inconsistency
 
-### 1.2. Принципы ведения бэклога
+**Причина неконсистентности:** the file started on 2026-06-03 as a Phase 1
+migration execution plan with detailed task narratives and local `P0/P1/P2`
+priorities. Later, open questions were appended as a checklist, and RFC-243
+added an implementation sprint as a compact issue table. Those additions were
+valid locally, but they used different units of work, fields, status semantics,
+and priority scales. The result was one backlog file with three formats:
+migration narrative, question checklist, and RFC sprint table.
 
-- **Одна задача = один атомарный артефакт или действие.** Задача завершается
-  созданием/изменением конкретного файла либо выполнением одного проверяемого
-  действия.
-- **Трассируемость.** Каждая задача ссылается на раздел RFC, который её
-  обосновывает.
-- **Anti-Inflation (RFC §1.2, P5).** Бэклог — один файл. Дополнительные
-  документы-планы не создаются; каталоги создаются только под реальный артефакт.
-- **Stop-factor.** Этот бэклог фиксирует *что* делать; *выполнение* задач
-  начинается отдельными reviewable PR после снятия открытых вопросов Q1–Q4.
+### 1.3. Industry baseline
 
-### 1.3. Условные обозначения
+**Индустриальная норма:** backlog tools separate the work item from the view.
+The durable item has structured metadata; sprint, board, roadmap, and question
+views are projections over the same item set.
 
-| Поле | Значение |
-| :--- | :--- |
-| **Приоритет** | `P0` — блокирует Фазу 1; `P1` — обязательно в Фазе 1, но не блокирует старт; `P2` — финализирующая часть Фазы 1. |
-| **Статус** | `TODO` / `IN PROGRESS` / `REVIEW` / `DONE`. На момент создания бэклога — все `TODO`. |
-| **Зависимости** | ID задач, которые должны быть `DONE` до старта данной. `—` — зависимостей нет. |
+- **GitHub Projects** treats a project as table, board, and roadmap over issues
+  and pull requests, with custom fields, filtering, grouping, roadmaps, and
+  automation:
+  <https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects>.
+  GitHub fields support metadata such as priority, effort, dates, iterations,
+  parent issues, and issue type:
+  <https://docs.github.com/en/issues/planning-and-tracking-with-projects/understanding-fields>.
+- **Jira Scrum backlog** groups work into backlog and sprints, supports ranking,
+  sprint assignment, epics, versions, estimates, parent, assignee, and priority:
+  <https://support.atlassian.com/jira-software-cloud/docs/use-your-scrum-backlog/>.
+  Jira dependency views model `blocks` / `is blocked by` relationships:
+  <https://support.atlassian.com/jira-software-cloud/docs/create-or-remove-dependencies-on-your-timeline/>.
+- **Linear cycles** are time-boxed sets of planned work:
+  <https://linear.app/docs/use-cycles>. Linear also groups backlog views by
+  status, assignee, project, priority, and cycle:
+  <https://linear.app/changelog/2022-05-26-combined-board-and-issue-view>.
+- **Notion roadmap databases** emphasize a living database that tracks
+  initiatives, dependencies, milestones, deliverables, stakeholders, metrics,
+  and links back to research and documents:
+  <https://www.notion.com/use-case/project-management/ai-product-roadmap>.
+  Notion Projects templates include sprints, dependencies, issue tracking, and
+  subtasks:
+  <https://www.notion.com/templates/collections/project-management>.
 
-## 2. Сводная таблица задач
+### 1.4. Project backlog format
 
-| ID | Название | Приоритет | Зависимости | Статус | Оценка |
-|----|----------|-----------|-------------|--------|--------|
-| M-001 | Переписать README.md спока | P0 | — | TODO | 1ч |
-| M-002 | Создать базовую структуру папок проекта | P0 | — | TODO | 30мин |
-| M-003 | Скопировать `standards/GLOSSARY.md` из Хаба | P0 | M-002 | TODO | 15мин |
-| M-004 | Перенести и переименовать `classification-glossary` → `standards/product-classification-contract.md` | P0 | M-002 | TODO | 30мин |
-| M-005 | Перенести эксперименты в `prompts/experiments/` | P0 | M-002 | TODO | 1ч |
-| M-006 | Нормализовать промпты (7 полей frontmatter) | P1 | M-002, M-003, M-004 | TODO | 3ч |
-| M-007 | Создать `docs/hub-research-dependencies.md` | P1 | M-006 | TODO | 1ч |
-| M-008 | Добавить временный workflow в `CONTRIBUTING.md` | P0 | — | TODO | 30мин |
-| M-009 | Создать Migration Manifest | P2 | M-006 | TODO | 30мин |
+The project keeps the Markdown backlog as the governance source of truth and
+uses GitHub issues as executable tracking records when a task needs discussion,
+labels, or independent PRs. This fits the current team size and traceability
+needs: one reviewer can read the entire dependency graph without opening a
+separate project-management tool, while issue links preserve audit trails.
 
-> Все 9 задач выведены из обязательных артефактов Фазы 1 (RFC §3.2, «Артефакты»)
-> и сопровождающих разделов §3.5, §5. Дополнительные задачи не добавляются
-> (режим `Structured`).
+Every backlog row uses this schema:
 
-## 3. Детальное описание задач
+| Field | Rule |
+| --- | --- |
+| `ID` | Stable ID. Prefixes: `M` migration, `OQ` open question, `RFC-243` implementation sprint, `BKL-247` backlog governance. |
+| `Title` | Imperative or question-like title; no hidden scope outside the linked evidence. |
+| `Type` | One of `implementation`, `decision`, `research`, `question`, `governance`. |
+| `Priority` | `P1` blocks sequencing or review; `P2` required but not an immediate gate; `P3` follow-up or research. Old migration `P0` maps to `P1`. |
+| `Status` | `TODO`, `IN PROGRESS`, `REVIEW`, `DONE`, `BLOCKED`, or `DEFERRED`. |
+| `Blocked by` | `none` or a comma-separated list of row IDs / external gates. |
+| `Blocks` | `none` or a comma-separated list of row IDs. |
+| `Evidence` | Issue, PR, artifact, RFC, or source document that proves the row's current state. |
 
-### M-001: Переписать README.md спока
+### 1.5. Write and read rules
 
-- **Приоритет:** P0 — **Зависимости:** — — **Оценка:** 1ч
-- **Контекст:** RFC §3.2, подраздел «Переписка README.md спока (обязательная
-  задача Фазы 1)»; таблица файлов Фазы 1 (строка `README.md` — действие «Не
-  переносить», обновить навигацию); edge case E3 (§4).
-- **Что сделать:**
-  1. Переписать корневой `README.md` под спок: назначение проекта Mango BA
-     Prompts.
-  2. Описать структуру `prompts/` и `standards/`.
-  3. Дать ссылку на временный workflow (`CONTRIBUTING.md`).
-  4. Указать контакты / ответственных.
-  5. Удалить все ссылки на Хаб, кроме `docs/hub-research-dependencies.md`.
-- **DoD:**
-  - [ ] `README.md` описывает назначение спока и структуру `prompts/`/`standards/`.
-  - [ ] Нет hub-относительных и битых ссылок (`../../standards/...` и т. п.).
-  - [ ] Единственная ссылка на Хаб — через `docs/hub-research-dependencies.md`.
-  - [ ] Есть ссылка на `CONTRIBUTING.md` (временный workflow).
-- **Артефакты:** `README.md`
+1. Add new work only under a sprint section. If the work has no sprint yet, add
+   it to `Sprint: Open questions` as a `question` until it is triaged.
+2. Do not mix prose-only task descriptions with table-only items. If a task
+   needs details, put the details in the linked issue, RFC, ADR, or artifact.
+3. Every item must have priority, status, dependencies, reverse dependencies,
+   and evidence. Use `none` explicitly instead of an empty dependency cell.
+4. Update status from evidence, not intent. Closed issues or merged PRs can
+   support `DONE`; work completed only in an open PR is `REVIEW`.
+5. Use `P1/P2/P3` everywhere. Do not introduce local priority scales inside a
+   sprint.
+6. Keep open questions in this file until they become issues, standards, RFCs,
+   ADRs, or explicit decisions.
 
-### M-002: Создать базовую структуру папок проекта
+## 2. Sprint index
 
-- **Приоритет:** P0 — **Зависимости:** — — **Оценка:** 30мин
-- **Контекст:** RFC §3.1, Edge Case E6.
-- **Что сделать:**
-  1. Создать каталоги: `prompts/`, `prompts/experiments/`, `prompts/archive/`,
-     `standards/`, `kb/`, `docs/`, `docs/adr/`, `docs/audit/`.
-  2. В каждом каталоге создать `.gitkeep` с поясняющим комментарием о
-     назначении.
-  3. **Обработка существующего `kb/glossary.md`:**
-     - Если файл существует — удалить его (будет заменен копией из Хаба в
-       M-003).
-     - Каталог `kb/` сохранить — он предназначен для практик, примеров и
-       справочников, НЕ для глоссария.
-  4. Убедиться, что `standards/` создан как отдельный каталог для стандартов
-     (глоссарий, контракт классификации).
-- **DoD:**
-  - [ ] Все 8 каталогов созданы с `.gitkeep`.
-  - [ ] `kb/glossary.md` удалён (если существовал).
-  - [ ] Каталог `kb/` существует и пуст (готов для будущих практик).
-  - [ ] Каталог `standards/` существует и пуст (готов для M-003 и M-004).
-- **Артефакты:** `prompts/`, `prompts/experiments/`, `prompts/archive/`,
-  `standards/`, `kb/`, `docs/`, `docs/adr/`, `docs/audit/`
+| Sprint | Scope | Status | Evidence |
+| --- | --- | --- | --- |
+| Migration Phase 1 | Physical migration from Hub to standalone spoke | Closed as backlog items; historical manifest remains draft | [migration RFC](../docs/analysis/2026-06-02-migration-strategy-rfc.md), [manifest](migration-manifest.md) |
+| Open questions | Cross-cutting unresolved governance questions | Active | [session digest rule](session-digests.md), [AI governance](../AI_GOVERNANCE.md) |
+| RFC-243 BA processes and observability | Proposal-backed implementation sequence after issue #243 | Active in fork tracking issues | [RFC-243](rfc/ba-processes-observability-implementation-proposal.md), [PR #244](https://github.com/G-Ivan-A/mango_ba_prompts/pull/244) |
+| Backlog governance | Normalize this backlog and add contract validation | In PR review | [Issue #247](https://github.com/G-Ivan-A/mango_ba_prompts/issues/247), [PR #249](https://github.com/G-Ivan-A/mango_ba_prompts/pull/249) |
 
-### M-003: Скопировать `standards/GLOSSARY.md` из Хаба
+## 3. Sprint: Migration Phase 1
 
-- **Приоритет:** P0 — **Зависимости:** M-002 — **Оценка:** 15мин
-- **Контекст:** RFC §2.4 (внешний стандарт Хаба), таблица файлов Фазы 1 (§3.2,
-  строка `standards/GLOSSARY.md` — «Копировать из Хаба»); принцип P2 (§1.2);
-  edge case E6 / §4.1.
-- **Что сделать:**
-  1. Скопировать `standards/GLOSSARY.md` Хаба в `standards/GLOSSARY.md` спока.
-  2. Добавить provenance: `source_hub` + `source_sha` (permalink-pinning, C3 /
-     E7) во frontmatter или в шапку файла.
-  3. Зафиксировать, что source of truth остаётся в Хабе; синхронизация — явное
-     действие спока (P2).
-- **DoD:**
-  - [ ] Файл `standards/GLOSSARY.md` присутствует в споке.
-  - [ ] Указаны `source_hub` и `source_sha` (permalink на коммит, не `main`).
-  - [ ] Файл — словарь терминов; классификация в него не смешивается (E6).
-- **Артефакты:** `standards/GLOSSARY.md`
+Source: [migration strategy RFC](../docs/analysis/2026-06-02-migration-strategy-rfc.md),
+[human review](../docs/reviews/migration-rfc-human-review-2026-06.md),
+[migration issue registry](migration-issues-registry.md), and
+[migration manifest](migration-manifest.md).
 
-### M-004: Перенести и переименовать `classification-glossary` → `standards/product-classification-contract.md`
+| ID | Title | Type | Priority | Status | Blocked by | Blocks | Evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| M-001 | Rewrite spoke README.md | implementation | P1 | DONE | none | none | [issue #28](https://github.com/G-Ivan-A/mango_ba_prompts/issues/28) closed 2026-06-04; [README.md](../README.md) |
+| M-002 | Create base project directory structure | implementation | P1 | DONE | none | M-003, M-004, M-005, M-006 | [issue #29](https://github.com/G-Ivan-A/mango_ba_prompts/issues/29) closed 2026-06-04; repository structure |
+| M-003 | Copy standards/GLOSSARY.md from Hub | implementation | P1 | DONE | M-002 | M-006 | [issue #30](https://github.com/G-Ivan-A/mango_ba_prompts/issues/30) closed 2026-06-04; [standards/GLOSSARY.md](../standards/GLOSSARY.md) |
+| M-004 | Rename classification glossary to product classification contract | implementation | P1 | DONE | M-002 | M-006 | [issue #31](https://github.com/G-Ivan-A/mango_ba_prompts/issues/31) closed 2026-06-04; [standards/product-classification-contract.md](../standards/product-classification-contract.md) |
+| M-005 | Migrate experiment evidence | implementation | P1 | DONE | M-002 | M-006 | [issue #32](https://github.com/G-Ivan-A/mango_ba_prompts/issues/32) closed 2026-06-04; outputs now live in [runs/](../runs/) |
+| M-006 | Normalize legacy prompt metadata | implementation | P2 | DONE | M-002, M-003, M-004, M-005 | M-007, M-009 | [issue #33](https://github.com/G-Ivan-A/mango_ba_prompts/issues/33) closed 2026-06-05; [prompts/](../prompts/) |
+| M-007 | Create Hub research dependency registry | implementation | P2 | DONE | M-006 | none | [issue #34](https://github.com/G-Ivan-A/mango_ba_prompts/issues/34) closed 2026-06-05; [docs/hub-research-dependencies.md](../docs/hub-research-dependencies.md) |
+| M-008 | Add temporary prompt workflow to CONTRIBUTING.md | governance | P1 | DONE | none | none | [issue #35](https://github.com/G-Ivan-A/mango_ba_prompts/issues/35) closed 2026-06-04; [CONTRIBUTING.md](../CONTRIBUTING.md) |
+| M-009 | Create migration manifest | governance | P3 | DONE | M-006 | none | [issue #36](https://github.com/G-Ivan-A/mango_ba_prompts/issues/36) closed 2026-06-05; [governance/migration-manifest.md](migration-manifest.md) |
 
-- **Приоритет:** P0 — **Зависимости:** M-002 — **Оценка:** 30мин
-- **Контекст:** RFC принцип P4 (§1.2), §2.3 (инвентарь), таблица файлов Фазы 1
-  (§3.2); edge cases E2 и E6 / §4.1.
-- **Что сделать:**
-  1. Перенести `projects/mango/standards/classification-glossary.md` Хаба в
-     `standards/product-classification-contract.md` спока (переименование).
-  2. Внутренние ссылки на research заменить на `research_dep`/якоря реестра
-     (`docs/hub-research-dependencies.md`, см. M-007 / E1, E8).
-  3. Добавить взаимную ссылку на `standards/GLOSSARY.md` («Для значений терминов
-     см. …», E6).
-  4. Добавить provenance (`source_hub`, `source_sha`).
-- **DoD:**
-  - [ ] Файл размещён как `standards/product-classification-contract.md`
-        (не в `kb/`, не как `glossary`).
-  - [ ] Контракт ссылается на `standards/GLOSSARY.md`; слияние не выполнено (E6).
-  - [ ] Ссылки на research идут через `research_dep`/реестр, не относительными
-        путями (E1).
-- **Артефакты:** `standards/product-classification-contract.md`
+## 4. Sprint: Open questions
 
-### M-005: Перенести эксперименты в `prompts/experiments/`
+Open questions are backlog items until a human decision, issue, RFC, ADR, or
+standard supersedes them.
 
-- **Приоритет:** P0 — **Зависимости:** M-002 — **Оценка:** 1ч
-- **Контекст:** RFC §2.3 (5 экспериментов помечены «Переносим физически»), §2.6
-  (сводка), таблица файлов Фазы 1 (§3.2); согласованная формулировка edge case
-  E5 (§4.1): «Эксперименты = часть продукта».
-- **Что сделать:**
-  1. Перенести физически все 5 экспериментов из `projects/mango/experiments/`
-     Хаба в `prompts/experiments/` спока:
-     `tz-stats-prototype-2026-05.md`,
-     `usecase_gen-stepwise-alignment_2026-05-26.md`,
-     `user-story_gen-from-raw-request_2026-05-26.md`,
-     `prompts-audit-2026-05-26.md`,
-     `prompts-selftest-2026-05-26.md`.
-  2. Не размещать `prompts-selftest-*` в корневом `experiments/` спока — только
-     в `prompts/experiments/` (RFC §3.2).
-  3. Если фактическое имя в snapshot отличается — заменить на подтверждённый
-     Hub-путь (открытый вопрос Q1, RFC §7).
-- **DoD:**
-  - [ ] Все 5 экспериментов физически присутствуют в `prompts/experiments/`.
-  - [ ] `prompts-selftest-2026-05-26.md` доступен как acceptance-сценарий для
-        M-006 (self-test gate, C2).
-  - [ ] Эксперименты не зарегистрированы как research-ссылки (они — часть
-        продукта, E5).
-- **Артефакты:** `prompts/experiments/*.md` (5 файлов)
+| ID | Title | Type | Priority | Status | Blocked by | Blocks | Evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| OQ-001 | Decide whether Hub needs mirrored `spoke-candidate` label | question | P3 | TODO | none | none | [docs/rfc-hub-integration.md](../docs/rfc-hub-integration.md) |
+| OQ-002 | Decide whether threshold C1 should be two applications or three | question | P2 | TODO | none | none | [docs/rfc-hub-integration.md](../docs/rfc-hub-integration.md) |
+| OQ-003 | Validate experiment log standard metrics on the next experiments | question | P2 | TODO | none | none | [standards/experiment-log-standard.md](../standards/experiment-log-standard.md), issue #101 context |
+| OQ-004 | Decide ontology refinements from experiment 1027 analysis track | question | P2 | TODO | none | none | [docs/analysis/2026-06-16-experiment-1027-analysis.md](../docs/analysis/2026-06-16-experiment-1027-analysis.md) |
 
-### M-006: Нормализовать промпты (7 полей frontmatter)
+## Sprint RFC-243: BA processes and observability
 
-- **Приоритет:** P1 — **Зависимости:** M-002, M-003, M-004 — **Оценка:** 3ч
-- **Контекст:** RFC §3.2 («Чек-лист нормализации промпта»); креативное улучшение
-  C1 (provenance + dependency frontmatter, §5); self-test gate C2.
-- **Что сделать:**
-  1. Перенести 6 промптов из `projects/mango/prompts/` Хаба в `prompts/`
-     (нормализованные имена — открытый вопрос Q1, RFC §7).
-  2. Для каждого файла добавить/обновить frontmatter, проверив наличие всех
-     7 обязательных полей.
-  3. Если `research_dep: none` — добавить комментарий о бизнес-задаче
-     (RFC §3.5, правила реестра).
-  4. Для `_exp`/canonical-вариантов — обеспечить явный раздел «ФОРМАТ ВЫВОДА».
-- **DoD:**
-  - [ ] Все промпты имеют валидный frontmatter с 7 полями: `status`, `version`,
-        `updated`, `temperature`, `output_format`, `glossary_ref`,
-        `research_dep`.
-  - [ ] Нет промптов без `glossary_ref` или `research_dep`.
-  - [ ] `temperature` указан явно.
-  - [ ] Есть provenance: `source_hub`, `source_sha`, `based_on` (C1).
-  - [ ] `_exp`/canonical-промпты содержат раздел «ФОРМАТ ВЫВОДА».
-- **Артефакты:** `prompts/*.md` (6 промптов)
+Source: Issue #243, merged [PR #244](https://github.com/G-Ivan-A/mango_ba_prompts/pull/244),
+and [RFC-243](rfc/ba-processes-observability-implementation-proposal.md). The
+current upstream token had `READ` access when RFC-243 was prepared, so executable
+tracking issues were created in the fork
+`konard/G-Ivan-A-mango_ba_prompts`. If maintainers require upstream tracking,
+recreate the same rows as upstream issues with labels `priority:P1`,
+`priority:P2`, `priority:P3`, `type:decision`, `type:implementation`,
+`type:research`, `governance`, `ba-processes`, `observability`, and `sprint-3`.
 
-### M-007: Создать `docs/hub-research-dependencies.md`
+Wave policy:
 
-- **Приоритет:** P1 — **Зависимости:** M-006 — **Оценка:** 1ч
-- **Контекст:** RFC §3.5 (реестр зависимостей от исследований Хаба), §2.5
-  (инвентарь research), креативное улучшение C4 (§5); edge cases E1, E8.
-- **Что сделать:**
-  1. Создать **единственный** файл-носитель реестра
-     `docs/hub-research-dependencies.md` (⚠️ **не** создавать
-     `hub-research-links.md` — RFC §3.5).
-  2. Заголовок файла — `# Реестр зависимостей от исследований Хаба`.
-  3. Заполнить таблицу по аудиту §2.5: `research/mango/*` → Hub-URL (permalink на
-     SHA) + затронутые артефакты спока + статус синхронизации.
-  4. Завести якоря (`#classification`, `#classification-tz`, `#taxonomy-concept`
-     и т. д.), на которые ссылаются промпты и контракт через `research_dep`.
-- **DoD:**
-  - [ ] Файл `docs/hub-research-dependencies.md` создан как единая точка ссылок.
-  - [ ] Файл `hub-research-links.md` НЕ создан (запрет дубля, RFC §3.5).
-  - [ ] Каждый якорь имеет полный Hub-URL (permalink на SHA, C3) и список
-        consumers.
-  - [ ] Каждый promp/контракт с зависимостью ссылается на якорь через
-        `research_dep` (E1, E8).
-- **Артефакты:** `docs/hub-research-dependencies.md`
+- **Волна 0 / Wave 0** is the decision gate.
+- **Волна 1 / Wave 1** reconciles process and taxonomy.
+- **Волна 2 / Wave 2** adds mapping and execution metadata.
+- **Волна 3 / Wave 3** adds enforcement and domain follow-up.
+- Dependency mode: `RFC-243-01` is `independent`; all later rows are
+  `dependent` on one or more previous rows.
 
-### M-008: Добавить временный workflow в `CONTRIBUTING.md`
-
-- **Приоритет:** P0 — **Зависимости:** — — **Оценка:** 30мин
-- **Контекст:** RFC §5.2 («Временный workflow промптов P0 — содержание для
-  `CONTRIBUTING.md`»); креативное улучшение C5; edge case E4.
-- **Что сделать:** добавить в `CONTRIBUTING.md` 5 нумерованных шагов временного
-  workflow промптов (без ADR и матрицы):
-  1. Создать файл в `prompts/drafts/` с именем `[biz-process]-[purpose].md`.
-  2. Обязательный frontmatter: `status: draft`, `version: 0.1`,
-     `updated: {{date}}`, `temperature: 0.1`.
-  3. Добавить комментарий
-     `<!-- Experimental: for [task/link], no formal research yet -->`.
-  4. Создать issue `prompt:review` с бизнес-контекстом.
-  5. После human review → переместить в `prompts/`, обновить `status: canonical`,
-     `version: 1.0`.
-- **DoD:**
-  - [ ] В `CONTRIBUTING.md` присутствуют ровно 5 шагов workflow из RFC §5.2.
-  - [ ] Workflow опирается на capability boundaries `prompts/drafts/`, не вводит
-        матрицу/ADR (E4, C5).
-  - [ ] Раздел согласован со структурой `prompts/` из M-002.
-- **Артефакты:** `CONTRIBUTING.md`
-
-### M-009: Создать Migration Manifest
-
-- **Приоритет:** P2 — **Зависимости:** M-006 — **Оценка:** 30мин
-- **Контекст:** RFC §5.1 (шаблон таблицы «артефакт → действие → статус →
-  ссылка») и §5.3 (минимальный локальный чек-лист-трекер); креативное улучшение
-  C6 (migration manifest как живой снимок).
-- **Что сделать:**
-  1. Создать migration manifest как живой снимок миграции по шаблонам §5.1/§5.3.
-  2. Заполнять по ходу Фаз 0–3: «что перенесено / что осталось в Хабе / что
-     архивировано» (включая архив-ссылку на монорепо-`README.md`, E3).
-  3. Manifest **закрывается** в Фазе 3 как воспроизводимый снимок миграции.
-- **DoD:**
-  - [ ] Manifest содержит таблицу «артефакт → категория → действие → статус →
-        назначение в споке» (§5.1).
-  - [ ] Присутствует чек-лист-трекер «Перенесено / Осталось в Хабе / Требует
-        уточнения» (§5.3).
-  - [ ] Монорепо-`README.md` зафиксирован как `archived` (E3), research — как
-        `referenced`.
-- **Артефакты:** migration manifest (путь фиксируется при выполнении задачи)
-
-## 4. Зависимости и критический путь
+| ID | Title | Type | Priority | Status | Blocked by | Blocks | Evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| RFC-243-01 | decision: зафиксировать RFC-243 governance proposal | decision | P1 | TODO | none | RFC-243-02, RFC-243-03, RFC-243-04 | [fork issue #1](https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/1); upstream [issue #243](https://github.com/G-Ivan-A/mango_ba_prompts/issues/243) is closed |
+| RFC-243-02 | implementation: сверить 00-index.md с BABOK-операциями | implementation | P1 | BLOCKED | RFC-243-01 | RFC-243-03, RFC-243-05 | [fork issue #3](https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/3) |
+| RFC-243-03 | implementation: обновить БА-онтологию для atomic-composite taxonomy | implementation | P1 | BLOCKED | RFC-243-01, RFC-243-02 | RFC-243-08 | [fork issue #4](https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/4) |
+| RFC-243-04 | implementation: создать L2-реестр operation-prompt mapping | implementation | P1 | BLOCKED | RFC-243-01 | RFC-243-05, RFC-243-06 | [fork issue #2](https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/2) |
+| RFC-243-05 | implementation: добавить applied_operations в generation contracts | implementation | P1 | BLOCKED | RFC-243-02, RFC-243-04 | RFC-243-07 | [fork issue #5](https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/5) |
+| RFC-243-06 | implementation: добавить applied_prompts и lineage в runs contract | implementation | P1 | BLOCKED | RFC-243-04 | RFC-243-07 | [fork issue #6](https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/6) |
+| RFC-243-07 | implementation: обновить валидаторы и статистику под трассируемость | implementation | P2 | BLOCKED | RFC-243-05, RFC-243-06 | none | [fork issue #7](https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/7) |
+| RFC-243-08 | research: оценить eTOM/SID как доменные БА-артефакты | research | P3 | BLOCKED | RFC-243-03 | none | [fork issue #8](https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/8) |
 
 ```mermaid
 graph TD
-    A[M-001 README] --> D[Готово]
-    B[M-002 Структура] --> C[M-003 GLOSSARY]
-    B --> E[M-004 CONTRACT]
-    B --> F[M-005 Эксперименты]
-    C & E & F --> G[M-006 Нормализация]
-    G --> H[M-007 Dependencies]
-    I[M-008 Workflow] --> D
-    G --> J[M-009 Manifest]
+    R1[RFC-243-01 decision gate] --> R2[RFC-243-02 BABOK reconciliation]
+    R1 --> R3[RFC-243-03 BA ontology taxonomy]
+    R1 --> R4[RFC-243-04 operation-prompt registry]
+    R2 --> R3
+    R2 --> R5[RFC-243-05 applied_operations]
+    R4 --> R5
+    R4 --> R6[RFC-243-06 applied_prompts and lineage]
+    R5 --> R7[RFC-243-07 validators and stats]
+    R6 --> R7
+    R3 --> R8[RFC-243-08 eTOM/SID research]
 ```
 
-**Критический путь:** `M-002 → (M-003 ∥ M-004 ∥ M-005) → M-006 → (M-007 ∥
-M-009)`. Задачи M-001 (README) и M-008 (workflow) независимы и могут идти
-параллельно основному пути.
+## 6. Sprint: Backlog governance
 
-## 5. Открытые вопросы
+Source: [Issue #247](https://github.com/G-Ivan-A/mango_ba_prompts/issues/247)
+and [PR #249](https://github.com/G-Ivan-A/mango_ba_prompts/pull/249). This
+sprint exists to normalize the backlog itself; rows stay `REVIEW` until PR #249
+is merged.
 
-Этот раздел — единый трекер открытых вопросов проекта. Если в
-[`governance/session-digests.md`](session-digests.md) появляется новый открытый
-вопрос, Исполнитель добавляет его сюда, если вопрос ещё не зафиксирован.
+| ID | Title | Type | Priority | Status | Blocked by | Blocks | Evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| BKL-247-01 | Determine why backlog formats diverged | governance | P1 | REVIEW | none | BKL-247-02, BKL-247-03 | Root cause recorded in section 1.2; [issue #247](https://github.com/G-Ivan-A/mango_ba_prompts/issues/247) |
+| BKL-247-02 | Define industry-normal backlog practice for this project | research | P1 | REVIEW | BKL-247-01 | BKL-247-03 | Industry sources recorded in section 1.3 |
+| BKL-247-03 | Create backlog contract and rules | governance | P1 | REVIEW | BKL-247-01, BKL-247-02 | BKL-247-04, BKL-247-05 | Contract recorded in sections 1.4 and 1.5 |
+| BKL-247-04 | Apply the contract to current backlog rows and RFC-243 tasks | governance | P1 | REVIEW | BKL-247-03 | BKL-247-05 | Normalized sprint tables in sections 3 through 6 |
+| BKL-247-05 | Add regression validator and changelog entry | implementation | P2 | REVIEW | BKL-247-03, BKL-247-04 | none | [scripts/validate_issue_247_backlog_contract.py](../scripts/validate_issue_247_backlog_contract.py), CHANGELOG.md |
 
-- [ ] [2026-06-11] [konard] Нужен ли в Хабе зеркальный label
-      `spoke-candidate` для встречного потока предложений?
-      Источник: [`docs/rfc-hub-integration.md`](../docs/rfc-hub-integration.md).
-- [ ] [2026-06-11] [konard] Порог C1 «≥ 2 применения» — достаточен или
-      требуется 3?
-      Источник: [`docs/rfc-hub-integration.md`](../docs/rfc-hub-integration.md).
-- [ ] [2026-06-16] [issue #101] Стандарт фиксации экспериментов — Draft v0.1:
-      достаточно ли 6 метрик и субъективной шкалы `quality`; где граница между
-      Уровнем 0 (Issue) и Уровнем 1 (Markdown). Валидировать на 2–3 следующих
-      экспериментах. Источник:
-      [`standards/experiment-log-standard.md`](../standards/experiment-log-standard.md).
-- [ ] [2026-06-16] [issue #101] Рекомендации по онтологии для трека ADR
-      #003–#008 (НЕ менять здесь): O1 разделение `documentation` на
-      «генерацию с нуля» vs «редактирование черновика»; O2 «валидация против
-      источника» как первоклассная семантика; O3 типизация промежуточных
-      артефактов (As-Is-выжимка, сценарная матрица, отчёт валидации, вопросы
-      заказчику). Источник:
-      [`docs/analysis/2026-06-16-experiment-1027-analysis.md`](../docs/analysis/2026-06-16-experiment-1027-analysis.md).
+## Related artifacts
 
-## Спринт RFC-243: BA-процессы и observability
-
-Этот раздел формирует implementation sprint по Issue #243 и RFC-243:
-[`governance/rfc/ba-processes-observability-implementation-proposal.md`](rfc/ba-processes-observability-implementation-proposal.md).
-Спринт не реализует стандарты и артефакты сам по себе: он фиксирует порядок
-работ после review/canonical решения по RFC.
-
-> Ограничение доступа: текущий токен имеет `READ` на upstream
-> `G-Ivan-A/mango_ba_prompts`, поэтому labels/issues созданы в fork
-> `konard/G-Ivan-A-mango_ba_prompts`. При переносе в upstream требуется
-> воспроизвести labels `priority:P1`, `priority:P2`, `priority:P3`,
-> `type:decision`, `type:implementation`, `type:research`, `sprint-3`.
-
-### Метки спринта
-
-- Priority labels: `priority:P1`, `priority:P2`, `priority:P3`.
-- Type labels: `type:decision`, `type:implementation`, `type:research`.
-- Sprint label: `sprint-3`.
-- Domain labels: `governance`, `ba-processes`, `observability`.
-
-### Волны
-
-- **Волна 0** — decision gate: принять RFC/ADR-формат и статус RFC-243.
-- **Волна 1** — процессная и онтологическая сверка: сначала `00-index.md`,
-  затем BA-онтология.
-- **Волна 2** — execution mapping: L2 registry, `applied_operations`,
-  `applied_prompts`.
-- **Волна 3** — enforcement и доменные уточнения: validators/stats и eTOM/SID.
-
-| № | Title | Type | Priority | Dependencies | Issue in repo |
-| --- | --- | --- | --- | --- | --- |
-| 1 | decision: зафиксировать RFC-243 governance proposal | decision | P1 | independent: upstream Issue #243 and PR #244 | <https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/1> |
-| 2 | implementation: сверить 00-index.md с BABOK-операциями | implementation | P1 | dependent: #1 | <https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/3> |
-| 3 | implementation: обновить БА-онтологию для atomic-composite taxonomy | implementation | P1 | dependent: #1, #3 | <https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/4> |
-| 4 | implementation: создать L2-реестр operation-prompt mapping | implementation | P1 | dependent: #1 | <https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/2> |
-| 5 | implementation: добавить applied_operations в generation contracts | implementation | P1 | dependent: #2, #3 | <https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/5> |
-| 6 | implementation: добавить applied_prompts и lineage в runs contract | implementation | P1 | dependent: #2 | <https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/6> |
-| 7 | implementation: обновить валидаторы и статистику под трассируемость | implementation | P2 | dependent: #5, #6 | <https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/7> |
-| 8 | research: оценить eTOM/SID как доменные БА-артефакты | research | P3 | dependent: #4 | <https://github.com/konard/G-Ivan-A-mango_ba_prompts/issues/8> |
-
-### Dependency map
-
-```mermaid
-graph TD
-    T1[decision RFC-243] --> T2[00-index.md BABOK reconciliation]
-    T1 --> T4[L2 operation-prompt mapping]
-    T1 --> T3[BA ontology taxonomy]
-    T2 --> T3
-    T2 --> T5[applied_operations in contracts]
-    T4 --> T5
-    T4 --> T6[applied_prompts in runs]
-    T5 --> T7[validators and stats]
-    T6 --> T7
-    T3 --> T8[eTOM/SID research]
-```
-
-### DoD спринта
-
-- Каждая задача имеет тип `decision` / `implementation` / `research`, priority
-  `P1` / `P2` / `P3`, sprint label `sprint-3` и явные dependencies.
-- Волна 1 не стартует до review решения по RFC-243.
-- Волна 2 не стартует до сверки `docs/ba-processes/00-index.md` и фиксации
-  operation IDs.
-- Ни одна задача из спринта не изменяется в этом PR; этот раздел только
-  формирует backlog и issue links.
-
----
-
-## Связанные артефакты
-
-- Issue: <https://github.com/G-Ivan-A/mango_ba_prompts/issues/14>
-- Утверждённый RFC: [`docs/analysis/2026-06-02-migration-strategy-rfc.md`](../docs/analysis/2026-06-02-migration-strategy-rfc.md)
-- Human Review: [`docs/reviews/migration-rfc-human-review-2026-06.md`](../docs/reviews/migration-rfc-human-review-2026-06.md)
-- Контракт и правила: [`AI_GOVERNANCE.md`](../AI_GOVERNANCE.md), [`AI_QUICK_RULES.md`](../AI_QUICK_RULES.md)
-- Вклад и workflow: [`CONTRIBUTING.md`](../CONTRIBUTING.md)
-</content>
-</invoke>
+- Backlog update issue: <https://github.com/G-Ivan-A/mango_ba_prompts/issues/247>
+- Prepared pull request: <https://github.com/G-Ivan-A/mango_ba_prompts/pull/249>
+- RFC-243: [governance/rfc/ba-processes-observability-implementation-proposal.md](rfc/ba-processes-observability-implementation-proposal.md)
+- Migration manifest: [governance/migration-manifest.md](migration-manifest.md)
+- Project rules: [AI_GOVERNANCE.md](../AI_GOVERNANCE.md), [AI_QUICK_RULES.md](../AI_QUICK_RULES.md), [CONTRIBUTING.md](../CONTRIBUTING.md)

--- a/governance/migration-issues-registry.md
+++ b/governance/migration-issues-registry.md
@@ -2,12 +2,12 @@
 
 | ID | Название | URL Issue | Статус |
 |----|----------|-----------|--------|
-| M-001 | Переписать README.md спока | https://github.com/G-Ivan-A/mango_ba_prompts/issues/28 | Open |
-| M-002 | Создать базовую структуру папок проекта | https://github.com/G-Ivan-A/mango_ba_prompts/issues/29 | Open |
-| M-003 | Скопировать standards/GLOSSARY.md из Хаба | https://github.com/G-Ivan-A/mango_ba_prompts/issues/30 | Open |
-| M-004 | Перенести и переименовать classification-glossary → standards/product-classification-contract.md | https://github.com/G-Ivan-A/mango_ba_prompts/issues/31 | Open |
-| M-005 | Перенести эксперименты в prompts/experiments/ | https://github.com/G-Ivan-A/mango_ba_prompts/issues/32 | Open |
-| M-006 | Нормализовать frontmatter у всех старых промптов | https://github.com/G-Ivan-A/mango_ba_prompts/issues/33 | Open |
-| M-007 | Создать docs/hub-research-dependencies.md | https://github.com/G-Ivan-A/mango_ba_prompts/issues/34 | Open |
-| M-008 | Добавить временный workflow в CONTRIBUTING.md | https://github.com/G-Ivan-A/mango_ba_prompts/issues/35 | Open |
-| M-009 | Создать Migration Manifest | https://github.com/G-Ivan-A/mango_ba_prompts/issues/36 | Open |
+| M-001 | Переписать README.md спока | https://github.com/G-Ivan-A/mango_ba_prompts/issues/28 | Closed 2026-06-04 |
+| M-002 | Создать базовую структуру папок проекта | https://github.com/G-Ivan-A/mango_ba_prompts/issues/29 | Closed 2026-06-04 |
+| M-003 | Скопировать standards/GLOSSARY.md из Хаба | https://github.com/G-Ivan-A/mango_ba_prompts/issues/30 | Closed 2026-06-04 |
+| M-004 | Перенести и переименовать classification-glossary → standards/product-classification-contract.md | https://github.com/G-Ivan-A/mango_ba_prompts/issues/31 | Closed 2026-06-04 |
+| M-005 | Перенести эксперименты в prompts/experiments/ | https://github.com/G-Ivan-A/mango_ba_prompts/issues/32 | Closed 2026-06-04 |
+| M-006 | Нормализовать frontmatter у всех старых промптов | https://github.com/G-Ivan-A/mango_ba_prompts/issues/33 | Closed 2026-06-05 |
+| M-007 | Создать docs/hub-research-dependencies.md | https://github.com/G-Ivan-A/mango_ba_prompts/issues/34 | Closed 2026-06-05 |
+| M-008 | Добавить временный workflow в CONTRIBUTING.md | https://github.com/G-Ivan-A/mango_ba_prompts/issues/35 | Closed 2026-06-04 |
+| M-009 | Создать Migration Manifest | https://github.com/G-Ivan-A/mango_ba_prompts/issues/36 | Closed 2026-06-05 |

--- a/scripts/validate_issue_243_ba_processes_observability_rfc.py
+++ b/scripts/validate_issue_243_ba_processes_observability_rfc.py
@@ -157,13 +157,13 @@ def validate_rfc() -> None:
 
 def validate_backlog() -> None:
     text = read_text(BACKLOG)
-    marker = "## Спринт RFC-243"
+    marker = "## Sprint RFC-243"
     require(marker in text, f"{BACKLOG}: missing sprint section {marker!r}")
     sprint = text[text.index(marker) :]
 
     required_fragments = (
         "Issue #243",
-        "| № | Title | Type | Priority | Dependencies | Issue in repo |",
+        "| ID | Title | Type | Priority | Status | Blocked by | Blocks | Evidence |",
         "Волна 0",
         "Волна 1",
         "Волна 2",

--- a/scripts/validate_issue_247_backlog_contract.py
+++ b/scripts/validate_issue_247_backlog_contract.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Regression check for issue #247 backlog contract and normalized backlog."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+BACKLOG = Path("governance/BACKLOG.md")
+MIGRATION_REGISTRY = Path("governance/migration-issues-registry.md")
+CHANGELOG = Path("CHANGELOG.md")
+WORKFLOW = Path(".github/workflows/github-pages.yml")
+VALIDATOR = Path("scripts/validate_issue_247_backlog_contract.py")
+
+TABLE_HEADER = "| ID | Title | Type | Priority | Status | Blocked by | Blocks | Evidence |"
+
+ALLOWED_PRIORITIES = {"P1", "P2", "P3"}
+ALLOWED_STATUSES = {"TODO", "IN PROGRESS", "REVIEW", "DONE", "BLOCKED", "DEFERRED"}
+
+REQUIRED_ITEM_IDS = {
+    "M-001",
+    "M-002",
+    "M-003",
+    "M-004",
+    "M-005",
+    "M-006",
+    "M-007",
+    "M-008",
+    "M-009",
+    "OQ-001",
+    "OQ-002",
+    "OQ-003",
+    "OQ-004",
+    "RFC-243-01",
+    "RFC-243-02",
+    "RFC-243-03",
+    "RFC-243-04",
+    "RFC-243-05",
+    "RFC-243-06",
+    "RFC-243-07",
+    "RFC-243-08",
+    "BKL-247-01",
+    "BKL-247-02",
+    "BKL-247-03",
+    "BKL-247-04",
+    "BKL-247-05",
+}
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        fail(message)
+
+
+def read_text(path: Path) -> str:
+    full_path = ROOT / path
+    require(full_path.exists(), f"missing file: {path}")
+    return full_path.read_text(encoding="utf-8")
+
+
+def parse_backlog_rows(text: str) -> dict[str, list[str]]:
+    rows: dict[str, list[str]] = {}
+    item_id_re = re.compile(r"^(?:M|OQ|RFC-243|BKL-247)-[0-9]+$")
+
+    for line in text.splitlines():
+        if not line.startswith("| "):
+            continue
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) != 8 or not item_id_re.match(cells[0]):
+            continue
+        rows[cells[0]] = cells
+    return rows
+
+
+def validate_backlog() -> None:
+    text = read_text(BACKLOG)
+
+    required_fragments = (
+        "title: \"Backlog: Mango BA Prompts\"",
+        "updated: 2026-06-25",
+        "# BACKLOG: Mango BA Prompts",
+        "## 1. Backlog contract",
+        "### 1.2. Root cause of inconsistency",
+        "### 1.3. Industry baseline",
+        "### 1.4. Project backlog format",
+        "### 1.5. Write and read rules",
+        "## 2. Sprint index",
+        "## 3. Sprint: Migration Phase 1",
+        "## 4. Sprint: Open questions",
+        "## Sprint RFC-243: BA processes and observability",
+        "## 6. Sprint: Backlog governance",
+        "GitHub Projects",
+        "Jira Scrum backlog",
+        "Linear cycles",
+        "Notion roadmap database",
+        "https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects",
+        "https://support.atlassian.com/jira-software-cloud/docs/use-your-scrum-backlog/",
+        "https://linear.app/docs/use-cycles",
+        "https://www.notion.com/use-case/project-management/ai-product-roadmap",
+        "Причина неконсистентности",
+        "Индустриальная норма",
+        "Issue #247",
+        "CHANGELOG.md",
+    )
+    for fragment in required_fragments:
+        require(fragment in text, f"{BACKLOG}: missing {fragment!r}")
+
+    require(text.count(TABLE_HEADER) >= 4, f"{BACKLOG}: expected normalized backlog tables")
+
+    rows = parse_backlog_rows(text)
+    missing = sorted(REQUIRED_ITEM_IDS - set(rows))
+    require(not missing, f"{BACKLOG}: missing backlog item rows: {', '.join(missing)}")
+
+    for item_id, cells in sorted(rows.items()):
+        _, title, item_type, priority, status, blocked_by, blocks, evidence = cells
+        require(title, f"{BACKLOG}: {item_id} has empty title")
+        require(item_type, f"{BACKLOG}: {item_id} has empty type")
+        require(priority in ALLOWED_PRIORITIES, f"{BACKLOG}: {item_id} invalid priority {priority!r}")
+        require(status in ALLOWED_STATUSES, f"{BACKLOG}: {item_id} invalid status {status!r}")
+        require(blocked_by, f"{BACKLOG}: {item_id} has empty Blocked by")
+        require(blocks, f"{BACKLOG}: {item_id} has empty Blocks")
+        require(evidence, f"{BACKLOG}: {item_id} has empty evidence")
+
+    for item_id in [f"M-{number:03d}" for number in range(1, 10)]:
+        require(rows[item_id][4] == "DONE", f"{BACKLOG}: {item_id} must reflect closed migration issue")
+
+    for item_id in [f"RFC-243-{number:02d}" for number in range(1, 9)]:
+        require(rows[item_id][3] in ALLOWED_PRIORITIES, f"{BACKLOG}: {item_id} missing priority")
+        require(rows[item_id][4] in {"TODO", "BLOCKED"}, f"{BACKLOG}: {item_id} must remain not done")
+
+    for item_id in [f"BKL-247-{number:02d}" for number in range(1, 6)]:
+        require(rows[item_id][4] == "REVIEW", f"{BACKLOG}: {item_id} should be in PR review")
+
+
+def validate_project_hooks() -> None:
+    registry = read_text(MIGRATION_REGISTRY)
+    require("Open" not in registry, f"{MIGRATION_REGISTRY}: must not retain stale Open statuses")
+    for number in range(1, 10):
+        require(f"M-{number:03d}" in registry, f"{MIGRATION_REGISTRY}: missing M-{number:03d}")
+        require("Closed 2026-06-" in registry, f"{MIGRATION_REGISTRY}: missing closed dates")
+
+    changelog = read_text(CHANGELOG)
+    for fragment in (
+        "Issue #247",
+        BACKLOG.as_posix(),
+        MIGRATION_REGISTRY.as_posix(),
+        VALIDATOR.as_posix(),
+        "Индустриальная норма",
+    ):
+        require(fragment in changelog, f"{CHANGELOG}: missing {fragment!r}")
+
+    workflow = read_text(WORKFLOW)
+    require(
+        "Validate issue #247 backlog contract" in workflow,
+        f"{WORKFLOW}: missing validation step name",
+    )
+    require(VALIDATOR.as_posix() in workflow, f"{WORKFLOW}: missing validator path")
+
+
+def main() -> None:
+    validate_backlog()
+    validate_project_hooks()
+    print("OK: issue #247 backlog contract validated")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Normalizes governance/BACKLOG.md into a sprint-backlog contract with root-cause analysis, source-backed industry baseline, fill/read rules, priorities, statuses, dependencies, and evidence fields.
- Updates Phase 1 migration statuses and the migration issue registry to match the closed GitHub issues #28-#36.
- Preserves RFC-243 implementation-plan tasks in the normalized backlog and adds issue #247 regression validation to CI.

## Validation
- python3 scripts/validate_issue_247_backlog_contract.py
- python3 scripts/validate_issue_243_ba_processes_observability_rfc.py
- workflow Python validator set from .github/workflows/github-pages.yml (log: ci-logs/local-python-validators-issue-247.log)
- node scripts/generate-pages-data.mjs plus workflow validators passed locally; generated site/data timestamp churn was not committed

Fixes G-Ivan-A/mango_ba_prompts#247
