### PR TITLE
report: Состояние БЗ после удаления PDF из LFS

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-06-15T19:01:45.276Z for PR creation at branch issue-82-0e783db552e4 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/82
-# Updated: 2026-07-03T11:05:51.321Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-15T19:01:45.276Z for PR creation at branch issue-82-0e783db552e4 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/82
+# Updated: 2026-07-03T11:05:51.321Z

--- a/docs/report/2026-07-03-kb-state-after-lfs-cleanup.md
+++ b/docs/report/2026-07-03-kb-state-after-lfs-cleanup.md
@@ -26,9 +26,10 @@ PDF-источники в рабочем дереве отсутствуют: `f
 добавления PDF.
 
 Структура, индексы, метаданные, трассировка и изображения в `kb/processed/`
-сохранились. Локальная и CI-валидация текущего KB pipeline теперь падает на
-проверке наличия PDF-частей `mango-cc-manual`, что является прямым последствием
-удаления источников, а не повреждением сгенерированных Markdown-артефактов.
+сохранились. Lightweight-валидация KB pipeline проверяет generated snapshot,
+source provenance и manifest wiring без требования локальных PDF-payloads;
+локальный `make kb-validate` проходит. Запуск извлечения по-прежнему требует
+возврата реальных PDF-файлов.
 
 ## Метод проверки
 
@@ -305,7 +306,7 @@ Manifest-файлы подсказывают ожидаемые имена, по
 - Проверить, что Markdown точно соответствует PDF-оригиналу.
 - Исправить ошибки парсинга через корректный rerun pipeline.
 - Обновить БЗ на новую версию руководства.
-- Выполнить текущий полный `make kb-validate` без падения на missing PDF checks.
+- Выполнить source-backed проверку, которая читает оригинальные PDF-payloads.
 
 ## Риски
 
@@ -313,9 +314,6 @@ Manifest-файлы подсказывают ожидаемые имена, по
 
 - **Невоспроизводимость БЗ.** Generated artifacts сохранены, но source -> output
   цепочка разорвана из-за отсутствия PDF.
-- **Блокирующая CI-валидация.** `KB pipeline` для PR #260 уже падает на
-  `scripts/validate_issue_115_kb_mango_pipeline.py`: отсутствуют все шесть
-  `CC_manual_1.26.23-part-*.pdf`.
 - **Невозможность source-backed верификации.** Ссылки на страницы и части
   сохранены, но проверить их против оригинала нельзя.
 
@@ -345,10 +343,8 @@ Manifest-файлы подсказывают ожидаемые имена, по
    output, пока PDF отсутствуют.
 3. Не редактировать `kb/processed/**` вручную: текущая документация уже задает
    правило менять источник и перезапускать извлечение.
-4. Отдельной задачей решить, что делать с текущей CI-валидацией:
-   восстановить PDF через утвержденный LFS-процесс или изменить validation
-   contract так, чтобы он проверял generated artifacts без требования локальных
-   source PDF.
+4. Сохранять разделение lightweight-валидации generated artifacts и
+   source-backed проверок, которые требуют реальные PDF-payloads.
 
 ### Долгосрочные considerations для будущей задачи
 
@@ -366,26 +362,24 @@ Manifest-файлы подсказывают ожидаемые имена, по
 ```text
 make kb-validate
 issue-111 KB pipeline validation: PASS
-issue-115 KB mango pipeline validation: FAIL
-- kb/sources/mango-cc-manual/CC_manual_1.26.23-part-1.pdf: missing
-- kb/sources/mango-cc-manual/CC_manual_1.26.23-part-2.pdf: missing
-- kb/sources/mango-cc-manual/CC_manual_1.26.23-part-3.pdf: missing
-- kb/sources/mango-cc-manual/CC_manual_1.26.23-part-4.pdf: missing
-- kb/sources/mango-cc-manual/CC_manual_1.26.23-part-5.pdf: missing
-- kb/sources/mango-cc-manual/CC_manual_1.26.23-part-6.pdf: missing
+issue-115 KB mango pipeline validation: PASS
+issue-117 KB traceability validation: PASS
+issue-121 KB multi-file validation: PASS
 ```
 
-CI:
+CI до исправления validation contract:
 
 - workflow: `KB pipeline`;
-- run: `28656517739`;
-- created at: `2026-07-03T11:06:02Z`;
-- head SHA: `1f63ab02f30fb50b7db013048b00ce941a323940`;
+- run: `28657113496`;
+- created at: `2026-07-03T11:18:10Z`;
+- head SHA: `8feff699ffc72847083ad13b16c47a53ed925b26`;
 - result: failure;
 - root cause in log: the same six missing `mango-cc-manual` PDF parts.
 
-Это подтверждает, что текущий валидатор по-прежнему ожидает PDF-источники, хотя
-задача #259 фиксирует состояние после их удаления.
+После исправления lightweight validation contract `make kb-validate` не требует
+локальные PDF-payloads и продолжает проверять generated artifacts, manifest
+source paths и provenance. Реальный запуск `scripts/kb/process_sources.py`
+без `--dry-run` по-прежнему завершается ошибкой, если PDF-файлы отсутствуют.
 
 ## Definition of Done
 
@@ -396,8 +390,8 @@ CI:
 - [x] Отчет зафиксирован как
   `docs/report/2026-07-03-kb-state-after-lfs-cleanup.md`.
 - [x] Локальная проверка отчета `git diff --check` прошла.
-- [ ] Полный `make kb-validate` не проходит в текущем post-cleanup состоянии;
-  failure зафиксирован в разделе "Локальная и CI-валидация".
+- [x] Полный `make kb-validate` проходит после разделения lightweight checks и
+  source-backed payload checks.
 - [x] Структура `kb/processed/` не изменялась.
 - [x] PDF не восстанавливались и БЗ не перепарсивалась.
 - [x] Задача переведена в состояние `review` через frontmatter отчета.

--- a/docs/report/2026-07-03-kb-state-after-lfs-cleanup.md
+++ b/docs/report/2026-07-03-kb-state-after-lfs-cleanup.md
@@ -1,0 +1,403 @@
+---
+status: review
+version: 0.1
+updated: 2026-07-03
+ai-generated: true
+type: kb-state-report
+scope: kb/processed
+related_issues:
+  - "https://github.com/G-Ivan-A/mango_ba_prompts/issues/259"
+---
+
+# Отчет: Состояние БЗ после удаления PDF из LFS
+
+## Executive Summary
+
+База знаний в `kb/processed/` сохранилась как самостоятельный набор
+сгенерированных артефактов: 1 126 Markdown-файлов, 1 116 файлов-разделов,
+9 индексов, 9 `meta.json` и 3 906 извлеченных изображений. Общий объем
+`kb/processed/` составляет 138M; по метаданным это 1 395 страниц источников и
+924 795 токенов сгенерированного материала.
+
+PDF-источники в рабочем дереве отсутствуют: `find . -iname '*.pdf'` и
+`git ls-files '*.pdf'` не вернули файлов. Поэтому БЗ пригодна для чтения,
+поиска, цитирования и анализа уже извлеченных разделов, но не пригодна для
+перепарсинга, повторной верификации против оригиналов и обновления без повторного
+добавления PDF.
+
+Структура, индексы, метаданные, трассировка и изображения в `kb/processed/`
+сохранились. Локальная и CI-валидация текущего KB pipeline теперь падает на
+проверке наличия PDF-частей `mango-cc-manual`, что является прямым последствием
+удаления источников, а не повреждением сгенерированных Markdown-артефактов.
+
+## Метод проверки
+
+Отчет составлен по состоянию рабочей копии на ветке
+`issue-259-c669a0c27b56` 2026-07-03. PDF не восстанавливались, извлечение не
+перезапускалось, структура `kb/processed/` не менялась.
+
+Основные проверки:
+
+- инвентаризация `find`, `du`, `ls` по `kb/processed/`;
+- анализ `meta.json` через стандартный JSON-парсер Python;
+- поиск PDF/LFS-упоминаний через `rg`;
+- проверка пустых и минимальных Markdown-файлов через `find`;
+- проверка локальных Markdown-ссылок на изображения;
+- анализ source manifests в `kb/sources/`;
+- локальный запуск `make kb-validate`;
+- просмотр текущего лога CI `KB pipeline` для PR #260.
+
+## Что сохранилось
+
+### Общая структура
+
+`kb/processed/` содержит четыре верхнеуровневых набора:
+
+```text
+kb/processed/
+├── README.md
+├── contact-center-manual-sample/
+│   ├── index.md
+│   ├── meta.json
+│   ├── sections/
+│   └── images/
+├── mango-cc-manual/
+│   ├── index.md
+│   ├── meta.json
+│   ├── sections/
+│   └── images/
+├── mango-lk-manual/
+│   ├── index.md
+│   ├── meta.json
+│   ├── sections/
+│   └── images/
+└── mtalker/
+    ├── index.md
+    ├── meta.json
+    ├── quick-start/
+    ├── windows-mac-working/
+    ├── windows-mac-settings/
+    ├── windows-mac-admin/
+    └── android-user-guide/
+```
+
+Для `mtalker` сохранена multi-document структура: общий индекс продукта и пять
+вложенных БЗ, каждая со своим `index.md`, `meta.json`, `sections/` и `images/`.
+
+### Количественная инвентаризация
+
+| Набор | Размер | Markdown | Разделы | Изображения | Страницы | Токены | PDF-источники в метаданных |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `contact-center-manual-sample` | 64K | 8 | 7 | 1 | 7 | 1 923 | 1, отсутствует |
+| `mango-cc-manual` | 60M | 233 | 232 | 1 771 | 614 | 429 951 | 6, отсутствуют |
+| `mango-lk-manual` | 73M | 349 | 348 | 1 545 | 568 | 311 325 | 5, отсутствуют |
+| `mtalker` | 6.1M | 535 | 529 | 589 | 206 | 181 596 | 5, отсутствуют |
+| **Итого `kb/processed/`** | **138M** | **1 126** | **1 116** | **3 906** | **1 395** | **924 795** | **17, отсутствуют** |
+
+Дополнительные счетчики:
+
+- всего файлов в `kb/processed/`: 5 041;
+- `index.md`: 9;
+- `meta.json`: 9;
+- файлов-разделов `sections/*.md`: 1 116;
+- Markdown-файлов любого типа: 1 126.
+
+### Содержимое ключевых каталогов
+
+`mango-cc-manual` сохранил 232 раздела, 1 771 изображение, индекс на 72 816 байт
+и `meta.json` на 129 775 байт. Начало `sections/` содержит ожидаемые файлы
+`00-titulnaya-chast.md`, `01-nachalo-raboty.md`,
+`02-registraciya-novogo-polzovatelya.md`, `03-vhod-v-sistemu.md`,
+`04-glavnoe-okno-programmy.md`.
+
+`mango-lk-manual` сохранил 348 разделов, 1 545 изображений, индекс на 99 341 байт
+и `meta.json` на 194 462 байт.
+
+`mtalker` сохранил общий product index и пять вложенных документов:
+
+- `quick-start`: 7 разделов, 4 страницы, 16 изображений;
+- `windows-mac-working`: 317 разделов, 122 страницы, 396 изображений;
+- `windows-mac-settings`: 55 разделов, 19 страниц, 42 изображения;
+- `windows-mac-admin`: 15 разделов, 9 страниц, 10 изображений;
+- `android-user-guide`: 135 разделов, 52 страницы, 125 изображений.
+
+`contact-center-manual-sample` сохранил синтетическую фикстуру: 7 разделов,
+7 страниц, 1 изображение. В `meta.json` явно указано, что это синтетическая
+фикстура, созданная потому что реальный `CC_manual_1.26.23.pdf` не загрузился
+для issue #111.
+
+### Индексы и метаданные
+
+Сохранились:
+
+- `kb/processed/README.md` с описанием контракта generated KB;
+- `index.md` для каждого документа и вложенного документа;
+- `meta.json` для каждого документа и product collection;
+- трассировка из разделов к исходным PDF-путям, частям и страницам;
+- счетчики страниц, разделов, изображений, токенов и источников;
+- `source_sha256` в метаданных сгенерированных документов.
+
+Секции остаются самодостаточными chunks: в frontmatter есть `pdf_section`,
+`pdf_heading`, `pages`, `source`, `source_refs`, а в теле есть строка
+`Трассировка`.
+
+## Проверка целостности
+
+### PDF-ссылки и source references
+
+В `kb/processed/**/*.md` найдено 3 378 упоминаний `.pdf`. Это не Markdown-ссылки
+на PDF: отдельная проверка Markdown-гиперссылок вида `[...](...pdf)` вернула 0.
+Найденные упоминания являются provenance-полями и человекочитаемой трассировкой,
+например:
+
+- `source: kb/sources/mango-cc-manual/CC_manual_1.26.23-part-*.pdf`;
+- `source_refs: [{"source_pdf": "...pdf", ...}]`;
+- строки `Трассировка` в разделах;
+- блоки `Источник БЗ` в `index.md`.
+
+Все 17 уникальных PDF-источников, на которые ссылается `kb/processed/`, сейчас
+отсутствуют в рабочем дереве:
+
+- 1 synthetic/sample source PDF;
+- 6 частей `mango-cc-manual`;
+- 5 частей `mango-lk-manual`;
+- 5 документов `mtalker`.
+
+### LFS-упоминания
+
+В `kb/processed/**/*.md` не найдено упоминаний `lfs`.
+
+`.gitattributes` продолжает объявлять PDF как LFS-файлы:
+
+```text
+*.pdf filter=lfs diff=lfs merge=lfs -text
+```
+
+Локально команда `git lfs ls-files` недоступна, потому что `git lfs` не
+установлен в контейнере. При этом `git ls-files '*.pdf'` и поиск по файловой
+системе не нашли ни одного PDF.
+
+### Пустые и минимальные файлы
+
+Проблем не найдено:
+
+- пустых `*.md` в `kb/processed/`: 0;
+- `*.md` меньше 100 байт: 0.
+
+### Изображения
+
+Локальная проверка Markdown image references в `kb/processed/**/*.md` не нашла
+битых ссылок на изображения: 0 missing image references. Файлы `images/`
+сохранились и соответствуют ссылкам из Markdown-разделов.
+
+## Анализ зависимостей
+
+### Manifest-файлы
+
+Сохранились 23 JSON-файла в `kb/`: 9 в `kb/processed/` и 14 в `kb/sources/`.
+YAML-manifest в `kb/` не найден.
+
+В `kb/sources/` сохранены source manifests, включая:
+
+- `kb/sources/mango-cc-manual/meta.json`;
+- `kb/sources/mango-lk-manual/meta.json`;
+- `kb/sources/mtalker/meta.json`;
+- manifests для интеграций, SSO, SIP trunk, speech analytics, wallboard и других
+  источников.
+
+Среди `kb/sources/*/meta.json` восемь manifest-групп перечисляют 24 ожидаемых
+PDF-файла. Ни один из этих PDF-файлов сейчас не присутствует. Отдельный
+`kb/sources/contact-center-manual/source.md` также описывает ожидаемый
+`CC_manual_1.26.23.pdf` со статусом `pending-source-file`.
+
+### Скрипты и workflow
+
+Сохранились:
+
+- `scripts/kb/extract.py`: PDF -> `sections/*.md`, `index.md`, `meta.json`,
+  `images/`;
+- `scripts/kb/process_sources.py`: manifest-driven запуск для `single`,
+  `multi_part`, `multi_document`;
+- `scripts/kb/tokens.py`;
+- `scripts/kb/make_sample_pdf.py`;
+- `scripts/kb/requirements.txt`;
+- validators `scripts/validate_issue_111_*`, `115_*`, `117_*`, `121_*`;
+- Make targets `kb-extract`, `kb-source-plan`, `kb-source-extract`, `kb-mango`,
+  `kb-lk`, `kb-mtalker`, `kb-validate`;
+- workflow `.github/workflows/kb.yml`.
+
+### Документация процесса
+
+Сохранились README-файлы:
+
+- `kb/README.md`;
+- `kb/processed/README.md`;
+- `kb/sources/README.md`;
+- `kb/fragments/README.md`;
+- `kb/sources/web-links/README.md`;
+- `scripts/kb/README.md`.
+
+`kb/sources/README.md` по-прежнему описывает, что PDF должны лежать в
+`kb/sources/<slug>/`, управляться через Git LFS и обрабатываться через локальный
+Makefile или workflow `KB pipeline`.
+
+## Что потеряно
+
+### PDF-источники
+
+Подтверждено отсутствие PDF-файлов:
+
+- в рабочем дереве нет `*.pdf`;
+- в `git ls-files '*.pdf'` нет tracked PDF;
+- source manifests и processed metadata указывают на PDF-пути, которых нет на
+  диске.
+
+Для текущей `kb/processed/` потеряны исходные байты 17 PDF-файлов, на основании
+которых были созданы сохраненные generated artifacts.
+
+### Возможность перепарсинга
+
+Без PDF нельзя воспроизвести текущую БЗ через:
+
+- `make kb-mango`;
+- `make kb-lk`;
+- `make kb-mtalker`;
+- `make kb-source-extract SOURCE_DIR=...`;
+- workflow `KB pipeline` в режиме извлечения.
+
+Manifest-файлы подсказывают ожидаемые имена, порядок частей, версии и страницы,
+но не заменяют сами PDF.
+
+### Возможность верификации
+
+Сохраненная БЗ содержит трассировку до путей, частей и страниц, но оригинальные
+страницы недоступны. Поэтому нельзя:
+
+- сверить извлеченный текст с PDF;
+- проверить полноту таблиц и изображений против оригинала;
+- подтвердить корректность outline boundaries на исходном документе;
+- пересчитать или проверить `source_sha256` против локальных PDF-байтов.
+
+### Возможность обновления
+
+Обновление БЗ при выходе новой версии PDF невозможно в текущем состоянии без
+повторного добавления новых PDF-источников. При этом существующие `output_slug`
+и manifests позволяют понять, куда должна быть перегенерирована БЗ после
+возврата источников.
+
+## Последствия
+
+### Что можно делать сейчас
+
+- Читать `kb/processed/*/index.md` как карту разделов.
+- Использовать `sections/*.md` как chunks для анализа, поиска и цитирования.
+- Ссылаться на стабильные Markdown-пути и заголовки.
+- Использовать извлеченные изображения, потому что локальные image references
+  не битые.
+- Определять происхождение разделов по сохраненным `source_refs`, номерам частей
+  и страницам.
+- Оценивать объем БЗ по сохраненным счетчикам страниц, секций, изображений и
+  токенов.
+
+### Что нельзя делать без восстановления источников
+
+- Перегенерировать БЗ из PDF.
+- Проверить, что Markdown точно соответствует PDF-оригиналу.
+- Исправить ошибки парсинга через корректный rerun pipeline.
+- Обновить БЗ на новую версию руководства.
+- Выполнить текущий полный `make kb-validate` без падения на missing PDF checks.
+
+## Риски
+
+### Критические
+
+- **Невоспроизводимость БЗ.** Generated artifacts сохранены, но source -> output
+  цепочка разорвана из-за отсутствия PDF.
+- **Блокирующая CI-валидация.** `KB pipeline` для PR #260 уже падает на
+  `scripts/validate_issue_115_kb_mango_pipeline.py`: отсутствуют все шесть
+  `CC_manual_1.26.23-part-*.pdf`.
+- **Невозможность source-backed верификации.** Ссылки на страницы и части
+  сохранены, но проверить их против оригинала нельзя.
+
+### Средние
+
+- **Риск накопления ошибок парсинга.** Если в текущих chunks есть ошибки
+  извлечения, исправлять их без PDF можно только вручную, что противоречит
+  контракту `kb/processed/` как generated layer.
+- **Риск устаревания.** При новой версии руководств невозможно обновить
+  `kb/processed/<slug>/` тем же процессом, пока не появятся источники.
+- **Риск неполной dependency-карты.** Manifests сохранили имена и параметры, но
+  не все source manifests имеют локальные payloads или web URL.
+
+### Низкие
+
+- **Битые image references не обнаружены.** Риск потери изображений внутри
+  `kb/processed/` сейчас низкий.
+- **Пустые Markdown-файлы не обнаружены.** Риск очевидной деградации generated
+  Markdown слоя сейчас низкий.
+
+## Рекомендации
+
+### Немедленные действия
+
+1. Зафиксировать этот отчет как текущий baseline состояния после LFS cleanup.
+2. Считать `kb/processed/` последним сохраненным snapshot, а не воспроизводимым
+   output, пока PDF отсутствуют.
+3. Не редактировать `kb/processed/**` вручную: текущая документация уже задает
+   правило менять источник и перезапускать извлечение.
+4. Отдельной задачей решить, что делать с текущей CI-валидацией:
+   восстановить PDF через утвержденный LFS-процесс или изменить validation
+   contract так, чтобы он проверял generated artifacts без требования локальных
+   source PDF.
+
+### Долгосрочные considerations для будущей задачи
+
+- Определить политику хранения source payloads и external source locations для
+  БЗ, чтобы source-backed верификация не зависела только от Git LFS history.
+- Хранить machine-readable manifest состояния: какие sources обязательны для
+  rerun, какие optional, какие intentionally removed.
+- Разделить проверки generated artifacts и проверки source availability, чтобы
+  cleanup источников не маскировал состояние уже извлеченной БЗ.
+
+## Локальная и CI-валидация
+
+Локально:
+
+```text
+make kb-validate
+issue-111 KB pipeline validation: PASS
+issue-115 KB mango pipeline validation: FAIL
+- kb/sources/mango-cc-manual/CC_manual_1.26.23-part-1.pdf: missing
+- kb/sources/mango-cc-manual/CC_manual_1.26.23-part-2.pdf: missing
+- kb/sources/mango-cc-manual/CC_manual_1.26.23-part-3.pdf: missing
+- kb/sources/mango-cc-manual/CC_manual_1.26.23-part-4.pdf: missing
+- kb/sources/mango-cc-manual/CC_manual_1.26.23-part-5.pdf: missing
+- kb/sources/mango-cc-manual/CC_manual_1.26.23-part-6.pdf: missing
+```
+
+CI:
+
+- workflow: `KB pipeline`;
+- run: `28656517739`;
+- created at: `2026-07-03T11:06:02Z`;
+- head SHA: `1f63ab02f30fb50b7db013048b00ce941a323940`;
+- result: failure;
+- root cause in log: the same six missing `mango-cc-manual` PDF parts.
+
+Это подтверждает, что текущий валидатор по-прежнему ожидает PDF-источники, хотя
+задача #259 фиксирует состояние после их удаления.
+
+## Definition of Done
+
+- [x] Инвентаризация `kb/processed/` выполнена.
+- [x] Проверка целостности выполнена.
+- [x] Анализ зависимостей выполнен.
+- [x] Отчет составлен в формате Executive Summary + детали.
+- [x] Отчет зафиксирован как
+  `docs/report/2026-07-03-kb-state-after-lfs-cleanup.md`.
+- [x] Локальная проверка отчета `git diff --check` прошла.
+- [ ] Полный `make kb-validate` не проходит в текущем post-cleanup состоянии;
+  failure зафиксирован в разделе "Локальная и CI-валидация".
+- [x] Структура `kb/processed/` не изменялась.
+- [x] PDF не восстанавливались и БЗ не перепарсивалась.
+- [x] Задача переведена в состояние `review` через frontmatter отчета.

--- a/scripts/kb/process_sources.py
+++ b/scripts/kb/process_sources.py
@@ -127,7 +127,12 @@ def infer_mode(source_dir: Path, manifest: dict) -> str:
     return "single"
 
 
-def resolve_files(source_dir: Path, files: object, context: str) -> tuple[Path, ...]:
+def resolve_files(
+    source_dir: Path,
+    files: object,
+    context: str,
+    require_sources: bool = True,
+) -> tuple[Path, ...]:
     if files is None:
         discovered = sorted(source_dir.glob("*.pdf"), key=natural_key)
         if not discovered:
@@ -145,7 +150,7 @@ def resolve_files(source_dir: Path, files: object, context: str) -> tuple[Path, 
             path.relative_to(source_dir.resolve())
         except ValueError as exc:
             raise ManifestError(f"{context}: source file {item!r} escapes source directory") from exc
-        if not path.exists():
+        if require_sources and not path.exists():
             raise ManifestError(f"{context}: source file {item!r} does not exist")
         resolved.append(path)
     return tuple(resolved)
@@ -201,6 +206,7 @@ def make_job(
 def build_plan(
     source_dir: Path,
     processed_root: Path = PROCESSED_ROOT,
+    require_sources: bool = True,
 ) -> SourcePlan:
     source_dir = source_dir.resolve()
     manifest = load_manifest(source_dir)
@@ -212,7 +218,12 @@ def build_plan(
     collection_dir = (processed_root / collection_slug).resolve()
 
     if mode in {"single", "multi_part"}:
-        files = resolve_files(source_dir, manifest.get("source_files"), rel_to_root(source_dir / "meta.json"))
+        files = resolve_files(
+            source_dir,
+            manifest.get("source_files"),
+            rel_to_root(source_dir / "meta.json"),
+            require_sources=require_sources,
+        )
         if mode == "single" and len(files) != 1:
             raise ManifestError(f"{rel_to_root(source_dir / 'meta.json')}: single mode requires exactly one PDF")
         if mode == "multi_part" and len(files) < 2:
@@ -241,7 +252,7 @@ def build_plan(
         if files is None and doc.get("file_name"):
             files = [doc["file_name"]]
         context = f"{rel_to_root(source_dir / 'meta.json')}: documents[{index}]"
-        pdf_paths = resolve_files(source_dir, files, context)
+        pdf_paths = resolve_files(source_dir, files, context, require_sources=require_sources)
         doc_slug = str(doc.get("output_slug") or slugify(doc.get("title") or pdf_paths[0].stem))
         if doc_slug in seen_slugs:
             raise ManifestError(f"{context}: duplicate output_slug {doc_slug!r}")
@@ -417,7 +428,11 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Process kb/sources/<slug>/meta.json manifests.")
     parser.add_argument("source_dir", nargs="?", help="source directory with meta.json")
     parser.add_argument("--all", action="store_true", help="process every kb/sources/*/meta.json")
