### PR TITLE
feat(templates): #323 — два шаблона задач (Issue Forms) для категории runs

### DIFF
--- a/.github/ISSUE_TEMPLATE/run-execution.yml
+++ b/.github/ISSUE_TEMPLATE/run-execution.yml
@@ -1,0 +1,91 @@
+name: "🚀 Прогон задачи: Исполнение процесса (получение артефакта)"
+description: "Запуск бизнес-процесса БА ради конкретного артефакта: ФТ, ТЗ, User Story, матрица UC, анализ."
+title: "[run] "
+labels:
+  - "runs"
+  - "execution"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Шаблон для прогона с `run_type: execution` — цель задачи сформулирована как
+        «выполнить процесс», «сформировать ФТ/ТЗ/документ», «получить артефакт»
+        (критерий выбора типа — [`runs/README.md`](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/runs/README.md#как-выбрать-тип)).
+        Если цель — накопить эмпирические данные о диалогах с ИИ, возьмите шаблон
+        «📊 Прогон статистики».
+
+        ⚠️ **Не вставляйте ссылки на закрытые корпоративные документы** (Confluence, Jira, диски).
+        Входные данные прикладывайте **обезличенными** файлами прямо к задаче.
+
+  - type: input
+    id: run_title
+    attributes:
+      label: "Краткое название прогона"
+      description: "Одна строка: что и для чего запускаем."
+      placeholder: "ФТ по BCREQ-1069: голосовой сценарий подтверждения заказа"
+    validations:
+      required: true
+
+  - type: textarea
+    id: process_description
+    attributes:
+      label: "Исполняемый процесс и целевой артефакт"
+      description: "Опишите словами, какой процесс БА исполняется и какой артефакт должен получиться."
+      placeholder: |
+        Процесс указывается вручную: таксономия процессов БА ещё не формализована,
+        поэтому жёсткого списка (dropdown) в шаблоне намеренно нет.
+
+        Процесс: разработка функциональных требований по входному бизнес-требованию.
+        Целевой артефакт: документ ФТ с матрицей UC, в outputs/ прогона.
+    validations:
+      required: true
+
+  - type: textarea
+    id: inputs
+    attributes:
+      label: "Входные данные"
+      description: "Что подаётся на вход: ТЗ, данные, экспорт чата с инструкцией."
+      placeholder: |
+        Перечислите файлы и **приложите их к этой задаче** (перетащите в поле комментария).
+
+        - tz-prilozhenie-2.pdf — исходное ТЗ, разделы 4.1–4.6;
+        - chat-export.json — экспорт диалога с инструкцией модели;
+        - ссылка на промпт: prompts/fr-validation-stepwise.md.
+    validations:
+      required: true
+
+  - type: textarea
+    id: constraints
+    attributes:
+      label: "Ограничения, правила и контекст прогона"
+      description: "Специфика именно этого прогона: модель, формат вывода, отраслевые стандарты, запреты."
+      placeholder: |
+        - модель и режим: укажите вручную (например, Claude Opus, temperature 0.1);
+        - формат вывода: таблица требований, идентификаторы вида FR-XXX;
+        - отраслевой контекст: телеком, требования ЦБ РФ не применять;
+        - границы: прогон пишет только в runs/YYYY/RUN-XXXX/, prompts/ и kb/ не трогает.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: labels
+    attributes:
+      label: "Категория прогона (для навигации)"
+      description: "Метки `runs` и `execution` проставляются автоматически; здесь уточните подкатегорию."
+      options:
+        - "runs / execution — получение артефакта"
+        - "runs / execution — повтор прогона с изменёнными вводными"
+        - "runs / execution — другое (поясню в описании процесса)"
+      default: 0
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: "Перед отправкой"
+      options:
+        - label: "Входные файлы приложены к задаче или явно описаны выше"
+          required: true
+        - label: "В тексте нет ссылок на закрытые корпоративные документы"
+          required: true

--- a/.github/ISSUE_TEMPLATE/run-statistics.yml
+++ b/.github/ISSUE_TEMPLATE/run-statistics.yml
@@ -1,0 +1,88 @@
+name: "📊 Прогон статистики: Анализ диалогов и использования промптов"
+description: "Фиксация истории коммуникации «пользователь ↔ ИИ» по задаче ради накопления эмпирических данных."
+title: "[run:stats] "
+labels:
+  - "runs"
+  - "statistics"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Шаблон для прогона с `run_type: statistics` — цель задачи сформулирована как
+        «зафиксировать прогон», «собрать эмпирические данные», «накопить статистику»
+        (критерий выбора типа — [`runs/README.md`](https://github.com/G-Ivan-A/mango_ba_prompts/blob/main/runs/README.md#как-выбрать-тип)).
+        Наличие ФТ в результатах не делает прогон `execution`: тип берётся из цели задачи.
+
+        ⚠️ **Не вставляйте ссылки на закрытые корпоративные документы** (Confluence, Jira, диски).
+        Экспорты чатов прикладывайте **обезличенными**.
+
+  - type: input
+    id: run_title
+    attributes:
+      label: "Краткое название"
+      description: "Одна строка."
+      placeholder: "Статистика по задаче #319: качество уточняющих вопросов модели"
+    validations:
+      required: true
+
+  - type: input
+    id: task_reference
+    attributes:
+      label: "Исходная задача"
+      description: "Номер или ссылка на задачу/прогон, к которому относится диалог."
+      placeholder: "#319 или runs/2026/RUN-0057"
+    validations:
+      required: true
+
+  - type: textarea
+    id: chat_exports
+    attributes:
+      label: "Экспорты чата"
+      description: "Какие файлы экспорта приложены и что в них."
+      placeholder: |
+        **Приложите файлы к этой задаче** (перетащите в поле комментария), затем опишите:
+
+        - chat-export.json — полный экспорт диалога, 42 сообщения, 2026-08-20;
+        - chat-export.md — тот же диалог после scripts/chat_export_to_markdown.py;
+        - модель и режим: укажите вручную.
+    validations:
+      required: true
+
+  - type: textarea
+    id: analysis_goal
+    attributes:
+      label: "Цель статистического анализа"
+      description: "Что именно измеряем и на какой вопрос отвечаем."
+      placeholder: |
+        Цель указывается вручную: таксономия видов анализа ещё не формализована,
+        поэтому жёсткого списка (dropdown) в шаблоне намеренно нет.
+
+        Например: оценка качества уточняющих вопросов; выявление галлюцинаций;
+        замеры токенов и длительности (token_method обязателен); A/B-сравнение
+        двух формулировок промпта; success_rate с указанием success_rate_basis.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: labels
+    attributes:
+      label: "Категория прогона (для навигации)"
+      description: "Метки `runs` и `statistics` проставляются автоматически; здесь уточните подкатегорию."
+      options:
+        - "runs / statistics — анализ диалогов и качества коммуникации"
+        - "runs / statistics — замеры токенов, длительности, success_rate"
+        - "runs / statistics — A/B-сравнение промптов"
+        - "runs / statistics — другое (поясню в цели анализа)"
+      default: 0
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: "Перед отправкой"
+      options:
+        - label: "Экспорты чата приложены к задаче или явно описаны выше"
+          required: true
+        - label: "Данные обезличены, ссылок на закрытые документы нет"
+          required: true

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-26T09:01:14.427Z for PR creation at branch issue-323-5cee0aad4118 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/323

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-26T09:01:14.427Z for PR creation at branch issue-323-5cee0aad4118 for issue https://github.com/G-Ivan-A/mango_ba_prompts/issues/323

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,35 @@ temperature: 0.1
 
 ## Unreleased
 
+### Added — Issue #323: шаблоны задач (Issue Forms) для категории `runs`
+
+- Добавлены два шаблона GitHub Issue Forms:
+  [`.github/ISSUE_TEMPLATE/run-execution.yml`](.github/ISSUE_TEMPLATE/run-execution.yml)
+  («🚀 Прогон задачи: Исполнение процесса», метки `runs`, `execution`) и
+  [`.github/ISSUE_TEMPLATE/run-statistics.yml`](.github/ISSUE_TEMPLATE/run-statistics.yml)
+  («📊 Прогон статистики: Анализ диалогов и использования промптов», метки
+  `runs`, `statistics`). Разделение по `run_type` из
+  [`runs/README.md`](runs/README.md#типы-прогонов): тип берётся из формулировки
+  цели в issue, поэтому шаблон выбирается там же, где формулируется цель.
+- Исполняемый процесс (`process_description`) и цель анализа (`analysis_goal`)
+  оставлены свободным текстом с направляющими `placeholder`: таксономия
+  процессов БА не формализована, жёсткие `dropdown` со списками процессов
+  внесли бы в данные прогонов классификацию, которой ещё нет.
+- Расширение файлов — `.yml`, а не `.md` из постановки: GitHub распознаёт Issue
+  Forms только в `.yml`/`.yaml`, а `.md` в этом каталоге трактуется как легаси
+  шаблон Markdown без полей формы. Именование совпадает с уже существующим
+  [`prompt-feedback.yml`](.github/ISSUE_TEMPLATE/prompt-feedback.yml).
+- Добавлен валидатор
+  [`scripts/validate_issue_323_issue_forms.py`](scripts/validate_issue_323_issue_forms.py)
+  и тесты правил на синтетике
+  [`scripts/test_issue_323_issue_forms.py`](scripts/test_issue_323_issue_forms.py)
+  (оба подхватываются `scripts/validate_all.py` по маске): проверяются валидность
+  YAML, обязательные ключи Issue Forms, уникальность `id`, наличие `placeholder`
+  у каждой `textarea`, состав предвыбранных меток и то, что поля свободного
+  описания не превратились в `dropdown`. Разбор YAML встроенный — в CI стоит
+  голый `setup-python` без PyYAML; когда PyYAML доступен, результаты
+  сверяются с ним.
+
 ### Fixed — Issue #273: расхождение в реестре прогонов `runs/README.md`
 
 - Удалена дублирующая строка таблицы «Локальные инструменты воспроизводимости»

--- a/scripts/test_issue_323_issue_forms.py
+++ b/scripts/test_issue_323_issue_forms.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Тесты правил шаблонов задач `runs` (issue #323) на синтетике.
+
+Валидатор `validate_issue_323_issue_forms.py` проверяет реальные шаблоны — и
+молчит, если оба файла корректны. Эти тесты проверяют сами правила: что
+валидатор действительно падает на нарушениях (жёсткий dropdown вместо
+свободного текста, textarea без placeholder, потерянное поле, битый YAML), и
+что встроенный парсер YAML разбирает конструкции Issue Forms так же, как
+PyYAML.
+
+Запуск: ``python3 scripts/test_issue_323_issue_forms.py``
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from validate_issue_323_issue_forms import (  # noqa: E402
+    EXPECTED,
+    check_text,
+    parse_yaml,
+)
+
+SPEC = {"labels": {"runs", "execution"}, "ids": {"process_description"}}
+
+VALID = """\
+name: "Прогон"
+description: "Описание"
+labels:
+  - "runs"
+  - "execution"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Вступление.
+  - type: textarea
+    id: process_description
+    attributes:
+      label: "Процесс"
+      placeholder: "Указывается вручную"
+    validations:
+      required: true
+"""
+
+
+def errors_for(text: str, spec: dict = SPEC) -> list[str]:
+    return check_text(Path("synthetic.yml"), text, spec)
+
+
+class TemplateRulesTest(unittest.TestCase):
+    def test_valid_template_passes(self) -> None:
+        self.assertEqual(errors_for(VALID), [])
+
+    def test_freeform_field_as_dropdown_fails(self) -> None:
+        broken = VALID.replace("  - type: textarea", "  - type: dropdown").replace(
+            '      placeholder: "Указывается вручную"',
+            '      options:\n        - "Разработка ФТ"\n        - "Разработка ТЗ"',
+        )
+        self.assertTrue(any("textarea" in e for e in errors_for(broken)))
+
+    def test_textarea_without_placeholder_fails(self) -> None:
+        broken = VALID.replace('      placeholder: "Указывается вручную"\n', "")
+        self.assertTrue(any("placeholder" in e for e in errors_for(broken)))
+
+    def test_missing_required_field_fails(self) -> None:
+        broken = VALID.replace("    id: process_description\n", "    id: other\n")
+        self.assertTrue(any("обязательные поля" in e for e in errors_for(broken)))
+
+    def test_missing_label_fails(self) -> None:
+        broken = VALID.replace('  - "execution"\n', "")
+        self.assertTrue(any("метки" in e for e in errors_for(broken)))
+
+    def test_duplicate_id_fails(self) -> None:
+        broken = VALID + (
+            "  - type: input\n    id: process_description\n"
+            '    attributes:\n      label: "Дубль"\n'
+        )
+        self.assertTrue(any("дублирующийся" in e for e in errors_for(broken)))
+
+    def test_unknown_block_type_fails(self) -> None:
+        broken = VALID.replace("  - type: markdown", "  - type: slider")
+        self.assertTrue(any("недопустимый type" in e for e in errors_for(broken)))
+
+    def test_broken_indentation_fails(self) -> None:
+        broken = VALID.replace('      label: "Процесс"', '     label: "Процесс"')
+        self.assertTrue(errors_for(broken))
+
+
+class ParserTest(unittest.TestCase):
+    def test_matches_pyyaml_on_real_templates(self) -> None:
+        try:
+            import yaml
+        except ImportError:
+            self.skipTest("PyYAML недоступен")
+        directory = Path(__file__).resolve().parents[1] / ".github" / "ISSUE_TEMPLATE"
+        for name in EXPECTED:
+            text = (directory / name).read_text(encoding="utf-8")
+            self.assertEqual(parse_yaml(text), yaml.safe_load(text), name)
+
+    def test_block_scalar_and_nested_lists(self) -> None:
+        parsed = parse_yaml(VALID)
+        self.assertEqual(parsed["labels"], ["runs", "execution"])
+        self.assertEqual(parsed["body"][0]["attributes"]["value"], "Вступление.\n")
+        self.assertIs(parsed["body"][1]["validations"]["required"], True)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/validate_issue_323_issue_forms.py
+++ b/scripts/validate_issue_323_issue_forms.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Валидатор шаблонов задач категории `runs` (issue #323).
+
+Что проверяется
+---------------
+1. Оба шаблона существуют и лежат в `.github/ISSUE_TEMPLATE/` с расширением
+   `.yml` — GitHub считает Issue Forms только `.yml`/`.yaml`; `.md` в этом
+   каталоге трактуется как легаси-шаблон Markdown без полей формы.
+2. YAML валиден и содержит обязательные ключи Issue Forms: `name`,
+   `description`, `body`; `labels` — предвыбранные метки прогона.
+3. Каждый блок `body` имеет разрешённый `type`, поля с вводом — уникальный `id`
+   и `attributes.label`; у `dropdown`/`checkboxes` непустой список `options`.
+4. У всех `textarea` есть `placeholder` — требование issue #323 (подсказка,
+   куда прикладывать файлы и что писать руками).
+5. Ключевые поля описания процесса и цели анализа остаются `textarea`, а не
+   `dropdown`: таксономия процессов БА не формализована, жёсткие списки
+   запрещены постановкой.
+
+Парсер YAML
+-----------
+В CI (`.github/workflows/validate.yml`) стоит голый `setup-python` без
+установки зависимостей, поэтому PyYAML может отсутствовать. Валидатор
+разбирает подмножество YAML сам; если PyYAML всё же доступен, результаты
+сверяются между собой — расхождение считается ошибкой.
+
+Запуск: ``python3 scripts/validate_issue_323_issue_forms.py``
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE_DIR = ROOT / ".github" / "ISSUE_TEMPLATE"
+
+ALLOWED_TYPES = {"markdown", "input", "textarea", "dropdown", "checkboxes"}
+
+#: Поля, которые постановка требует держать свободным текстом.
+FREEFORM_FIELDS = {"process_description", "analysis_goal"}
+
+#: Шаблон -> обязательные `id` полей (issue #323, «Контракты задачи»).
+EXPECTED = {
+    "run-execution.yml": {
+        "labels": {"runs", "execution"},
+        "ids": {"run_title", "process_description", "inputs", "constraints", "labels"},
+    },
+    "run-statistics.yml": {
+        "labels": {"runs", "statistics"},
+        "ids": {"run_title", "task_reference", "chat_exports", "analysis_goal", "labels"},
+    },
+}
+
+
+# --------------------------------------------------------------------------
+# Минимальный разбор YAML: блочные отображения, списки, скаляры и `|`-блоки.
+# --------------------------------------------------------------------------
+
+
+def _scalar(raw: str):
+    text = raw.strip()
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in "\"'":
+        return text[1:-1]
+    if text in ("true", "false"):
+        return text == "true"
+    if text.lstrip("-").isdigit():
+        return int(text)
+    return text
+
+
+def _lines(text: str) -> list[tuple[int, int, str]]:
+    """(номер строки, отступ, содержимое) без комментариев и пустых строк."""
+    out = []
+    for number, raw in enumerate(text.splitlines(), start=1):
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        out.append((number, len(raw) - len(raw.lstrip(" ")), stripped))
+    return out
+
+
+def _block_scalar(raw_lines: list[str], start: int, indent: int) -> tuple[str, int]:
+    """Читает `|`-блок: все строки с отступом больше `indent`."""
+    body, index = [], start
+    while index < len(raw_lines):
+        line = raw_lines[index]
+        if line.strip() and len(line) - len(line.lstrip(" ")) <= indent:
+            break
+        body.append(line)
+        index += 1
+    while body and not body[-1].strip():
+        body.pop()
+    if not body:
+        return "", index
+    pad = min(len(l) - len(l.lstrip(" ")) for l in body if l.strip())
+    return "\n".join(l[pad:] for l in body) + "\n", index
+
+
+def parse_yaml(text: str):
+    raw_lines = text.splitlines()
+    items = _lines(text)
+
+    def parse(pos: int, indent: int):
+        if items[pos][2].startswith("- "):
+            result, index = [], pos
+            while index < len(items):
+                number, own_indent, content = items[index]
+                if own_indent < indent or not content.startswith("- "):
+                    break
+                rest = content[2:].strip()
+                if ":" in rest and not rest.startswith(("|", ">")):
+                    # элемент-отображение: разбираем его как блок с виртуальным
+                    # отступом на позиции первого ключа
+                    inner_indent = own_indent + 2
+                    items[index] = (number, inner_indent, rest)
+                    value, index = parse(index, inner_indent)
+                else:
+                    result.append(_scalar(rest))
+                    index += 1
+                    continue
+                result.append(value)
+            return result, index
+
+        mapping, index = {}, pos
+        while index < len(items):
+            number, own_indent, content = items[index]
+            if own_indent < indent:
+                break
+            if own_indent > indent:
+                raise ValueError(f"строка {number}: неожиданный отступ")
+            if ":" not in content:
+                raise ValueError(f"строка {number}: ожидалась пара ключ: значение")
+            key, _, rest = content.partition(":")
+            key, rest = key.strip().strip("\"'"), rest.strip()
+            index += 1
+            if rest in ("|", "|-", ">"):
+                value, cursor = _block_scalar(raw_lines, number, own_indent)
+                if rest == "|-":
+                    value = value.rstrip("\n")
+                while index < len(items) and items[index][0] <= cursor:
+                    index += 1
+            elif rest:
+                value = _scalar(rest)
+            elif index < len(items) and items[index][1] >= own_indent:
+                value, index = parse(index, items[index][1])
+            else:
+                value = None
+            mapping[key] = value
+        return mapping, index
+
+    if not items:
+        return {}
+    return parse(0, items[0][1])[0]
+
+
+# --------------------------------------------------------------------------
+# Проверки
+# --------------------------------------------------------------------------
+
+
+def check_template(name: str, spec: dict, errors: list[str]) -> None:
+    path = TEMPLATE_DIR / name
+    if not path.is_file():
+        errors.append(f"{path.relative_to(ROOT)}: файл отсутствует")
+        return
+    errors.extend(check_text(path.relative_to(ROOT), path.read_text(encoding="utf-8"), spec))
+
+
+def check_text(where, text: str, spec: dict) -> list[str]:
+    """Проверки над содержимым шаблона; вынесены ради тестов на синтетике."""
+    errors: list[str] = []
+    try:
+        data = parse_yaml(text)
+    except ValueError as exc:
+        errors.append(f"{where}: YAML не разобран — {exc}")
+        return errors
+
+    try:  # перекрёстная сверка, когда PyYAML доступен (локально)
+        import yaml  # noqa: PLC0415
+    except ImportError:
+        pass
+    else:
+        try:
+            reference = yaml.safe_load(text)
+        except yaml.YAMLError as exc:
+            errors.append(f"{where}: PyYAML не разобрал файл — {exc}")
+            return errors
+        if reference != data:
+            errors.append(f"{where}: разбор PyYAML и встроенного парсера расходится")
+
+    if not isinstance(data, dict):
+        errors.append(f"{where}: корень должен быть отображением")
+        return errors
+
+    for key in ("name", "description", "body"):
+        if not data.get(key):
+            errors.append(f"{where}: отсутствует обязательный ключ {key!r}")
+
+    labels = set(data.get("labels") or [])
+    missing_labels = spec["labels"] - labels
+    if missing_labels:
+        errors.append(f"{where}: не проставлены метки {sorted(missing_labels)}")
+
+    body = data.get("body")
+    if not isinstance(body, list):
+        errors.append(f"{where}: 'body' должен быть списком блоков")
+        return errors
+
+    seen_ids: set[str] = set()
+    for position, block in enumerate(body, start=1):
+        label = f"{where}: блок #{position}"
+        if not isinstance(block, dict):
+            errors.append(f"{label}: должен быть отображением")
+            continue
+        block_type = block.get("type")
+        if block_type not in ALLOWED_TYPES:
+            errors.append(f"{label}: недопустимый type={block_type!r}")
+            continue
+        attributes = block.get("attributes")
+        if not isinstance(attributes, dict):
+            errors.append(f"{label}: отсутствует 'attributes'")
+            continue
+
+        if block_type == "markdown":
+            if not attributes.get("value"):
+                errors.append(f"{label}: markdown без 'value'")
+            continue
+
+        block_id = block.get("id")
+        if not block_id:
+            errors.append(f"{label}: поле без 'id'")
+        elif block_id in seen_ids:
+            errors.append(f"{label}: дублирующийся id={block_id!r}")
+        else:
+            seen_ids.add(block_id)
+
+        if not attributes.get("label"):
+            errors.append(f"{label}: поле без 'attributes.label'")
+
+        if block_type == "textarea" and not attributes.get("placeholder"):
+            errors.append(f"{label} (id={block_id!r}): textarea без 'placeholder'")
+
+        if block_type in ("dropdown", "checkboxes") and not attributes.get("options"):
+            errors.append(f"{label} (id={block_id!r}): {block_type} без 'options'")
+
+        if block_id in FREEFORM_FIELDS and block_type != "textarea":
+            errors.append(
+                f"{label} (id={block_id!r}): должно быть 'textarea' — жёсткие списки "
+                "процессов запрещены до формализации таксономии (issue #323)"
+            )
+
+    missing_ids = spec["ids"] - seen_ids
+    if missing_ids:
+        errors.append(f"{where}: отсутствуют обязательные поля {sorted(missing_ids)}")
+    return errors
+
+
+def main() -> int:
+    errors: list[str] = []
+    for name, spec in EXPECTED.items():
+        check_template(name, spec, errors)
+
+    stray = sorted(p.name for p in TEMPLATE_DIR.glob("run-*.md"))
+    if stray:
+        errors.append(
+            ".github/ISSUE_TEMPLATE: шаблоны прогонов в .md не распознаются как "
+            f"Issue Forms: {stray}"
+        )
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        print(f"Issue forms validation failed with {len(errors)} error(s).", file=sys.stderr)
+        return 1
+
+    print("Issue forms validation passed (issue #323).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Что сделано (issue #323)

Два шаблона GitHub Issue Forms для категории `runs`:

| Файл | Название в UI | Метки | `run_type` |
| --- | --- | --- | --- |
| `.github/ISSUE_TEMPLATE/run-execution.yml` | 🚀 Прогон задачи: Исполнение процесса (получение артефакта) | `runs`, `execution` | `execution` |
| `.github/ISSUE_TEMPLATE/run-statistics.yml` | 📊 Прогон статистики: Анализ диалогов и использования промптов | `runs`, `statistics` | `statistics` |

Поля соответствуют контракту задачи: `run_title` (input), `process_description` /
`inputs` / `constraints` (textarea) в первом; `run_title`, `task_reference` (input),
`chat_exports`, `analysis_goal` (textarea) во втором; в обоих — `labels` (dropdown
подкатегории) и блок `checkboxes` перед отправкой.

Жёстких выпадающих списков процессов и артефактов нет: описание процесса и цель
анализа — свободный текст с направляющими `placeholder`, которые прямо говорят,
что процесс указывается вручную до формализации таксономии и что входные файлы
нужно приложить к задаче.

## Отклонения от постановки

1. **Расширение `.yml` вместо `.md`.** Постановка называет файлы
   `run-execution.md` / `run-statistics.md`, но GitHub распознаёт Issue Forms
   только в `.yml`/`.yaml` — `.md` в `.github/ISSUE_TEMPLATE/` трактуется как
   легаси-шаблон Markdown без полей формы, и требование «строгий синтаксис Issue
   Forms» стало бы невыполнимым. Имена совпадают с существующим
   `prompt-feedback.yml` — раздел «Отклонения от постановки» issue разрешает
   адаптацию под существующий стандарт именования.
2. **`labels` реализованы двумя способами.** Предвыбранные метки задаются
   верхнеуровневым ключом `labels:` (единственный механизм автопростановки в
   Issue Forms — `dropdown` метки проставлять не умеет), а поле `labels`
   (dropdown) оставлено как уточнение подкатегории для навигации.

## Тесты

- `scripts/validate_issue_323_issue_forms.py` — валидатор реальных шаблонов:
  валидность YAML, обязательные ключи Issue Forms, уникальность `id`, наличие
  `placeholder` у каждой `textarea`, состав меток, и что поля свободного
  описания не превратились в `dropdown`.
- `scripts/test_issue_323_issue_forms.py` — 10 тестов правил на синтетике:
  каждое нарушение (dropdown вместо textarea, textarea без placeholder,
  потерянное поле, дублирующийся `id`, неизвестный `type`, битый отступ) даёт
  падение валидатора.
- Разбор YAML встроенный: в CI (`validate.yml`) стоит голый `setup-python` без
  PyYAML. Когда PyYAML доступен, результат сверяется с ним — на обоих реальных
  шаблонах разбор совпадает.

Оба скрипта подхватываются `scripts/validate_all.py` по маске, то есть попадают
в CI без правки workflow. Локально: `make validate-full` — 32 валидатора, 0 провалов.

## Что требуется от мейнтейнера

Меток `runs`, `execution`, `statistics` в репозитории пока нет — GitHub молча
пропускает несуществующие метки при создании задачи. Их нужно завести в
Settings → Labels (или `gh label create runs`), чтобы автопростановка заработала.

Closes #323