-    parser.add_argument("--dry-run", action="store_true", help="validate and print the extraction plan only")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="validate the manifest and print the extraction plan without reading PDF payloads",
+    )
     parser.add_argument("--json", action="store_true", help="print dry-run plan as JSON")
     parser.add_argument("--python", default=sys.executable, help="Python executable for extract.py")
     parser.add_argument("--extractor", default=str(EXTRACTOR), help="path to scripts/kb/extract.py")
@@ -430,7 +445,10 @@ def main(argv: list[str] | None = None) -> int:
     source_dirs = iter_source_dirs() if args.all else [Path(args.source_dir)]
     try:
         processed_root = Path(args.processed_root).resolve()
-        plans = [build_plan(path, processed_root) for path in source_dirs]
+        plans = [
+            build_plan(path, processed_root, require_sources=not args.dry_run)
+            for path in source_dirs
+        ]
         for plan in plans:
             if args.json:
                 print_plan(plan, as_json=True)

--- a/scripts/validate_issue_115_kb_mango_pipeline.py
+++ b/scripts/validate_issue_115_kb_mango_pipeline.py
@@ -11,11 +11,16 @@ handle those parts as one document with continuous page numbering.
 
 This stdlib-only check locks the fix:
 
-- the real processed KB exists and points to all uploaded PDF parts;
+- the real processed KB exists and points to all expected PDF parts;
 - it contains index/meta/sections/images with real-manual scale;
 - section boundaries come from the PDF outline, not bold numbered list items;
 - the GitHub workflow checks out LFS files and passes multi-part inputs to
   ``make kb-extract``.
+
+After the LFS cleanup in issue #259, the lightweight CI validator must not
+require the PDF payload bytes to be present in the repository. Extraction still
+requires real PDF files; this check validates the generated KB snapshot and its
+source provenance.
 """
 
 from __future__ import annotations
@@ -83,8 +88,6 @@ def all_source_refs(sections: list[dict]) -> list[dict]:
 
 def check_processed_mango() -> list[str]:
     errors: list[str] = []
-    for source in CC_SOURCES:
-        errors += require_path(source)
     errors += require_path(f"{PROCESSED}/index.md")
     errors += require_path(f"{PROCESSED}/sections")
     errors += require_path(f"{PROCESSED}/images")

--- a/scripts/validate_issue_121_kb_multi_file.py
+++ b/scripts/validate_issue_121_kb_multi_file.py
@@ -134,7 +134,7 @@ def check_real_manifests() -> list[str]:
         ROOT / "kb/sources/mtalker",
     ):
         try:
-            plan = build_plan(source_dir)
+            plan = build_plan(source_dir, require_sources=False)
         except ManifestError as exc:
             errors.append(str(exc))
             continue
@@ -172,6 +172,28 @@ def check_synthetic_update_scenarios() -> list[str]:
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         processed_root = tmp_path / "processed"
+
+        # Post-LFS-cleanup planning: CI can validate explicit manifest intent
+        # without local PDF payloads, while real extraction remains strict.
+        missing_dir = tmp_path / "sources" / "missing-doc"
+        write_manifest(missing_dir, {
+            "name": "Missing Doc",
+            "version": "1",
+            "processing_mode": "multi_part",
+            "output_slug": "missing-doc",
+            "source_files": ["part-1.pdf", "part-2.pdf"],
+        })
+        try:
+            missing_plan = build_plan(missing_dir, processed_root, require_sources=False)
+            if rel_paths(missing_plan.jobs[0].pdf_paths, missing_dir) != ["part-1.pdf", "part-2.pdf"]:
+                errors.append("synthetic missing sources: expected explicit manifest file order")
+        except ManifestError as exc:
+            errors.append(f"synthetic missing sources: planning without payloads failed ({exc})")
+        try:
+            build_plan(missing_dir, processed_root)
+            errors.append("synthetic missing sources: extraction planning must require payload files")
+        except ManifestError:
+            pass
 
         # Single-file baseline: one file -> one stable output.
         single_dir = tmp_path / "sources" / "single-doc"
@@ -267,6 +289,7 @@ def check_docs_and_wiring() -> list[str]:
         "processing_mode",
         "multi_part",
         "multi_document",
+        "require_sources",
         "Git LFS pointer checked out instead of PDF bytes",
         "clean_stale_collection_docs",
     )


### PR DESCRIPTION
## Summary

Fixes G-Ivan-A/mango_ba_prompts#259.

Added the requested factual report:

- `docs/report/2026-07-03-kb-state-after-lfs-cleanup.md`

The report covers:

- inventory of `kb/processed/` structure, sizes, file counts, indexes, metadata, sections, and images;
- integrity checks for PDF references, LFS mentions, empty/minimal Markdown files, and image references;
- dependency analysis for source manifests, parser scripts, Make targets, README files, and workflow wiring;
- consequences, risks, and recommendations after the PDF source files were removed from Git LFS history.

CI fix added in this update:

- lightweight KB validators now validate generated artifacts, manifest paths, and provenance without requiring removed PDF payload bytes in the repository;
- `scripts/kb/process_sources.py --dry-run` can plan explicit manifest sources without reading PDF payloads;
- non-dry extraction remains strict and still fails when required PDF files are absent.

No PDF files were restored, no KB extraction was rerun, and `kb/processed/` content was not modified.

## Key Findings

- `kb/processed/` remains intact as a generated snapshot: 1,126 Markdown files, 1,116 section chunks, 9 indexes, 9 `meta.json` files, 3,906 images, and 138M total size.
- The generated metadata represents 1,395 source pages and 924,795 tokens.
- No `*.pdf` files exist in the working tree or tracked file list.
- `kb/processed/` references 17 unique PDF source paths, all currently missing.
- Markdown image references in `kb/processed/` resolve successfully; no empty or under-100-byte Markdown files were found.

## Validation

- `make kb-validate` passes.
- `git diff --check` passes.
- `python3 scripts/kb/process_sources.py kb/sources/mango-cc-manual --dry-run --json` passes and prints the six-part manifest plan.
- `python3 scripts/kb/process_sources.py kb/sources/mango-cc-manual` still fails as expected because the source PDF payloads are absent.

The previous `KB pipeline / validate` failure on run `28657113496` was caused by validators requiring removed PDF files. This PR now separates lightweight generated-artifact validation from source-backed extraction checks.
